### PR TITLE
feat(onboarding): create location on demand from IP + GPS

### DIFF
--- a/src/app/HomeLanding.test.ts
+++ b/src/app/HomeLanding.test.ts
@@ -74,6 +74,14 @@ describe("HomeLanding — GPS button (stage 2)", () => {
     expect(source).toContain("detectUserLocation");
   });
 
+  it("creates the location on demand from GPS (autoCreate)", () => {
+    // "Use my current location" must create the location when none exists
+    // nearby, not just find-nearest — otherwise sparse regions dead-end.
+    expect(source).toContain("detectUserLocation({ autoCreate: true })");
+    // handleGps treats a freshly-created location as a valid redirect target.
+    expect(source).toContain('result.status === "created"');
+  });
+
   it("shows detecting state while GPS is running", () => {
     expect(source).toContain("Detecting");
     expect(source).toContain("gpsState");

--- a/src/app/HomeLanding.tsx
+++ b/src/app/HomeLanding.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { WeatherLocation } from "@/lib/locations";
 import { detectUserLocation } from "@/lib/geolocation";
-import { MapPinIcon, SearchIcon, NavigationIcon } from "@/lib/weather-icons";
+import { SearchIcon, NavigationIcon } from "@/lib/weather-icons";
 import { WeatherLoadingScene } from "@/components/weather/WeatherLoadingScene";
 
 interface Props {
@@ -54,7 +54,10 @@ export function HomeLanding({ detectedLocation }: Props) {
     setGpsState("detecting");
     setCancelled(true);
     try {
-      const result = await detectUserLocation();
+      // autoCreate: the app creates the location from the user's GPS position
+      // when none exists nearby (create-on-demand). Dedup in upsert_placesgeo_city
+      // (5 km + normalised-name) prevents duplicates.
+      const result = await detectUserLocation({ autoCreate: true });
       if ((result.status === "success" || result.status === "created") && result.location) {
         router.replace(`/${result.location.slug}`);
       } else if (result.status === "denied") {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,8 +50,13 @@ export default async function Home() {
 
   if (lat && lon) {
     try {
+      // autoCreate=true: create-on-demand from the IP-derived position so a
+      // first-time visitor from a city we haven't seen still lands on a real,
+      // resolvable location instead of the "not found" page. Dedup in
+      // upsert_placesgeo_city (5 km + normalised-name) prevents duplicates, so
+      // repeat visits from the same city resolve the existing entry.
       const res = await fetch(
-        `${APP_URL}/api/py/geo?lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}`,
+        `${APP_URL}/api/py/geo?lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}&autoCreate=true`,
         { cache: "no-store" },
       );
       if (res.ok) {


### PR DESCRIPTION
## Problem
The home onboarding dead-ends on "Location not found":
- The GPS **"Use my current location"** button called `detectUserLocation()` **without `autoCreate`** — it only found the nearest *existing* location and never created one. On sparse regions (or an empty placesGeo) there was no way forward.
- `page.tsx`'s IP-geo lookup queried `/api/py/geo` **without `autoCreate`** too.

This matches the reported symptoms: no working "use my current location", and the app not creating the location from IP/GPS.

## Changes
- **`HomeLanding.tsx`** — GPS button now calls `detectUserLocation({ autoCreate: true })`; the app reverse-geocodes the position and **creates** the placesGeo entry when none exists.
- **`page.tsx`** — server-side IP-geo lookup now passes `autoCreate=true`, so a first-time visitor from an unseen city lands on a real, resolvable location instead of the not-found page.
- Test: locks in the GPS create-on-demand behavior. Dropped an unused import.

Dedup in `upsert_placesgeo_city` (5 km + normalised-name, no numeric suffixes) prevents duplicates.

## Note
This is the frontend half. The **root cause of the live 'Location not found'** is that prod `MONGODB_URI` points at the old `mukoko-weather.8d0zkjd` cluster instead of the platform cluster `nyuchi-platform-doc-db.ge8d8qi` (where all placesGeo data lives). That env repoint + redeploy is required for the live site; this PR ensures onboarding creates locations once the DB is correct.

## Verification
1646/1646 tests pass · typecheck clean · lint clean.