### PR TITLE
feat(embed): rework widget to 4 variants + public IP-based current-weather API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ mukoko-weather/
 │   │   │       ├── leaflet-css.ts         # Leaflet CSS import
 │   │   │       └── leaflet-icon-fix.ts    # Marker icon URL fix for bundlers
 │   │   └── embed/
-│   │       ├── MukokoWeatherEmbed.tsx          # Embeddable widget (current/forecast/badge)
+│   │       ├── MukokoWeatherEmbed.tsx          # Embeddable widget (current / today / 5day / 7day; IP-based default via /api/embed/current)
 │   │       ├── MukokoWeatherEmbed.module.css   # Self-contained widget CSS (no Tailwind)
 │   │       ├── MukokoWeatherEmbed.test.ts
 │   │       └── index.ts

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ All data, AI, and CRUD operations run in **Python FastAPI** (`api/py/`), deploye
 | ------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------- |
 | `/api/og?title=&subtitle=&template=` | GET    | Dynamic OG image generation (Edge runtime, Satori). 6 templates, in-memory rate-limited, 1-day CDN cache |
 | `/api/db-init`                       | POST   | One-time DB setup + seed data (incl. AI prompts). Protected by `DB_INIT_SECRET` in production            |
+| `/api/embed/current?slug=\|lat=&lon=` | GET    | Public embed API (Edge, open CORS). Compact current weather + up to 7 daily entries. No params → visitor's IP location (Vercel `x-vercel-ip-*` headers). Powers the embed widget |
 
 ### Resilience
 

--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ All data, AI, and CRUD operations run in **Python FastAPI** (`api/py/`), deploye
 
 **TypeScript API (remaining):**
 
