### PR TITLE
fix(cors): allow mobile client headers (X-Mukoko-Client, Authorization)

### DIFF
--- a/api/py/index.py
+++ b/api/py/index.py
@@ -78,7 +78,13 @@ app.add_middleware(
     allow_origins=_ALLOWED_ORIGINS,
     allow_origin_regex=_ALLOWED_ORIGIN_REGEX,
     allow_methods=["GET", "POST", "PATCH", "OPTIONS"],
-    allow_headers=["Content-Type", "X-Mukoko-User-Id", "X-Mukoko-User-Email"],
+    allow_headers=[
+        "Content-Type",
+        "Authorization",  # mobile client sends a Bearer token when signed in
+        "X-Mukoko-Client",  # mobile client stamps "mukoko-mobile/<platform>"
+        "X-Mukoko-User-Id",
+        "X-Mukoko-User-Email",
+    ],
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/py/test_index.py
+++ b/tests/py/test_index.py
@@ -29,6 +29,27 @@ class TestAllowedOrigins:
         assert "*" not in _ALLOWED_ORIGINS
 
 
+class TestCorsPreflight:
+    """The mobile client stamps X-Mukoko-Client and (when signed in) an
+    Authorization header. A CORS preflight for those must succeed, or the
+    browser blocks the request — see the mukoko-mobile fetch client."""
+
+    def test_preflight_allows_mobile_client_headers(self):
+        client = TestClient(app)
+        resp = client.options(
+            "/api/py/weather",
+            headers={
+                "Origin": "http://localhost:8081",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-mukoko-client, authorization",
+            },
+        )
+        assert resp.status_code == 200
+        allowed = resp.headers.get("access-control-allow-headers", "").lower()
+        assert "x-mukoko-client" in allowed
+        assert "authorization" in allowed
+
+
 # ---------------------------------------------------------------------------
 # Health endpoint
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The mukoko-mobile fetch client stamps `X-Mukoko-Client` on every request (and `Authorization: Bearer` when signed in). Neither was in the API CORS `allow_headers`, so browser contexts (Expo web preview, future PWA) failed the CORS preflight with 400 → every call errored "Failed to fetch". Native devices don't enforce CORS so on-device was unaffected. Adds both headers + a preflight test. 28/28 Python index tests pass.