### PR TITLE
Update domain from weather.nyuchi.com to weather.mukoko.com

### DIFF
--- a/src/app/embed/page.tsx
+++ b/src/app/embed/page.tsx
@@ -36,7 +36,7 @@ export default function EmbedPage() {
 <div data-mukoko-widget="current"
      data-location="harare">
 </div>
-<script src="https://weather.nyuchi.com/embed/widget.js" async></script>`}</code>
+<script src="https://weather.mukoko.com/embed/widget.js" async></script>`}</code>
             </pre>
           </div>
         </section>
@@ -56,7 +56,7 @@ export default function EmbedPage() {
      data-location="bulawayo"
      data-days="5">
 </div>
-<script src="https://weather.nyuchi.com/embed/widget.js" async></script>`}</code>
+<script src="https://weather.mukoko.com/embed/widget.js" async></script>`}</code>
             </pre>
           </div>
         </section>
@@ -76,7 +76,7 @@ export default function EmbedPage() {
 <div data-mukoko-widget="badge"
      data-location="mutare">
 </div>
-<script src="https://weather.nyuchi.com/embed/widget.js" async></script>`}</code>
+<script src="https://weather.mukoko.com/embed/widget.js" async></script>`}</code>
             </pre>
           </div>
         </section>
@@ -93,7 +93,7 @@ export default function EmbedPage() {
           <div className="mt-4 overflow-hidden rounded-[var(--radius-card)] bg-surface-card p-4">
             <pre className="overflow-x-auto text-sm">
               <code className="font-mono text-text-primary">{`<iframe
-  src="https://weather.nyuchi.com/embed/iframe/harare?type=current&theme=auto"
+  src="https://weather.mukoko.com/embed/iframe/harare?type=current&theme=auto"
   width="380"
   height="280"
   frameborder="0"

--- a/src/components/embed/MukokoWeatherEmbed.tsx
+++ b/src/components/embed/MukokoWeatherEmbed.tsx
@@ -12,7 +12,7 @@ interface MukokoWeatherEmbedProps {
   days?: number;
   /** Theme override */
   theme?: "light" | "dark" | "auto";
-  /** Base API URL (defaults to weather.nyuchi.com) */
+  /** Base API URL (defaults to weather.mukoko.com) */
   apiUrl?: string;
   /** Additional CSS class */
   className?: string;
@@ -68,7 +68,7 @@ export function MukokoWeatherEmbed({
   type = "current",
   days = 5,
   theme = "auto",
-  apiUrl = "https://weather.nyuchi.com",
+  apiUrl = "https://weather.mukoko.com",
   className = "",
 }: MukokoWeatherEmbedProps) {
   const [data, setData] = useState<WeatherData | null>(null);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * nyuchi-weather-api — Cloudflare Worker
  *
- * Edge API layer for mukoko weather at weather.nyuchi.com
+ * Edge API layer for mukoko weather at weather.mukoko.com
  *
  * Routes:
  *   GET  /api/weather?lat=&lon=         — Cached Open-Meteo weather proxy

--- a/worker/src/routes/embed.ts
+++ b/worker/src/routes/embed.ts
@@ -5,15 +5,15 @@
  *
  *   <!-- Current conditions widget -->
  *   <div data-mukoko-widget="current" data-location="harare"></div>
- *   <script src="https://weather.nyuchi.com/embed/widget.js" async></script>
+ *   <script src="https://weather.mukoko.com/embed/widget.js" async></script>
  *
  *   <!-- Forecast widget -->
  *   <div data-mukoko-widget="forecast" data-location="bulawayo" data-days="5"></div>
- *   <script src="https://weather.nyuchi.com/embed/widget.js" async></script>
+ *   <script src="https://weather.mukoko.com/embed/widget.js" async></script>
  *
  *   <!-- Compact badge -->
  *   <div data-mukoko-widget="badge" data-location="mutare"></div>
- *   <script src="https://weather.nyuchi.com/embed/widget.js" async></script>
+ *   <script src="https://weather.mukoko.com/embed/widget.js" async></script>
  *
  * Widget types:
  *   - "current"  — Current conditions card (temp, conditions, wind, humidity)
@@ -36,7 +36,7 @@ export const embedRoutes = new Hono<{ Bindings: Env }>();
 
 // ───── Widget JavaScript loader ─────
 embedRoutes.get("/widget.js", (c) => {
-  const baseUrl = c.env.NEXT_APP_URL ?? "https://weather.nyuchi.com";
+  const baseUrl = c.env.NEXT_APP_URL ?? "https://weather.mukoko.com";
   const script = generateWidgetScript(baseUrl);
 
   return new Response(script, {
@@ -102,7 +102,7 @@ embedRoutes.get("/data/:location", async (c) => {
     weather,
     _meta: {
       source: "mukoko weather by Nyuchi Africa",
-      url: `https://weather.nyuchi.com/${slug}`,
+      url: `https://weather.mukoko.com/${slug}`,
     },
   }, 200, {
     "Cache-Control": "public, max-age=900",
@@ -115,7 +115,7 @@ embedRoutes.get("/iframe/:location", (c) => {
   const slug = c.req.param("location");
   const type = c.req.query("type") ?? "current";
   const theme = c.req.query("theme") ?? "auto";
-  const baseUrl = c.env.NEXT_APP_URL ?? "https://weather.nyuchi.com";
+  const baseUrl = c.env.NEXT_APP_URL ?? "https://weather.mukoko.com";
 
   const location = getLocationBySlug(slug);
   if (!location) {

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -5,7 +5,7 @@ main = "src/index.ts"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
-# Domain: weather.nyuchi.com
+# Domain: weather.mukoko.com
 # Configure via Cloudflare Dashboard: Workers > nyuchi-weather-api > Custom Domains
 
 # ───── KV Namespace Bindings ─────
@@ -30,8 +30,8 @@ preview_id = "REPLACE_WITH_PREVIEW_KV_NAMESPACE_ID"
 # ───── Environment Variables ─────
 [vars]
 ENVIRONMENT = "production"
-CORS_ORIGINS = "https://nyuchi.com,https://mukoko.com,https://weather.mukoko.com,https://weather.nyuchi.com"
-NEXT_APP_URL = "https://weather.nyuchi.com"
+CORS_ORIGINS = "https://nyuchi.com,https://mukoko.com,https://weather.mukoko.com"
+NEXT_APP_URL = "https://weather.mukoko.com"
 
 # ───── Secrets (set via `wrangler secret put`) ─────
 # ANTHROPIC_API_KEY — Claude API key for AI summaries
@@ -49,5 +49,5 @@ NEXT_APP_URL = "http://localhost:3000"
 name = "nyuchi-weather-api-staging"
 [env.staging.vars]
 ENVIRONMENT = "staging"
-CORS_ORIGINS = "https://staging.weather.nyuchi.com,https://staging.nyuchi.com"
-NEXT_APP_URL = "https://staging.weather.nyuchi.com"
+CORS_ORIGINS = "https://staging.weather.mukoko.com,https://staging.nyuchi.com"
+NEXT_APP_URL = "https://staging.weather.mukoko.com"


### PR DESCRIPTION
## Summary
This PR updates all references to the weather API domain from `weather.nyuchi.com` to `weather.mukoko.com` across the codebase, reflecting a domain migration for the Mukoko weather service.

## Changes Made
- **Embed page examples** (`src/app/embed/page.tsx`): Updated widget and iframe script URLs in all three code examples (current conditions, forecast, and badge widgets)
- **Embed component** (`src/components/embed/MukokoWeatherEmbed.tsx`): Updated default API URL and JSDoc comment
- **Worker configuration** (`worker/wrangler.toml`): 
  - Updated production `NEXT_APP_URL` to use new domain
  - Removed deprecated `weather.nyuchi.com` from `CORS_ORIGINS`
  - Updated staging environment URLs to use `weather.mukoko.com`
- **Worker routes** (`worker/src/routes/embed.ts`): Updated widget loader base URL, data endpoint response URL, and iframe endpoint base URL
- **Worker index** (`worker/src/index.ts`): Updated JSDoc comment to reflect new domain

## Implementation Details
- All changes are straightforward domain replacements with no functional logic changes
- The migration maintains backward compatibility in terms of API structure
- Both production and staging environments are updated consistently
- CORS configuration has been cleaned up to remove the old domain reference

https://claude.ai/code/session_015c2iiTN4V9mnPeRAPuwDVJ