-| Endpoint                             | Method | Description                                                                                              |
-| ------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------- |
-| `/api/og?title=&subtitle=&template=` | GET    | Dynamic OG image generation (Edge runtime, Satori). 6 templates, in-memory rate-limited, 1-day CDN cache |
-| `/api/db-init`                       | POST   | One-time DB setup + seed data (incl. AI prompts). Protected by `DB_INIT_SECRET` in production            |
+| Endpoint                              | Method | Description                                                                                                                                                                      |
+| ------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/og?title=&subtitle=&template=`  | GET    | Dynamic OG image generation (Edge runtime, Satori). 6 templates, in-memory rate-limited, 1-day CDN cache                                                                         |
+| `/api/db-init`                        | POST   | One-time DB setup + seed data (incl. AI prompts). Protected by `DB_INIT_SECRET` in production                                                                                    |
 | `/api/embed/current?slug=\|lat=&lon=` | GET    | Public embed API (Edge, open CORS). Compact current weather + up to 7 daily entries. No params → visitor's IP location (Vercel `x-vercel-ip-*` headers). Powers the embed widget |
 
 ### Resilience

--- a/src/app/api/embed/current/route.test.ts
+++ b/src/app/api/embed/current/route.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the public embed API route (/api/embed/current).
+ * Covers the pure response shaper + weather-code / wind-direction helpers,
+ * and validates route structure (CORS, IP-geo headers, cache-control).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { weatherLabel, windDir, shapeEmbedResponse } from "./shape";
+
+const source = readFileSync(resolve(__dirname, "route.ts"), "utf-8");
+
+const LOCATION = {
+  name: "Harare",
+  province: "Harare",
+  slug: "harare",
+  country: "ZW",
+  lat: -17.83,
+  lon: 31.05,
+};
+
+const WEATHER = {
+  current: {
+    temperature_2m: 24.4,
+    apparent_temperature: 23.1,
+    relative_humidity_2m: 55,
+    weather_code: 2,
+    wind_speed_10m: 9.2,
+    wind_direction_10m: 135,
+    is_day: 1,
+  },
+  daily: {
+    time: ["2026-06-30", "2026-07-01", "2026-07-02", "2026-07-03", "2026-07-04", "2026-07-05", "2026-07-06", "2026-07-07"],
+    weather_code: [2, 3, 61, 0, 2, 2, 3, 1],
+    temperature_2m_max: [27.6, 25, 22, 28, 27, 26, 24, 25],
+    temperature_2m_min: [14.2, 13, 12, 15, 14, 13, 12, 13],
+    precipitation_probability_max: [0, 20, 80, 0, 5, 10, 30, 0],
+  },
+};
+
+describe("weatherLabel", () => {
+  it("maps known WMO codes", () => {
+    expect(weatherLabel(0)).toBe("Clear sky");
+    expect(weatherLabel(2)).toBe("Partly cloudy");
+    expect(weatherLabel(65)).toBe("Heavy rain");
+    expect(weatherLabel(95)).toBe("Thunderstorm");
+  });
+
+  it("falls back to Unknown for unmapped codes", () => {
+    expect(weatherLabel(999)).toBe("Unknown");
+  });
+});
+
+describe("windDir", () => {
+  it("maps degrees to compass points", () => {
+    expect(windDir(0)).toBe("N");
+    expect(windDir(90)).toBe("E");
+    expect(windDir(135)).toBe("SE");
+    expect(windDir(180)).toBe("S");
+    expect(windDir(360)).toBe("N");
+  });
+});
+
+describe("shapeEmbedResponse", () => {
+  it("rounds current values and derives condition + wind direction", () => {
+    const out = shapeEmbedResponse(WEATHER, LOCATION, "slug");
+    expect(out.current.temp).toBe(24);
+    expect(out.current.feelsLike).toBe(23);
+    expect(out.current.condition).toBe("Partly cloudy");
+    expect(out.current.windDirection).toBe("SE");
+    expect(out.current.isDay).toBe(true);
+    expect(out.current.humidity).toBe(55);
+  });
+
+  it("pulls today's high/low from the first daily entry", () => {
+    const out = shapeEmbedResponse(WEATHER, LOCATION, "slug");
+    expect(out.current.high).toBe(28);
+    expect(out.current.low).toBe(14);
+  });
+
+  it("caps the daily array at 7 entries and labels the first as Today", () => {
+    const out = shapeEmbedResponse(WEATHER, LOCATION, "slug");
+    expect(out.daily).toHaveLength(7);
+    expect(out.daily[0].day).toBe("Today");
+    expect(out.daily[2].condition).toBe("Rain");
+    expect(out.daily[2].precipitationProbability).toBe(80);
+  });
+
+  it("builds an attribution URL from the slug", () => {
+    const out = shapeEmbedResponse(WEATHER, LOCATION, "slug", "https://example.com");
+    expect(out.attribution.url).toBe("https://example.com/harare");
+    expect(out.attribution.name).toBe("mukoko weather");
+  });
+
+  it("is resilient to a null weather payload", () => {
+    const out = shapeEmbedResponse(null, LOCATION, "ip");
+    expect(out.current.temp).toBeNull();
+    expect(out.daily).toEqual([]);
+    expect(out.source).toBe("ip");
+  });
+
+  it("falls back to the site root when the location has no slug", () => {
+    const out = shapeEmbedResponse(WEATHER, { ...LOCATION, slug: "" }, "ip", "https://example.com");
+    expect(out.attribution.url).toBe("https://example.com");
+  });
+});
+
+describe("route structure", () => {
+  it("runs on the edge runtime", () => {
+    expect(source).toContain('export const runtime = "edge"');
+  });
+
+  it("exports GET and OPTIONS handlers", () => {
+    expect(source).toContain("export async function GET");
+    expect(source).toContain("export async function OPTIONS");
+  });
+
+  it("sets permissive CORS for a public embed endpoint", () => {
+    expect(source).toContain('"Access-Control-Allow-Origin": "*"');
+  });
+
+  it("derives location from Vercel IP-geo headers when unparameterised", () => {
+    expect(source).toContain("x-vercel-ip-latitude");
+    expect(source).toContain("x-vercel-ip-longitude");
+  });
+
+  it("calls the existing internal geo + weather endpoints", () => {
+    expect(source).toContain("/api/py/weather");
+    expect(source).toContain("/api/py/geo");
+    expect(source).toContain("/api/py/locations");
+  });
+
+  it("does not shared-cache IP-derived responses", () => {
+    expect(source).toContain("private, max-age=300");
+    expect(source).toContain("Cache-Control");
+  });
+});

--- a/src/app/api/embed/current/route.ts
+++ b/src/app/api/embed/current/route.ts
@@ -31,6 +31,15 @@ export const runtime = "edge";
 const DEFAULT_LAT = -17.83;
 const DEFAULT_LON = 31.05;
 
+// Trusted base URL for internal API calls. Derived ONLY from server env — never
+// from the incoming request (`req.url`/Host is attacker-controllable, which
+// would make the internal fetches an SSRF sink). Mirrors src/app/page.tsx.
+const INTERNAL_BASE =
+  process.env.NEXT_PUBLIC_APP_URL ??
+  (process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : "http://localhost:3000");
+
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, OPTIONS",
@@ -58,7 +67,6 @@ export async function OPTIONS(): Promise<Response> {
 }
 
 export async function GET(req: NextRequest): Promise<Response> {
-  const origin = new URL(req.url).origin;
   const params = req.nextUrl.searchParams;
 
   const qsLat = parseCoord(params.get("lat"));
@@ -78,7 +86,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   } else if (slug && /^[a-z0-9-]{1,80}$/.test(slug)) {
     // 2. Known location slug — resolve to coordinates via internal locations API.
     const loc = await fetchJson<Record<string, unknown> | Record<string, unknown>[]>(
-      `${origin}/api/py/locations?slug=${encodeURIComponent(slug)}`,
+      `${INTERNAL_BASE}/api/py/locations?slug=${encodeURIComponent(slug)}`,
     );
     const doc = Array.isArray(loc) ? loc[0] : loc;
     const dLat = doc ? Number(doc.lat) : NaN;
@@ -116,13 +124,13 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   // Fetch weather (resilient — the internal route never fails, but guard anyway).
   const weather = await fetchJson<WeatherResponse>(
-    `${origin}/api/py/weather?lat=${lat}&lon=${lon}`,
+    `${INTERNAL_BASE}/api/py/weather?lat=${lat}&lon=${lon}`,
   );
 
   // Resolve a display name if we don't already have one (coords / ip paths).
   if (!meta) {
     const geo = await fetchJson<{ nearest?: Record<string, unknown> }>(
-      `${origin}/api/py/geo?lat=${lat}&lon=${lon}`,
+      `${INTERNAL_BASE}/api/py/geo?lat=${lat}&lon=${lon}`,
     );
     const near = geo?.nearest;
     meta = {

--- a/src/app/api/embed/current/route.ts
+++ b/src/app/api/embed/current/route.ts
@@ -1,0 +1,149 @@
+/**
+ * Public embed API — current weather for the visitor's location.
+ *
+ * GET /api/embed/current
+ *   ?lat=<n>&lon=<n>   — explicit coordinates (highest priority)
+ *   ?slug=<location>   — a known location slug
+ *   (none)             — derive location from the request IP via Vercel's
+ *                        `x-vercel-ip-latitude` / `x-vercel-ip-longitude` headers
+ *
+ * This route is a thin public shaper: it reads IP-geo headers, calls the
+ * EXISTING internal `/api/py/geo` (name lookup) and `/api/py/weather`
+ * (weather by lat/lon) endpoints, and returns a compact embed-friendly JSON
+ * payload (current conditions + up to 7 daily entries for the forecast cards).
+ *
+ * It is a PUBLIC embed endpoint: permissive CORS, resilient fallbacks, and
+ * cache-control tuned so IP-derived responses are never shared-cached.
+ */
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import {
+  DEFAULT_SITE,
+  shapeEmbedResponse,
+  type EmbedSource,
+  type LocationMeta,
+  type WeatherResponse,
+} from "./shape";
+
+export const runtime = "edge";
+
+// Harare — used as a last-resort default when no location can be derived.
+const DEFAULT_LAT = -17.83;
+const DEFAULT_LON = 31.05;
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers: { accept: "application/json" } });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+function parseCoord(value: string | null): number | null {
+  if (!value) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const origin = new URL(req.url).origin;
+  const params = req.nextUrl.searchParams;
+
+  const qsLat = parseCoord(params.get("lat"));
+  const qsLon = parseCoord(params.get("lon"));
+  const slug = (params.get("slug") || "").trim().toLowerCase();
+
+  let lat: number;
+  let lon: number;
+  let source: EmbedSource;
+  let meta: LocationMeta | null = null;
+
+  if (qsLat !== null && qsLon !== null) {
+    // 1. Explicit coordinates win.
+    lat = qsLat;
+    lon = qsLon;
+    source = "coords";
+  } else if (slug && /^[a-z0-9-]{1,80}$/.test(slug)) {
+    // 2. Known location slug — resolve to coordinates via internal locations API.
+    const loc = await fetchJson<Record<string, unknown> | Record<string, unknown>[]>(
+      `${origin}/api/py/locations?slug=${encodeURIComponent(slug)}`,
+    );
+    const doc = Array.isArray(loc) ? loc[0] : loc;
+    const dLat = doc ? Number(doc.lat) : NaN;
+    const dLon = doc ? Number(doc.lon) : NaN;
+    if (doc && Number.isFinite(dLat) && Number.isFinite(dLon)) {
+      lat = dLat;
+      lon = dLon;
+      meta = {
+        name: String(doc.name ?? slug),
+        province: String(doc.province ?? ""),
+        slug: String(doc.slug ?? slug),
+        country: String(doc.country ?? ""),
+        lat,
+        lon,
+      };
+    } else {
+      lat = DEFAULT_LAT;
+      lon = DEFAULT_LON;
+    }
+    source = "slug";
+  } else {
+    // 3. Derive location from the request IP (Vercel injects these headers).
+    const ipLat = parseCoord(req.headers.get("x-vercel-ip-latitude"));
+    const ipLon = parseCoord(req.headers.get("x-vercel-ip-longitude"));
+    if (ipLat !== null && ipLon !== null) {
+      lat = ipLat;
+      lon = ipLon;
+      source = "ip";
+    } else {
+      lat = DEFAULT_LAT;
+      lon = DEFAULT_LON;
+      source = "fallback";
+    }
+  }
+
+  // Fetch weather (resilient — the internal route never fails, but guard anyway).
+  const weather = await fetchJson<WeatherResponse>(
+    `${origin}/api/py/weather?lat=${lat}&lon=${lon}`,
+  );
+
+  // Resolve a display name if we don't already have one (coords / ip paths).
+  if (!meta) {
+    const geo = await fetchJson<{ nearest?: Record<string, unknown> }>(
+      `${origin}/api/py/geo?lat=${lat}&lon=${lon}`,
+    );
+    const near = geo?.nearest;
+    meta = {
+      name: near ? String(near.name ?? "Your location") : "Your location",
+      province: near ? String(near.province ?? "") : "",
+      slug: near ? String(near.slug ?? "") : "",
+      country: near ? String(near.country ?? "") : "",
+      lat,
+      lon,
+    };
+  }
+
+  const body = shapeEmbedResponse(weather, meta, source, DEFAULT_SITE);
+
+  // IP-derived responses vary per visitor → must not be shared-cached.
+  const cacheControl =
+    source === "ip" || source === "fallback"
+      ? "private, max-age=300"
+      : "public, max-age=300, s-maxage=600, stale-while-revalidate=1800";
+
+  return NextResponse.json(body, {
+    headers: { ...CORS_HEADERS, "Cache-Control": cacheControl },
+  });
+}

--- a/src/app/api/embed/current/shape.ts
+++ b/src/app/api/embed/current/shape.ts
@@ -1,0 +1,154 @@
+/**
+ * Pure helpers for the public embed API (/api/embed/current).
+ *
+ * Kept in a sibling module (not route.ts) because Next.js route files may only
+ * export route handlers + config — arbitrary named exports are rejected at build.
+ */
+
+export const DEFAULT_SITE = "https://weather.mukoko.com";
+
+// WMO 4677 weather-code → human label (mirrors the embed widget map).
+export function weatherLabel(code: number): string {
+  const map: Record<number, string> = {
+    0: "Clear sky", 1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
+    45: "Fog", 48: "Fog", 51: "Drizzle", 53: "Drizzle", 55: "Drizzle",
+    56: "Freezing drizzle", 57: "Freezing drizzle",
+    61: "Rain", 63: "Rain", 65: "Heavy rain",
+    66: "Freezing rain", 67: "Freezing rain",
+    71: "Snow", 73: "Snow", 75: "Heavy snow", 77: "Snow grains",
+    80: "Showers", 81: "Showers", 82: "Violent showers",
+    85: "Snow showers", 86: "Snow showers",
+    95: "Thunderstorm", 96: "Thunderstorm", 99: "Thunderstorm",
+  };
+  return map[code] ?? "Unknown";
+}
+
+export function windDir(deg: number): string {
+  const dirs = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+  return dirs[Math.round(deg / 45) % 8];
+}
+
+// Weather shapes we consume from /api/py/weather (only the fields we use).
+export interface WeatherCurrent {
+  temperature_2m?: number;
+  apparent_temperature?: number;
+  relative_humidity_2m?: number;
+  weather_code?: number;
+  wind_speed_10m?: number;
+  wind_direction_10m?: number;
+  is_day?: number;
+}
+export interface WeatherDaily {
+  time?: string[];
+  weather_code?: number[];
+  temperature_2m_max?: number[];
+  temperature_2m_min?: number[];
+  precipitation_probability_max?: number[];
+}
+export interface WeatherResponse {
+  current?: WeatherCurrent;
+  daily?: WeatherDaily;
+}
+export interface LocationMeta {
+  name: string;
+  province: string;
+  slug: string;
+  country: string;
+  lat: number;
+  lon: number;
+}
+
+export type EmbedSource = "coords" | "slug" | "ip" | "fallback";
+
+export interface EmbedResponse {
+  location: LocationMeta;
+  current: {
+    temp: number | null;
+    feelsLike: number | null;
+    code: number;
+    condition: string;
+    high: number | null;
+    low: number | null;
+    humidity: number | null;
+    windSpeed: number | null;
+    windDirection: string | null;
+    isDay: boolean;
+  };
+  daily: Array<{
+    date: string;
+    day: string;
+    code: number;
+    condition: string;
+    high: number | null;
+    low: number | null;
+    precipitationProbability: number | null;
+  }>;
+  source: EmbedSource;
+  attribution: { name: string; url: string };
+}
+
+function round(n: number | undefined | null): number | null {
+  return typeof n === "number" && Number.isFinite(n) ? Math.round(n) : null;
+}
+
+function dayName(dateStr: string, index: number): string {
+  if (index === 0) return "Today";
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-ZW", { weekday: "short" });
+}
+
+/**
+ * Pure shaper — converts the internal weather + location payloads into the
+ * compact public embed response.
+ */
+export function shapeEmbedResponse(
+  weather: WeatherResponse | null,
+  location: LocationMeta,
+  source: EmbedSource,
+  site: string = DEFAULT_SITE,
+): EmbedResponse {
+  const current = weather?.current ?? {};
+  const daily = weather?.daily ?? {};
+  const times = daily.time ?? [];
+
+  const dailyEntries = times.slice(0, 7).map((date, i) => {
+    const code = daily.weather_code?.[i] ?? 0;
+    return {
+      date,
+      day: dayName(date, i),
+      code,
+      condition: weatherLabel(code),
+      high: round(daily.temperature_2m_max?.[i]),
+      low: round(daily.temperature_2m_min?.[i]),
+      precipitationProbability: round(daily.precipitation_probability_max?.[i]),
+    };
+  });
+
+  const code = current.weather_code ?? dailyEntries[0]?.code ?? 0;
+
+  return {
+    location,
+    current: {
+      temp: round(current.temperature_2m),
+      feelsLike: round(current.apparent_temperature),
+      code,
+      condition: weatherLabel(code),
+      high: dailyEntries[0]?.high ?? null,
+      low: dailyEntries[0]?.low ?? null,
+      humidity: round(current.relative_humidity_2m),
+      windSpeed: round(current.wind_speed_10m),
+      windDirection:
+        typeof current.wind_direction_10m === "number"
+          ? windDir(current.wind_direction_10m)
+          : null,
+      isDay: current.is_day !== 0,
+    },
+    daily: dailyEntries,
+    source,
+    attribution: {
+      name: "mukoko weather",
+      url: location.slug ? `${site}/${location.slug}` : site,
+    },
+  };
+}

--- a/src/app/embed/page.tsx
+++ b/src/app/embed/page.tsx
@@ -5,7 +5,7 @@ import { Footer } from "@/components/layout/Footer";
 export const metadata: Metadata = {
   title: "Embed Weather Widgets",
   description:
-    "Add mukoko weather widgets to your website. Current conditions, forecasts, and compact badges for any location worldwide.",
+    "Add mukoko weather widgets to your website. Four widget types — current condition, today card, 5-day and 7-day forecast cards — for any location worldwide, or the visitor's own location automatically.",
   alternates: {
     canonical: "https://weather.mukoko.com/embed",
   },
@@ -20,176 +20,178 @@ export default function EmbedPage() {
           Embed Weather Widgets
         </h1>
         <p className="mt-4 text-text-secondary">
-          Add live weather data to any website. Three widget types
-          available — all free, no API key required.
+          Add live weather to any React or Next.js site — all free, no API key
+          required. Four widget types are available. Omit the{" "}
+          <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+            location
+          </code>{" "}
+          prop and the widget automatically shows the visitor&apos;s local
+          weather (detected from their IP).
         </p>
 
-        {/* Current Conditions Widget */}
+        {/* Install */}
         <section className="mt-10">
-          <h2 className="eagle">
-            Current Conditions
-          </h2>
-          <p className="mt-2 text-base text-text-secondary">
-            A card showing live temperature, conditions, humidity, wind, and UV
-            for any location worldwide.
-          </p>
+          <h2 className="eagle">Install</h2>
           <div className="mt-4 tortoise">
             <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`<!-- Current conditions for Harare -->
-<div data-mukoko-widget="current"
-     data-location="harare">
-</div>
-<script src="https://weather.mukoko.com/embed/widget.js" async></script>`}</code>
+              <code className="font-mono text-text-primary">{`import { MukokoWeatherEmbed } from "@mukoko/weather-embed";`}</code>
             </pre>
           </div>
         </section>
 
-        {/* Forecast Widget */}
+        {/* 1. Current condition */}
         <section className="mt-10">
-          <h2 className="eagle">
-            Forecast
-          </h2>
+          <h2 className="eagle">1 · Current condition</h2>
           <p className="mt-2 text-base text-text-secondary">
-            A multi-day forecast strip. Configure 3, 5, or 7 days.
+            A compact inline card — current temperature, condition, and an icon.
+            Great for navbars, headers, or sidebars.
           </p>
           <div className="mt-4 tortoise">
             <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`<!-- 5-day forecast for Bulawayo -->
-<div data-mukoko-widget="forecast"
-     data-location="bulawayo"
-     data-days="5">
-</div>
-<script src="https://weather.mukoko.com/embed/widget.js" async></script>`}</code>
+              <code className="font-mono text-text-primary">{`{/* A specific location */}
+<MukokoWeatherEmbed type="current" location="harare" />
+
+{/* The visitor's own location (IP-based) */}
+<MukokoWeatherEmbed type="current" />`}</code>
             </pre>
           </div>
         </section>
 
-        {/* Badge Widget */}
+        {/* 2. Today card */}
         <section className="mt-10">
-          <h2 className="eagle">
-            Compact Badge
-          </h2>
+          <h2 className="eagle">2 · Today card</h2>
           <p className="mt-2 text-base text-text-secondary">
-            An inline badge that fits in navbars, headers, or sidebars. Shows
-            temperature and condition at a glance.
+            A fuller current-day card — temperature, condition, feels-like, and
+            today&apos;s high / low.
           </p>
           <div className="mt-4 tortoise">
             <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`<!-- Compact badge for Mutare -->
-<div data-mukoko-widget="badge"
-     data-location="mutare">
-</div>
-<script src="https://weather.mukoko.com/embed/widget.js" async></script>`}</code>
+              <code className="font-mono text-text-primary">{`<MukokoWeatherEmbed type="today" location="bulawayo" />`}</code>
             </pre>
           </div>
         </section>
 
-        {/* iframe embed */}
+        {/* 3. 5-day card */}
         <section className="mt-10">
-          <h2 className="eagle">
-            iframe Embed
-          </h2>
+          <h2 className="eagle">3 · 5-day card</h2>
           <p className="mt-2 text-base text-text-secondary">
-            For complete isolation, use an iframe. Useful for CMS platforms
-            that don&apos;t allow custom scripts.
+            A five-day forecast strip — day, condition, and high / low per day.
           </p>
           <div className="mt-4 tortoise">
             <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`<iframe
-  src="https://weather.mukoko.com/embed/iframe/harare?type=current&theme=auto"
-  width="380"
-  height="280"
-  frameborder="0"
-  title="Harare Weather"
-></iframe>`}</code>
+              <code className="font-mono text-text-primary">{`<MukokoWeatherEmbed type="5day" location="victoria-falls" />`}</code>
             </pre>
           </div>
         </section>
 
-        {/* React/Next.js integration */}
+        {/* 4. 7-day card */}
         <section className="mt-10">
-          <h2 className="eagle">
-            React / Next.js
-          </h2>
+          <h2 className="eagle">4 · 7-day card</h2>
           <p className="mt-2 text-base text-text-secondary">
-            For Nyuchi products and React apps, use the{" "}
-            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
-              MukokoWeatherEmbed
-            </code>{" "}
-            component directly.
+            A seven-day forecast strip — same layout as the 5-day card, extended
+            to a full week.
           </p>
           <div className="mt-4 tortoise">
             <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`import { MukokoWeatherEmbed } from "@mukoko/weather-embed";
-
-// Current conditions
-<MukokoWeatherEmbed location="harare" type="current" />
-
-// Forecast
-<MukokoWeatherEmbed location="victoria-falls" type="forecast" days={5} />
-
-// Badge
-<MukokoWeatherEmbed location="marondera" type="badge" />`}</code>
+              <code className="font-mono text-text-primary">{`<MukokoWeatherEmbed type="7day" location="mutare" />`}</code>
             </pre>
           </div>
         </section>
 
-        {/* Configuration options */}
+        {/* Props */}
         <section className="mt-10">
-          <h2 className="eagle">
-            Configuration
-          </h2>
+          <h2 className="eagle">Props</h2>
           <div className="mt-4 overflow-x-auto">
             <table className="w-full text-base">
               <thead>
                 <tr className="border-b border-text-tertiary/10 text-left">
-                  <th className="pb-2 pr-4 font-semibold text-text-primary">Attribute</th>
+                  <th className="pb-2 pr-4 font-semibold text-text-primary">Prop</th>
                   <th className="pb-2 pr-4 font-semibold text-text-primary">Values</th>
                   <th className="pb-2 font-semibold text-text-primary">Description</th>
                 </tr>
               </thead>
               <tbody className="text-text-secondary">
                 <tr className="border-b border-text-tertiary/10">
-                  <td className="py-2 pr-4 font-mono text-base">data-mukoko-widget</td>
-                  <td className="py-2 pr-4">current, forecast, badge</td>
-                  <td className="py-2">Widget type (required)</td>
+                  <td className="py-2 pr-4 font-mono text-base">type</td>
+                  <td className="py-2 pr-4">current, today, 5day, 7day</td>
+                  <td className="py-2">Widget variant (default: current)</td>
                 </tr>
                 <tr className="border-b border-text-tertiary/10">
-                  <td className="py-2 pr-4 font-mono text-base">data-location</td>
+                  <td className="py-2 pr-4 font-mono text-base">location</td>
                   <td className="py-2 pr-4">harare, bulawayo, ...</td>
-                  <td className="py-2">Location slug (required)</td>
+                  <td className="py-2">Location slug. Omit for the visitor&apos;s IP location</td>
                 </tr>
                 <tr className="border-b border-text-tertiary/10">
-                  <td className="py-2 pr-4 font-mono text-base">data-days</td>
-                  <td className="py-2 pr-4">3, 5, 7</td>
-                  <td className="py-2">Forecast days (default: 5)</td>
+                  <td className="py-2 pr-4 font-mono text-base">lat / lon</td>
+                  <td className="py-2 pr-4">numbers</td>
+                  <td className="py-2">Explicit coordinates (override slug + IP)</td>
                 </tr>
                 <tr className="border-b border-text-tertiary/10">
-                  <td className="py-2 pr-4 font-mono text-base">data-theme</td>
+                  <td className="py-2 pr-4 font-mono text-base">theme</td>
                   <td className="py-2 pr-4">light, dark, auto</td>
                   <td className="py-2">Theme (default: auto)</td>
+                </tr>
+                <tr className="border-b border-text-tertiary/10">
+                  <td className="py-2 pr-4 font-mono text-base">apiUrl</td>
+                  <td className="py-2 pr-4">URL</td>
+                  <td className="py-2">API origin (default: weather.mukoko.com)</td>
                 </tr>
               </tbody>
             </table>
           </div>
         </section>
 
-        {/* Available locations */}
+        {/* Public API */}
         <section className="mt-10 mb-10">
-          <h2 className="eagle">
-            Available Locations
-          </h2>
+          <h2 className="eagle">Public API</h2>
           <p className="mt-2 text-base text-text-secondary">
-            265+ locations worldwide. Use the slug value in{" "}
+            The widget is powered by a public JSON endpoint you can call directly
+            from any site. With no parameters it returns weather for the
+            visitor&apos;s location (derived from their IP); pass{" "}
             <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
-              data-location
-            </code>
-            . Full list available at{" "}
+              slug
+            </code>{" "}
+            or{" "}
             <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
-              GET /api/locations
-            </code>
-            .
+              lat
+            </code>{" "}
+            &amp;{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              lon
+            </code>{" "}
+            to pin a location. CORS is open to all origins.
           </p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`# Visitor's local weather (IP-based)
+GET https://weather.mukoko.com/api/embed/current
+
+# A specific location
+GET https://weather.mukoko.com/api/embed/current?slug=harare
+
+# Explicit coordinates
+GET https://weather.mukoko.com/api/embed/current?lat=-17.83&lon=31.05`}</code>
+            </pre>
+          </div>
+          <p className="mt-4 text-base text-text-secondary">Response shape:</p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`{
+  "location": { "name": "Harare", "province": "Harare",
+                "slug": "harare", "country": "ZW" },
+  "current":  { "temp": 24, "feelsLike": 23, "code": 2,
+                "condition": "Partly cloudy", "high": 27, "low": 14,
+                "humidity": 55, "windSpeed": 9, "windDirection": "SE",
+                "isDay": true },
+  "daily": [ { "date": "2026-06-30", "day": "Today", "code": 2,
+               "condition": "Partly cloudy", "high": 27, "low": 14,
+               "precipitationProbability": 0 } /* up to 7 */ ],
+  "source": "ip",
+  "attribution": { "name": "mukoko weather",
+                   "url": "https://weather.mukoko.com/harare" }
+}`}</code>
+            </pre>
+          </div>
         </section>
       </main>
       <Footer />

--- a/src/components/embed/MukokoWeatherEmbed.module.css
+++ b/src/components/embed/MukokoWeatherEmbed.module.css
@@ -59,67 +59,119 @@
   font-weight: 600;
 }
 
-/* ---- Current Widget ---- */
+/* ---- Current Condition (compact) ---- */
 .currentCard {
+  composes: card;
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  max-width: 320px;
+}
+
+.currentIcon {
+  font-size: 34px;
+  line-height: 1;
+}
+
+.currentBody {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.currentTemp {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--mkw-text);
+  line-height: 1;
+  font-family: 'Noto Serif', Georgia, serif;
+}
+
+.currentMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.currentCondition {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--mkw-text);
+}
+
+.currentLocationName {
+  font-size: 12px;
+  color: var(--mkw-text-tertiary);
+}
+
+/* ---- Today Card ---- */
+.todayCard {
   composes: card;
   max-width: 360px;
 }
 
-.currentHeader {
+.todayHeader {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   margin-bottom: 12px;
 }
 
-.currentLocationName {
+.todayLocationName {
   font-weight: 600;
   font-size: 14px;
   color: var(--mkw-text);
 }
 
-.currentProvince {
+.todayProvince {
   font-size: 12px;
   color: var(--mkw-text-tertiary);
 }
 
-.currentBody {
+.todayBody {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.todayIcon {
+  font-size: 48px;
+  line-height: 1;
+}
+
+.todayTempBlock {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  margin-bottom: 16px;
 }
 
-.currentTemp {
-  font-size: 48px;
+.todayTemp {
+  font-size: 46px;
   font-weight: 700;
   color: var(--mkw-text);
-  line-height: 1.1;
+  line-height: 1.05;
   font-family: 'Noto Serif', Georgia, serif;
 }
 
-.currentCondition {
-  font-size: 16px;
+.todayCondition {
+  font-size: 15px;
   font-weight: 500;
   color: var(--mkw-text);
 }
 
-.currentFeelsLike {
-  font-size: 13px;
-  color: var(--mkw-text-secondary);
-}
-
-.currentStats {
+.todayStats {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
   padding-top: 12px;
   border-top: 1px solid var(--mkw-border);
-  font-size: 12px;
+  font-size: 13px;
   color: var(--mkw-text-secondary);
 }
 
-/* ---- Forecast Widget ---- */
+/* ---- Forecast Card (5-day / 7-day) ---- */
 .forecastCard {
   composes: card;
   max-width: 440px;
@@ -152,6 +204,11 @@
   color: var(--mkw-text-secondary);
 }
 
+.forecastIcon {
+  font-size: 18px;
+  line-height: 1;
+}
+
 .forecastCondition {
   flex: 1;
   color: var(--mkw-text-secondary);
@@ -161,39 +218,4 @@
   font-weight: 600;
   font-family: monospace;
   font-size: 12px;
-}
-
-/* ---- Badge Widget ---- */
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  background: var(--mkw-bg);
-  border: 1px solid var(--mkw-border);
-  border-radius: 9999px;
-  font-size: 13px;
-  color: var(--mkw-text);
-  text-decoration: none;
-  white-space: nowrap;
-  font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
-}
-
-.badgeTemp {
-  font-weight: 700;
-}
-
-.badgeCondition {
-  color: var(--mkw-text-secondary);
-}
-
-.badgeLocation {
-  color: var(--mkw-text-tertiary);
-  font-size: 11px;
-}
-
-.badgeBrand {
-  color: var(--mkw-primary);
-  font-size: 10px;
-  font-weight: 600;
 }

--- a/src/components/embed/MukokoWeatherEmbed.test.ts
+++ b/src/components/embed/MukokoWeatherEmbed.test.ts
@@ -3,16 +3,14 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 
 /**
- * Tests for MukokoWeatherEmbed CSS module.
- * Validates that the embed widget uses CSS custom properties via a module
- * instead of inline styles with hardcoded values.
+ * Tests for MukokoWeatherEmbed — validates the four supported embed variants,
+ * the self-contained CSS module (no inline styles / hardcoded colors in the
+ * component), and that the widget talks to the public embed API.
  */
 
-// Read the CSS module file content for validation
 const cssModulePath = resolve(__dirname, "./MukokoWeatherEmbed.module.css");
 const cssContent = readFileSync(cssModulePath, "utf-8");
 
-// Read the component file content
 const componentPath = resolve(__dirname, "./MukokoWeatherEmbed.tsx");
 const componentContent = readFileSync(componentPath, "utf-8");
 
@@ -29,19 +27,17 @@ describe("MukokoWeatherEmbed CSS module", () => {
     expect(cssContent).toContain(".widgetDark");
   });
 
-  it("defines styles for all widget types", () => {
+  it("defines styles for all four widget variants", () => {
     expect(cssContent).toContain(".currentCard");
+    expect(cssContent).toContain(".todayCard");
     expect(cssContent).toContain(".forecastCard");
-    expect(cssContent).toContain(".badge");
   });
 
   it("uses CSS custom properties for colors, not hardcoded values", () => {
-    // Extract all property declarations (not custom property definitions)
     const propertyDeclarations = cssContent
       .split("\n")
       .filter((line) => {
         const trimmed = line.trim();
-        // Skip custom property definitions (--mkw-*) and comments
         return (
           trimmed.includes(":") &&
           !trimmed.startsWith("--") &&
@@ -50,20 +46,16 @@ describe("MukokoWeatherEmbed CSS module", () => {
         );
       });
 
-    // Color-related properties should reference var(--mkw-*) not hardcoded colors
-    const colorProps = propertyDeclarations.filter((line) =>
-      /\b(color|background|border-top|border-bottom)\b/.test(line) &&
-      !line.includes("composes")
+    const colorProps = propertyDeclarations.filter(
+      (line) =>
+        /\b(color|background|border-top|border-bottom)\b/.test(line) &&
+        !line.includes("composes"),
     );
 
     for (const prop of colorProps) {
-      // Must use var(--mkw-*) for color values
       if (prop.includes("var(--mkw-")) continue;
-      // "none" is acceptable for border-bottom
       if (/:\s*none/.test(prop)) continue;
-      // border shorthand with var() is fine
       if (prop.includes("var(")) continue;
-      // Fail if there's a raw hex or rgb color
       expect(prop).not.toMatch(/#[0-9a-fA-F]{3,8}/);
     }
   });
@@ -71,18 +63,40 @@ describe("MukokoWeatherEmbed CSS module", () => {
 
 describe("MukokoWeatherEmbed component", () => {
   it("imports the CSS module", () => {
-    expect(componentContent).toContain('import styles from "./MukokoWeatherEmbed.module.css"');
+    expect(componentContent).toContain(
+      'import styles from "./MukokoWeatherEmbed.module.css"',
+    );
   });
 
   it("does not use inline style objects", () => {
-    // The component should not have style={{...}} patterns
     expect(componentContent).not.toMatch(/style=\{\{/);
   });
 
-  it("uses styles.* for class names", () => {
-    expect(componentContent).toContain("styles.widget");
+  it("supports exactly the four documented variants", () => {
+    expect(componentContent).toContain('"current" | "today" | "5day" | "7day"');
+    expect(componentContent).toContain('type === "today"');
+    expect(componentContent).toContain('type === "5day"');
+    expect(componentContent).toContain('type === "7day"');
+  });
+
+  it("no longer supports the removed badge / forecast variants", () => {
+    expect(componentContent).not.toContain('type === "badge"');
+    expect(componentContent).not.toContain('type === "forecast"');
+  });
+
+  it("calls the public embed API", () => {
+    expect(componentContent).toContain("/api/embed/current");
+  });
+
+  it("defaults to IP-based weather when no location is configured", () => {
+    // When no slug/lat/lon, the query string is empty → API derives from IP.
+    expect(componentContent).toContain("if (location)");
+    expect(componentContent).toContain('qs.set("slug", location)');
+  });
+
+  it("uses styles.* for the variant class names", () => {
     expect(componentContent).toContain("styles.currentCard");
+    expect(componentContent).toContain("styles.todayCard");
     expect(componentContent).toContain("styles.forecastCard");
-    expect(componentContent).toContain("styles.badge");
   });
 });

--- a/src/components/embed/MukokoWeatherEmbed.tsx
+++ b/src/components/embed/MukokoWeatherEmbed.tsx
@@ -3,99 +3,136 @@
 import { useState, useEffect } from "react";
 import styles from "./MukokoWeatherEmbed.module.css";
 
+/** The four supported embed variants. */
+export type EmbedType = "current" | "today" | "5day" | "7day";
+
 interface MukokoWeatherEmbedProps {
-  /** Location slug (e.g. "harare", "bulawayo", "marondera") */
-  location: string;
-  /** Widget type */
-  type?: "current" | "forecast" | "badge";
-  /** Number of forecast days (for type="forecast") */
-  days?: number;
+  /**
+   * Widget variant:
+   * - `current` — compact current temp + condition + icon
+   * - `today`   — fuller current-day card (temp, condition, feels-like, high/low)
+   * - `5day`    — 5-day forecast strip
+   * - `7day`    — 7-day forecast strip
+   */
+  type?: EmbedType;
+  /**
+   * Optional location slug (e.g. "harare"). When omitted, the widget shows the
+   * VISITOR's local weather via the IP-based public embed API.
+   */
+  location?: string;
+  /** Optional explicit coordinates (override slug + IP detection). */
+  lat?: number;
+  lon?: number;
   /** Theme override */
   theme?: "light" | "dark" | "auto";
-  /** Base API URL (defaults to weather.mukoko.com) */
+  /** Base URL of the mukoko weather deployment (defaults to weather.mukoko.com) */
   apiUrl?: string;
   /** Additional CSS class */
   className?: string;
 }
 
-interface WeatherData {
-  location: {
-    name: string;
-    slug: string;
-    province: string;
-    elevation: number;
-    tags: string[];
+interface EmbedData {
+  location: { name: string; province: string; slug: string; country: string };
+  current: {
+    temp: number | null;
+    feelsLike: number | null;
+    code: number;
+    condition: string;
+    high: number | null;
+    low: number | null;
+    humidity: number | null;
+    windSpeed: number | null;
+    windDirection: string | null;
+    isDay: boolean;
   };
-  weather: {
-    current: {
-      temperature_2m: number;
-      relative_humidity_2m: number;
-      apparent_temperature: number;
-      weather_code: number;
-      wind_speed_10m: number;
-      wind_direction_10m: number;
-      uv_index: number;
-      is_day: number;
-    };
-    daily: {
-      time: string[];
-      weather_code: number[];
-      temperature_2m_max: number[];
-      temperature_2m_min: number[];
-      precipitation_probability_max: number[];
-    };
-  };
-  _meta: { url: string };
+  daily: Array<{
+    date: string;
+    day: string;
+    code: number;
+    condition: string;
+    high: number | null;
+    low: number | null;
+    precipitationProbability: number | null;
+  }>;
+  attribution: { name: string; url: string };
 }
 
-function weatherLabel(code: number): string {
-  const map: Record<number, string> = {
-    0: "Clear sky", 1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
-    45: "Fog", 48: "Fog", 51: "Drizzle", 53: "Drizzle", 55: "Drizzle",
-    61: "Rain", 63: "Rain", 65: "Heavy rain", 80: "Showers", 81: "Showers",
-    95: "Thunderstorm", 96: "Thunderstorm", 99: "Thunderstorm",
-  };
-  return map[code] ?? "Unknown";
+/** WMO 4677 weather-code → emoji glyph (self-contained icon, no assets). */
+function weatherEmoji(code: number, isDay = true): string {
+  if (code === 0 || code === 1) return isDay ? "☀️" : "🌙";
+  if (code === 2) return isDay ? "⛅" : "☁️";
+  if (code === 3) return "☁️";
+  if (code === 45 || code === 48) return "🌫️";
+  if (code >= 51 && code <= 57) return "🌦️";
+  if (code >= 61 && code <= 67) return "🌧️";
+  if (code >= 71 && code <= 77) return "❄️";
+  if (code >= 80 && code <= 82) return "🌧️";
+  if (code >= 85 && code <= 86) return "🌨️";
+  if (code >= 95) return "⛈️";
+  return "🌡️";
 }
 
-function windDir(deg: number): string {
-  const dirs = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
-  return dirs[Math.round(deg / 45) % 8];
+function temp(n: number | null): string {
+  return n === null ? "--" : `${n}°`;
 }
 
 export function MukokoWeatherEmbed({
-  location,
   type = "current",
-  days = 5,
+  location,
+  lat,
+  lon,
   theme = "auto",
   apiUrl = "https://weather.mukoko.com",
   className = "",
 }: MukokoWeatherEmbedProps) {
-  const [data, setData] = useState<WeatherData | null>(null);
+  const [data, setData] = useState<EmbedData | null>(null);
   const [error, setError] = useState(false);
 
   const isDark =
     theme === "dark" ||
-    (theme === "auto" && typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    (theme === "auto" &&
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches);
 
   const themeClass = isDark ? `${styles.widget} ${styles.widgetDark}` : styles.widget;
 
   useEffect(() => {
-    fetch(`${apiUrl}/embed/data/${encodeURIComponent(location)}`)
+    const qs = new URLSearchParams();
+    if (typeof lat === "number" && typeof lon === "number") {
+      qs.set("lat", String(lat));
+      qs.set("lon", String(lon));
+    } else if (location) {
+      qs.set("slug", location);
+    }
+    const query = qs.toString();
+    let cancelled = false;
+    fetch(`${apiUrl}/api/embed/current${query ? `?${query}` : ""}`)
       .then((r) => {
         if (!r.ok) throw new Error(String(r.status));
         return r.json();
       })
-      .then((d) => setData(d as WeatherData))
-      .catch(() => setError(true));
-  }, [location, apiUrl]);
+      .then((d) => {
+        if (!cancelled) setData(d as EmbedData);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [location, lat, lon, apiUrl]);
 
   if (error) {
     return (
       <div className={`${themeClass} ${className}`}>
         <div className={styles.errorMessage}>
           Weather unavailable —{" "}
-          <a href={`${apiUrl}/${location}`} target="_blank" rel="noopener noreferrer" className={styles.errorLink}>
+          <a
+            href={location ? `${apiUrl}/${location}` : apiUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.errorLink}
+          >
             view on mukoko weather
           </a>
         </div>
@@ -111,86 +148,135 @@ export function MukokoWeatherEmbed({
     );
   }
 
-  if (type === "badge") {
-    return <BadgeWidget data={data} themeClass={themeClass} className={className} />;
+  if (type === "today") {
+    return <TodayCard data={data} themeClass={themeClass} className={className} />;
   }
-
-  if (type === "forecast") {
-    return <ForecastWidget data={data} days={days} themeClass={themeClass} className={className} />;
+  if (type === "5day") {
+    return <ForecastCard data={data} days={5} themeClass={themeClass} className={className} />;
   }
-
-  return <CurrentWidget data={data} themeClass={themeClass} className={className} />;
+  if (type === "7day") {
+    return <ForecastCard data={data} days={7} themeClass={themeClass} className={className} />;
+  }
+  return <CurrentCondition data={data} themeClass={themeClass} className={className} />;
 }
 
-function CurrentWidget({ data, themeClass, className }: { data: WeatherData; themeClass: string; className: string }) {
-  const c = data.weather.current;
+function Attribution({ data }: { data: EmbedData }) {
+  return (
+    <a
+      href={data.attribution.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={styles.attribution}
+    >
+      {data.attribution.name}
+    </a>
+  );
+}
+
+/** current condition — compact current temp + condition + icon */
+function CurrentCondition({
+  data,
+  themeClass,
+  className,
+}: {
+  data: EmbedData;
+  themeClass: string;
+  className: string;
+}) {
+  const c = data.current;
   return (
     <div className={`${themeClass} ${className}`}>
       <div className={styles.currentCard}>
-        <div className={styles.currentHeader}>
-          <span className={styles.currentLocationName}>{data.location.name}</span>
-          <span className={styles.currentProvince}>{data.location.province}</span>
-        </div>
+        <span className={styles.currentIcon} aria-hidden="true">
+          {weatherEmoji(c.code, c.isDay)}
+        </span>
         <div className={styles.currentBody}>
-          <span className={styles.currentTemp}>
-            {Math.round(c.temperature_2m)}°C
+          <span className={styles.currentTemp}>{temp(c.temp)}</span>
+          <span className={styles.currentMeta}>
+            <span className={styles.currentCondition}>{c.condition}</span>
+            <span className={styles.currentLocationName}>{data.location.name}</span>
           </span>
-          <span className={styles.currentCondition}>{weatherLabel(c.weather_code)}</span>
-          <span className={styles.currentFeelsLike}>Feels like {Math.round(c.apparent_temperature)}°C</span>
         </div>
-        <div className={styles.currentStats}>
-          <span>Humidity {c.relative_humidity_2m}%</span>
-          <span>Wind {Math.round(c.wind_speed_10m)} km/h {windDir(c.wind_direction_10m)}</span>
-          <span>UV {c.uv_index}</span>
-        </div>
-        <a href={data._meta.url} target="_blank" rel="noopener noreferrer" className={styles.attribution}>
-          mukoko weather
-        </a>
       </div>
     </div>
   );
 }
 
-function ForecastWidget({ data, days, themeClass, className }: { data: WeatherData; days: number; themeClass: string; className: string }) {
-  const d = data.weather.daily;
-  const n = Math.min(days, d.time.length);
+/** today card — temp, condition, feels-like, high/low */
+function TodayCard({
+  data,
+  themeClass,
+  className,
+}: {
+  data: EmbedData;
+  themeClass: string;
+  className: string;
+}) {
+  const c = data.current;
+  return (
+    <div className={`${themeClass} ${className}`}>
+      <div className={styles.todayCard}>
+        <div className={styles.todayHeader}>
+          <span className={styles.todayLocationName}>{data.location.name}</span>
+          {data.location.province && (
+            <span className={styles.todayProvince}>{data.location.province}</span>
+          )}
+        </div>
+        <div className={styles.todayBody}>
+          <span className={styles.todayIcon} aria-hidden="true">
+            {weatherEmoji(c.code, c.isDay)}
+          </span>
+          <div className={styles.todayTempBlock}>
+            <span className={styles.todayTemp}>{temp(c.temp)}</span>
+            <span className={styles.todayCondition}>{c.condition}</span>
+          </div>
+        </div>
+        <div className={styles.todayStats}>
+          <span>Feels like {temp(c.feelsLike)}</span>
+          <span>
+            H {temp(c.high)} · L {temp(c.low)}
+          </span>
+        </div>
+        <Attribution data={data} />
+      </div>
+    </div>
+  );
+}
+
+/** 5-day / 7-day forecast strip */
+function ForecastCard({
+  data,
+  days,
+  themeClass,
+  className,
+}: {
+  data: EmbedData;
+  days: number;
+  themeClass: string;
+  className: string;
+}) {
+  const n = Math.min(days, data.daily.length);
   return (
     <div className={`${themeClass} ${className}`}>
       <div className={styles.forecastCard}>
-        <div className={styles.forecastTitle}>
-          {data.location.name} Forecast
-        </div>
-        {Array.from({ length: n }).map((_, i) => {
-          const date = new Date(d.time[i]);
-          const dayName = i === 0 ? "Today" : date.toLocaleDateString("en-ZW", { weekday: "short" });
-          return (
-            <div key={d.time[i]} className={i < n - 1 ? styles.forecastRowBorder : styles.forecastRow}>
-              <span className={styles.forecastDay}>{dayName}</span>
-              <span className={styles.forecastCondition}>{weatherLabel(d.weather_code[i])}</span>
-              <span className={styles.forecastTemps}>
-                {Math.round(d.temperature_2m_max[i])}° / {Math.round(d.temperature_2m_min[i])}°
-              </span>
-            </div>
-          );
-        })}
-        <a href={data._meta.url} target="_blank" rel="noopener noreferrer" className={styles.attribution}>
-          mukoko weather
-        </a>
+        <div className={styles.forecastTitle}>{data.location.name} · {days}-day forecast</div>
+        {data.daily.slice(0, n).map((d, i) => (
+          <div
+            key={d.date}
+            className={i < n - 1 ? styles.forecastRowBorder : styles.forecastRow}
+          >
+            <span className={styles.forecastDay}>{d.day}</span>
+            <span className={styles.forecastIcon} aria-hidden="true">
+              {weatherEmoji(d.code)}
+            </span>
+            <span className={styles.forecastCondition}>{d.condition}</span>
+            <span className={styles.forecastTemps}>
+              {temp(d.high)} / {temp(d.low)}
+            </span>
+          </div>
+        ))}
+        <Attribution data={data} />
       </div>
-    </div>
-  );
-}
-
-function BadgeWidget({ data, themeClass, className }: { data: WeatherData; themeClass: string; className: string }) {
-  const c = data.weather.current;
-  return (
-    <div className={`${themeClass} ${className}`}>
-      <a href={data._meta.url} target="_blank" rel="noopener noreferrer" className={styles.badge}>
-        <span className={styles.badgeTemp}>{Math.round(c.temperature_2m)}°C</span>
-        <span className={styles.badgeCondition}>{weatherLabel(c.weather_code)}</span>
-        <span className={styles.badgeLocation}>{data.location.name}</span>
-        <span className={styles.badgeBrand}>mukoko</span>
-      </a>
     </div>
   );
 }

--- a/src/components/embed/index.ts
+++ b/src/components/embed/index.ts
@@ -1,1 +1,2 @@
 export { MukokoWeatherEmbed } from "./MukokoWeatherEmbed";
+export type { EmbedType } from "./MukokoWeatherEmbed";


### PR DESCRIPTION
## Summary

Reworks the embeddable weather widget to support **exactly four** variants and adds a **public IP-based current-weather API** so a site that embeds the widget shows the visitor's local weather with zero configuration.

### 1. Embed widget — 4 variants only
`src/components/embed/MukokoWeatherEmbed.tsx` (+ `.module.css`) now supports EXACTLY:
- **`current`** — compact current temp + condition + icon
- **`today`** — fuller current-day card (temp, condition, feels-like, high/low)
- **`5day`** — 5-day forecast strip
- **`7day`** — 7-day forecast strip

The old `badge` and generic `forecast` variants are removed. When no `location` (or `lat`/`lon`) is passed, the widget calls the new public API which resolves the **visitor's location from their IP** — so embeds "just work" locally. Styling stays self-contained in the CSS module (no Tailwind, no inline styles); icons are self-contained emoji glyphs keyed off WMO codes.

### 2. New public API — `GET /api/embed/current`
New Next.js Edge route handler `src/app/api/embed/current/route.ts` (pure helpers in `shape.ts`):
- `?lat=&lon=` (explicit) or `?slug=<location>` pin a location; **otherwise** the location is derived from the request IP via Vercel's `x-vercel-ip-latitude` / `x-vercel-ip-longitude` headers, falling back to Harare.
- Internally calls the **existing** `/api/py/geo` (IP/coords → nearest location name) and `/api/py/weather` (weather by lat/lon), then shapes a compact embed response. **`api/py/_weather.py` is untouched.**
- Permissive CORS (`Access-Control-Allow-Origin: *`, `OPTIONS` handler). IP-derived responses use `private` cache-control so they're never shared-cached; slug/coords responses get CDN caching.
- Resilient: every internal fetch is guarded; a null weather payload still yields a well-formed response.

**Response shape:**
```jsonc
{
  "location": { "name": "Harare", "province": "Harare", "slug": "harare", "country": "ZW" },
  "current":  { "temp": 24, "feelsLike": 23, "code": 2, "condition": "Partly cloudy",
                "high": 27, "low": 14, "humidity": 55, "windSpeed": 9,
                "windDirection": "SE", "isDay": true },
  "daily":    [ { "date": "2026-06-30", "day": "Today", "code": 2, "condition": "Partly cloudy",
                  "high": 27, "low": 14, "precipitationProbability": 0 } /* up to 7 */ ],
  "source": "ip",
  "attribution": { "name": "mukoko weather", "url": "https://weather.mukoko.com/harare" }
}
```

### How to embed each of the 4 types (React)
```tsx
import { MukokoWeatherEmbed } from "@mukoko/weather-embed";

<MukokoWeatherEmbed type="current" location="harare" /> {/* or omit location → visitor IP */}
<MukokoWeatherEmbed type="today"   location="bulawayo" />
<MukokoWeatherEmbed type="5day"    location="victoria-falls" />
<MukokoWeatherEmbed type="7day"    location="mutare" />
```
Third parties can also call the JSON API directly (open CORS): `GET https://weather.mukoko.com/api/embed/current[?slug=…|lat=…&lon=…]`.

### Docs / tests
- Rewrote `/embed` docs page to show the 4 types + the public API (removed the old non-existent `widget.js` / iframe sections).
- Updated `MukokoWeatherEmbed.test.ts`; added `route.test.ts` (shaper, weather-code / wind-direction helpers, CORS / IP-header / cache-control structure).
- Updated README API table + CLAUDE.md project-structure line.

### Verification
- `npm test` — **1675 passed**
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm run build` — compiles; `/api/embed/current` registered as a dynamic route

No Python touched (no `pytest` needed). No files from the do-not-touch list modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)