### PR TITLE
feat(places): use places.places POIs to refine location resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1722,8 +1722,12 @@ Mukoko-weather sits on the shared **Nyuchi Platform cluster** (27 databases). Mu
 | ---------------------------------------- | ---------------------------------------------------------- |
 | `resolveLocationSlug(slug)`              | Clean URL slug → adapted `LocationDoc` via placesGeo       |
 | `nearestPlacesGeo(lat, lon, maxKm?)`     | $nearSphere on placesGeo for IP-geo / GPS reverse lookup   |
+| `nearestPlace(lat, lon, maxKm?)`         | $nearSphere on `places.places` POIs — tight ≤250 m match   |
+| `poiTypeFromPlace(doc)`                  | Extract a single POI type (school/hospital/market/park)    |
 | `searchPlaces(query, bbox?)`             | Searches `places.places` POIs for the explore/search flows |
 | `adaptPlacesGeoToLocationDoc(doc, hint)` | Adapter — placesGeo doc → legacy `LocationDoc` shape       |
+
+**POI-nearest refinement (create-on-demand):** After a GPS/coords reverse-geocode, `geo_lookup` / `add_location` (`api/py/_locations.py` `_match_nearby_poi` → `_places_geo.find_nearest_place`) query `places.places` for the nearest POI within **≤250 m** (`POI_MATCH_RADIUS_KM`). If a named POI is that close, its name replaces the raw reverse-geocode name (richer + consistent with the platform POI catalog) and its type is stamped onto `sourceProvenance.mukokoPoiType` and surfaced as `poiType` on the location payload (so the location page + AI summary can mention "school", "hospital", "market", "park"). This is deliberately tight — NOT a coarse distance-snap to far-away places. The whole lookup is wrapped in try/except and falls back to the reverse-geocode on any miss, empty result, or missing 2dsphere index. TS mirror: `nearestPlace` / `poiTypeFromPlace` in `src/lib/places.ts`; the adapter surfaces `poiType` from `sourceProvenance.mukokoPoiType`.
 
 Resolution chain for `/harare`:
 

--- a/api/py/_locations.py
+++ b/api/py/_locations.py
@@ -33,8 +33,11 @@ from ._places_resolver import (
 )
 from ._places_geo import (
     find_nearby_placesgeo,
+    find_nearest_place,
+    poi_type_from_place,
     upsert_placesgeo_city,
     get_country_id,
+    POI_MATCH_RADIUS_KM,
 )
 
 router = APIRouter()
@@ -627,6 +630,31 @@ def _find_duplicate(
         return None
 
 
+def _match_nearby_poi(lat: float, lon: float) -> dict | None:
+    """Best-effort nearest-POI lookup against ``places.places``.
+
+    Returns ``{"name": str, "poiType": str | None}`` when a *named* POI exists
+    within ``POI_MATCH_RADIUS_KM`` (≤250 m) of (lat, lon), else ``None``.
+
+    A very close named POI (a school, hospital, market, park) gives a richer,
+    more consistent location name than a raw reverse-geocode. This is
+    intentionally tight — it is NOT a coarse distance-snap to far-away places.
+    Wrapped so a POI-lookup failure never breaks location resolution: any
+    error, missing index, or empty result falls through to ``None`` and the
+    caller keeps its reverse-geocoded name.
+    """
+    try:
+        poi = find_nearest_place(lat, lon, POI_MATCH_RADIUS_KM)
+    except Exception:  # noqa: BLE001
+        return None
+    if not poi:
+        return None
+    name = (poi.get("name") or "").strip()
+    if not name:
+        return None
+    return {"name": name, "poiType": poi_type_from_place(poi)}
+
+
 @router.get("/api/py/geo")
 async def geo_lookup(
     lat: float,
@@ -667,6 +695,16 @@ async def geo_lookup(
                     status_code=422,
                     detail="Could not determine location name",
                 )
+
+            # ── POI refinement — prefer a very-close named POI (≤250 m) ──────
+            # If the user is essentially standing on a named POI (school,
+            # hospital, market, park), use its name/type instead of the raw
+            # reverse-geocode — richer and consistent with the platform's POI
+            # catalog. Best-effort; falls back to the reverse-geocode on miss.
+            poi_match = _match_nearby_poi(lat, lon)
+            poi_type = poi_match.get("poiType") if poi_match else None
+            if poi_match:
+                geocoded["name"] = poi_match["name"]
 
             # ── Tight duplicate check against placesGeo (Phase 0G) ───────────
             # ONLY a 1km same-name dedup. Anything wider would snap a specific
@@ -730,6 +768,7 @@ async def geo_lookup(
                     mukoko_slug=slug,
                     mukoko_tags=tags,
                     mukoko_nominatim_address=geocoded.get("nominatimAddress"),
+                    mukoko_poi_type=poi_type,
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
@@ -751,6 +790,8 @@ async def geo_lookup(
                 "geo": {"type": "Point", "coordinates": [geocoded["lon"], geocoded["lat"]]},
                 "nominatimAddress": geocoded.get("nominatimAddress", {}),
             }
+            if poi_type:
+                new_loc["poiType"] = poi_type
 
             # Enrich: resolve seasons for this country if not already known
             _enrich_location_with_ai(geocoded["country"], lat, lon)
@@ -867,6 +908,13 @@ async def add_location(request: Request):
         if not geocoded:
             raise HTTPException(status_code=422, detail="Could not determine location name")
 
+        # POI refinement — prefer a very-close named POI (≤250 m) over the raw
+        # reverse-geocode (best-effort; falls back to the reverse-geocode name).
+        poi_match = _match_nearby_poi(lat, lon)
+        poi_type = poi_match.get("poiType") if poi_match else None
+        if poi_match:
+            geocoded["name"] = poi_match["name"]
+
         # Duplicate check (1km radius + name/country match)
         duplicate = _find_duplicate(
             lat, lon, DEDUP_RADIUS_KM,
@@ -948,6 +996,7 @@ async def add_location(request: Request):
                 mukoko_slug=slug,
                 mukoko_tags=tags,
                 mukoko_nominatim_address=geocoded.get("nominatimAddress"),
+                mukoko_poi_type=poi_type,
             )
             places_geo_id = placesgeo_doc.get("_id")
             places_geo_slug = placesgeo_doc.get("slug")
@@ -979,17 +1028,21 @@ async def add_location(request: Request):
         # Enrich: resolve seasons for this country if not already known
         _enrich_location_with_ai(geocoded["country"], lat, lon)
 
+        location_payload = {
+            "slug": new_loc["slug"],
+            "name": new_loc["name"],
+            "province": new_loc["province"],
+            "country": new_loc.get("country", geocoded["country"]),
+            "lat": new_loc["lat"],
+            "lon": new_loc["lon"],
+            "elevation": new_loc["elevation"],
+        }
+        if poi_type:
+            location_payload["poiType"] = poi_type
+
         return {
             "mode": "created",
-            "location": {
-                "slug": new_loc["slug"],
-                "name": new_loc["name"],
-                "province": new_loc["province"],
-                "country": new_loc.get("country", geocoded["country"]),
-                "lat": new_loc["lat"],
-                "lon": new_loc["lon"],
-                "elevation": new_loc["elevation"],
-            },
+            "location": location_payload,
             "placesGeoId": places_geo_id,
             "placesGeoSlug": places_geo_slug,
         }

--- a/api/py/_places_geo.py
+++ b/api/py/_places_geo.py
@@ -25,7 +25,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
-from ._db import places_db, places_geo_collection
+from ._db import places_collection, places_db, places_geo_collection
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +234,70 @@ def find_nearby_placesgeo(
 
 
 # ---------------------------------------------------------------------------
+# places.places — nearest POI matching (location refinement)
+# ---------------------------------------------------------------------------
+
+#: Tight radius for POI-nearest matching. POIs are point features (a school, a
+#: shop, a clinic); we only prefer one when the user is essentially standing on
+#: it. Intentionally small (≤250 m) — this is NOT a coarse city snap.
+POI_MATCH_RADIUS_KM: float = 0.25
+
+
+def poi_type_from_place(doc: Optional[dict]) -> Optional[str]:
+    """Return a single human-facing POI type from a ``places.places`` doc.
+
+    Prefers the first ``placeType`` entry, then the first
+    ``additionalCategories`` entry. Returns ``None`` when neither carries a
+    usable string.
+    """
+    if not doc:
+        return None
+    place_type = doc.get("placeType")
+    if isinstance(place_type, str) and place_type.strip():
+        return place_type.strip()
+    if isinstance(place_type, list):
+        for entry in place_type:
+            if isinstance(entry, str) and entry.strip():
+                return entry.strip()
+    extra = doc.get("additionalCategories")
+    if isinstance(extra, list):
+        for entry in extra:
+            if isinstance(entry, str) and entry.strip():
+                return entry.strip()
+    return None
+
+
+def find_nearest_place(
+    lat: float,
+    lon: float,
+    max_distance_km: float = POI_MATCH_RADIUS_KM,
+) -> Optional[dict]:
+    """Return the nearest ``places.places`` POI within ``max_distance_km``.
+
+    Uses the 2dsphere ``$nearSphere`` index on ``places.places.geo`` (assumed
+    present; guarded below). Returns ``None`` if nothing is in range, the index
+    is missing, or any error occurs — POI matching must NEVER break location
+    resolution, so every failure path falls back to ``None`` and the caller
+    keeps its reverse-geocode result.
+    """
+    max_meters = max(0.0, max_distance_km) * 1000
+    try:
+        result = places_collection().find_one({
+            "geo": {
+                "$nearSphere": {
+                    "$geometry": {"type": "Point", "coordinates": [lon, lat]},
+                    "$maxDistance": max_meters,
+                }
+            }
+        })
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("places.places $nearSphere failed: %s", exc)
+        return None
+    # Real POI docs are plain dicts; guard against non-dict mocks/None.
+    return result if isinstance(result, dict) else None
+
+
+# ---------------------------------------------------------------------------
 # placesGeo insert
 # ---------------------------------------------------------------------------
 
@@ -260,6 +324,7 @@ def upsert_placesgeo_city(
     mukoko_slug: Optional[str] = None,
     mukoko_tags: Optional[list[str]] = None,
     mukoko_nominatim_address: Optional[dict] = None,
+    mukoko_poi_type: Optional[str] = None,
 ) -> dict:
     """Insert a new ``places.placesGeo`` document, or return the existing one.
 
@@ -316,6 +381,8 @@ def upsert_placesgeo_city(
                     patch["sourceProvenance.mukokoElevation"] = elevation
                 if mukoko_nominatim_address and not existing_prov.get("mukokoNominatimAddress"):
                     patch["sourceProvenance.mukokoNominatimAddress"] = mukoko_nominatim_address
+                if mukoko_poi_type and not existing_prov.get("mukokoPoiType"):
+                    patch["sourceProvenance.mukokoPoiType"] = mukoko_poi_type
                 try:
                     places_geo_collection().update_one(
                         {"_id": existing["_id"]},
@@ -344,6 +411,8 @@ def upsert_placesgeo_city(
         source_provenance["mukokoTags"] = list(mukoko_tags)
     if mukoko_nominatim_address:
         source_provenance["mukokoNominatimAddress"] = mukoko_nominatim_address
+    if mukoko_poi_type:
+        source_provenance["mukokoPoiType"] = mukoko_poi_type
 
     doc: dict = {
         "_id": str(uuid.uuid4()),

--- a/api/py/_places_resolver.py
+++ b/api/py/_places_resolver.py
@@ -194,6 +194,8 @@ def adapt_placesgeo_to_location(
         adapted["country"] = iso
     if doc.get("slug"):
         adapted["platformSlug"] = doc["slug"]
+    if provenance.get("mukokoPoiType"):
+        adapted["poiType"] = provenance["mukokoPoiType"]
     if provenance.get("mukokoNominatimAddress"):
         adapted["nominatimAddress"] = provenance["mukokoNominatimAddress"]
     if geo:

--- a/src/lib/places.test.ts
+++ b/src/lib/places.test.ts
@@ -12,7 +12,10 @@ import {
   inferNameFromSlug,
   adaptPlacesGeoToLocationDoc,
   listSeedLocations,
+  poiTypeFromPlace,
+  POI_MATCH_RADIUS_KM,
   type PlacesGeoDoc,
+  type PlaceDoc,
 } from "./places";
 import { LOCATIONS } from "./locations";
 
@@ -130,6 +133,89 @@ describe("adaptPlacesGeoToLocationDoc", () => {
       cleanSlug: "some-new-place",
     });
     expect(adapted.tags).toEqual(["city"]);
+  });
+});
+
+describe("poiTypeFromPlace", () => {
+  it("prefers the first placeType entry", () => {
+    expect(
+      poiTypeFromPlace({
+        _id: "p1",
+        name: "Prince Edward School",
+        placeType: ["school", "college"],
+      }),
+    ).toBe("school");
+  });
+
+  it("falls back to additionalCategories when placeType is empty", () => {
+    expect(
+      poiTypeFromPlace({
+        _id: "p2",
+        name: "Mbare Musika",
+        placeType: [],
+        additionalCategories: ["market"],
+      }),
+    ).toBe("market");
+  });
+
+  it("trims whitespace and skips blank entries", () => {
+    expect(
+      poiTypeFromPlace({
+        _id: "p3",
+        name: "Clinic",
+        placeType: ["", "  ", " clinic "],
+      }),
+    ).toBe("clinic");
+  });
+
+  it("returns undefined when no type present", () => {
+    expect(poiTypeFromPlace({ _id: "p4", name: "Nowhere" })).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined input", () => {
+    expect(poiTypeFromPlace(null)).toBeUndefined();
+    expect(poiTypeFromPlace(undefined)).toBeUndefined();
+  });
+
+  it("keeps the POI-match radius tight (≤250 m)", () => {
+    expect(POI_MATCH_RADIUS_KM).toBe(0.25);
+    expect(POI_MATCH_RADIUS_KM).toBeLessThanOrEqual(0.25);
+  });
+});
+
+describe("adaptPlacesGeoToLocationDoc — POI type", () => {
+  const poiDoc: PlacesGeoDoc = {
+    _id: "poi-placegeo",
+    name: "Prince Edward School",
+    slug: "prince-edward-school-a1b2c3",
+    geoType: "town",
+    geo: { type: "Point", coordinates: [31.05, -17.83] },
+    sourceProvenance: {
+      dataOrigin: "mukoko_user",
+      dataConfidence: 0.6,
+      mukokoPoiType: "school",
+    },
+  };
+
+  it("surfaces sourceProvenance.mukokoPoiType as poiType", async () => {
+    const adapted = await adaptPlacesGeoToLocationDoc(poiDoc, {
+      cleanSlug: "prince-edward-school-zw",
+    });
+    expect(adapted.poiType).toBe("school");
+  });
+
+  it("leaves poiType undefined when not stamped", async () => {
+    const adapted = await adaptPlacesGeoToLocationDoc(
+      { ...poiDoc, sourceProvenance: { dataOrigin: "mukoko_user" } },
+      { cleanSlug: "prince-edward-school-zw" },
+    );
+    expect(adapted.poiType).toBeUndefined();
+  });
+
+  // Type-only guard: PlaceDoc must remain importable/usable here.
+  it("PlaceDoc shape is usable", () => {
+    const doc: PlaceDoc = { _id: "x", name: "X", placeType: ["park"] };
+    expect(poiTypeFromPlace(doc)).toBe("park");
   });
 });
 

--- a/src/lib/places.ts
+++ b/src/lib/places.ts
@@ -71,6 +71,8 @@ export interface PlacesGeoDoc {
     mukokoTags?: string[];
     /** Cached Nominatim structured address. */
     mukokoNominatimAddress?: NominatimAddress;
+    /** Nearest-POI type stamped at create time (e.g. "school", "hospital"). */
+    mukokoPoiType?: string;
   };
 }
 
@@ -101,6 +103,13 @@ export interface AdaptedLocation extends WeatherLocation {
   _id: string;
   /** Platform placesGeo.slug (hash-suffixed, e.g. "harare-a1b2c3"). */
   platformSlug?: string;
+  /**
+   * Nearest-POI type (e.g. "school", "hospital", "market", "park") when a
+   * named POI was within POI_MATCH_RADIUS_KM at create time. Surfaced from
+   * `sourceProvenance.mukokoPoiType` so the location page + AI summary can
+   * mention it.
+   */
+  poiType?: string;
   /** Always set when adapted from placesGeo. */
   updatedAt?: Date;
 }
@@ -237,6 +246,7 @@ export async function adaptPlacesGeoToLocationDoc(
     elevation,
     tags,
     country: country || undefined,
+    poiType: provenance.mukokoPoiType,
     provinceSlug: hint.seed?.provinceSlug,
     nominatimAddress: provenance.mukokoNominatimAddress ?? hint.seed?.nominatimAddress,
     source: hint.seed?.source ?? "community",
@@ -359,6 +369,58 @@ export async function nearestPlacesGeo(
         },
       },
     })) as unknown as PlacesGeoDoc | null;
+    return doc;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Nearest place (POI) — tight-radius matching for location refinement
+// ---------------------------------------------------------------------------
+
+/**
+ * Tight radius (km) for POI-nearest matching. POIs are point features (a
+ * school, a shop, a clinic) — we only prefer one when the user is essentially
+ * standing on it. Intentionally small (≤250 m): this is NOT a coarse city snap.
+ */
+export const POI_MATCH_RADIUS_KM = 0.25;
+
+/**
+ * Extract a single human-facing POI type from a `places.places` document.
+ * Prefers the first `placeType`, then the first `additionalCategories` entry.
+ * Returns `undefined` when neither carries a usable string.
+ */
+export function poiTypeFromPlace(doc: PlaceDoc | null | undefined): string | undefined {
+  if (!doc) return undefined;
+  const primary = doc.placeType?.find((t) => typeof t === "string" && t.trim());
+  if (primary) return primary.trim();
+  const extra = doc.additionalCategories?.find((t) => typeof t === "string" && t.trim());
+  return extra ? extra.trim() : undefined;
+}
+
+/**
+ * Find the nearest `places.places` POI to (lat, lon) within `maxKm`.
+ * Uses `$nearSphere` on the 2dsphere index against `places.places.geo`.
+ *
+ * Returns `null` on any error, a missing index, or when nothing is in range —
+ * POI matching must NEVER break location resolution, so every failure path
+ * falls back to `null` and the caller keeps its reverse-geocode result.
+ */
+export async function nearestPlace(
+  lat: number,
+  lon: number,
+  maxKm: number = POI_MATCH_RADIUS_KM,
+): Promise<PlaceDoc | null> {
+  try {
+    const doc = (await placesCollection().findOne({
+      geo: {
+        $nearSphere: {
+          $geometry: { type: "Point", coordinates: [lon, lat] },
+          $maxDistance: Math.max(0, maxKm) * 1000,
+        },
+      },
+    })) as unknown as PlaceDoc | null;
     return doc;
   } catch {
     return null;

--- a/tests/py/test_locations.py
+++ b/tests/py/test_locations.py
@@ -19,6 +19,7 @@ from py._locations import (
     _normalize_admin1,
     _build_nominatim_address,
     _find_duplicate,
+    _match_nearby_poi,
     _enrich_location_with_ai,
     _resolve_slug_collision,
     _CITY_STATES,
@@ -1917,3 +1918,113 @@ class TestSlugCollisionHardening:
         assert result["existing"]["slug"] == "windsor-zw"
         # And we did NOT mirror to placesGeo for a duplicate.
         mock_upsert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _match_nearby_poi — tight-radius POI refinement
+# ---------------------------------------------------------------------------
+
+
+class TestMatchNearbyPoi:
+    @patch("py._locations.find_nearest_place")
+    def test_returns_name_and_type_for_named_poi(self, mock_nearest):
+        mock_nearest.return_value = {
+            "name": "Prince Edward School",
+            "placeType": ["school"],
+        }
+        result = _match_nearby_poi(-17.83, 31.05)
+        assert result == {"name": "Prince Edward School", "poiType": "school"}
+
+    @patch("py._locations.find_nearest_place")
+    def test_uses_tight_250m_radius(self, mock_nearest):
+        mock_nearest.return_value = None
+        _match_nearby_poi(-17.83, 31.05)
+        # Radius passed is POI_MATCH_RADIUS_KM (0.25 km) — a tight match, not a snap.
+        assert mock_nearest.call_args.args[2] == 0.25
+
+    @patch("py._locations.find_nearest_place", return_value=None)
+    def test_none_when_no_poi(self, _mock_nearest):
+        assert _match_nearby_poi(0, 0) is None
+
+    @patch("py._locations.find_nearest_place")
+    def test_none_when_poi_unnamed(self, mock_nearest):
+        mock_nearest.return_value = {"name": "  ", "placeType": ["school"]}
+        assert _match_nearby_poi(0, 0) is None
+
+    @patch("py._locations.find_nearest_place")
+    def test_poi_type_none_when_untyped(self, mock_nearest):
+        mock_nearest.return_value = {"name": "Some Place"}
+        result = _match_nearby_poi(0, 0)
+        assert result == {"name": "Some Place", "poiType": None}
+
+    @patch("py._locations.find_nearest_place", side_effect=RuntimeError("boom"))
+    def test_swallows_errors(self, _mock_nearest):
+        """POI matching must never break resolution — errors fall back to None."""
+        assert _match_nearby_poi(0, 0) is None
+
+
+class TestGeoLookupPoiRefinement:
+    @pytest.mark.asyncio
+    @patch("py._locations.upsert_placesgeo_city")
+    @patch("py._locations._enrich_location_with_ai")
+    @patch("py._locations._get_elevation")
+    @patch("py._locations._find_duplicate")
+    @patch("py._locations._match_nearby_poi")
+    @patch("py._locations._reverse_geocode")
+    @patch("py._locations.find_nearest_location")
+    @patch("py._locations.places_geo_collection")
+    async def test_poi_overrides_name_and_flows_through(
+        self, mock_coll, mock_nearest, mock_geocode, mock_poi, mock_dedup,
+        mock_elev, mock_enrich, mock_upsert,
+    ):
+        """A close POI replaces the reverse-geocode name and poiType is surfaced."""
+        mock_nearest.return_value = None
+        mock_geocode.return_value = {
+            "country": "ZW", "countryName": "Zimbabwe",
+            "name": "Fourth Street",  # raw reverse-geocode name
+            "admin1": "Harare", "lat": -17.83, "lon": 31.05, "elevation": 1490,
+        }
+        mock_poi.return_value = {"name": "Prince Edward School", "poiType": "school"}
+        mock_dedup.return_value = None
+        mock_elev.return_value = 1490
+        mock_coll.return_value.find_one.return_value = None
+        mock_upsert.return_value = {"_id": "u", "slug": "prince-edward-school-abc123"}
+
+        result = await geo_lookup(-17.83, 31.05, autoCreate=True)
+        assert result["isNew"] is True
+        # POI name won over the reverse-geocode name.
+        assert result["nearest"]["name"] == "Prince Edward School"
+        assert result["nearest"]["poiType"] == "school"
+        # And the POI type was stamped into the placesGeo write.
+        assert mock_upsert.call_args.kwargs["mukoko_poi_type"] == "school"
+
+    @pytest.mark.asyncio
+    @patch("py._locations.upsert_placesgeo_city")
+    @patch("py._locations._enrich_location_with_ai")
+    @patch("py._locations._get_elevation")
+    @patch("py._locations._find_duplicate")
+    @patch("py._locations._match_nearby_poi")
+    @patch("py._locations._reverse_geocode")
+    @patch("py._locations.find_nearest_location")
+    @patch("py._locations.places_geo_collection")
+    async def test_no_poi_keeps_reverse_geocode_name(
+        self, mock_coll, mock_nearest, mock_geocode, mock_poi, mock_dedup,
+        mock_elev, mock_enrich, mock_upsert,
+    ):
+        """No nearby POI — the reverse-geocode result is used unchanged (fallback)."""
+        mock_nearest.return_value = None
+        mock_geocode.return_value = {
+            "country": "ZW", "countryName": "Zimbabwe",
+            "name": "Fourth Street", "admin1": "Harare",
+            "lat": -17.83, "lon": 31.05, "elevation": 1490,
+        }
+        mock_poi.return_value = None
+        mock_dedup.return_value = None
+        mock_elev.return_value = 1490
+        mock_coll.return_value.find_one.return_value = None
+        mock_upsert.return_value = {"_id": "u", "slug": "fourth-street-abc123"}
+
+        result = await geo_lookup(-17.83, 31.05, autoCreate=True)
+        assert result["nearest"]["name"] == "Fourth Street"
+        assert "poiType" not in result["nearest"]
+        assert mock_upsert.call_args.kwargs["mukoko_poi_type"] is None

--- a/tests/py/test_places_geo.py
+++ b/tests/py/test_places_geo.py
@@ -392,3 +392,120 @@ class TestEnqueueFundiSeed:
         assert request_id == "in-progress"
         coll.insert_not_called = MagicMock()
         coll.insert_one.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# poi_type_from_place — extract a single human-facing POI type
+# ---------------------------------------------------------------------------
+
+
+class TestPoiTypeFromPlace:
+    def test_prefers_first_placetype_list_entry(self):
+        assert pg.poi_type_from_place({"placeType": ["school", "college"]}) == "school"
+
+    def test_accepts_placetype_string(self):
+        assert pg.poi_type_from_place({"placeType": "hospital"}) == "hospital"
+
+    def test_falls_back_to_additional_categories(self):
+        assert pg.poi_type_from_place(
+            {"placeType": [], "additionalCategories": ["market"]}
+        ) == "market"
+
+    def test_strips_whitespace(self):
+        assert pg.poi_type_from_place({"placeType": ["  park  "]}) == "park"
+
+    def test_skips_blank_entries(self):
+        assert pg.poi_type_from_place({"placeType": ["", "  ", "clinic"]}) == "clinic"
+
+    def test_none_when_no_type(self):
+        assert pg.poi_type_from_place({"name": "Somewhere"}) is None
+
+    def test_none_for_empty_doc(self):
+        assert pg.poi_type_from_place(None) is None
+        assert pg.poi_type_from_place({}) is None
+
+
+# ---------------------------------------------------------------------------
+# find_nearest_place — tight-radius POI matching against places.places
+# ---------------------------------------------------------------------------
+
+
+class TestFindNearestPlace:
+    @patch("py._places_geo.places_collection")
+    def test_returns_dict_result(self, mock_coll):
+        poi = {"_id": "poi-1", "name": "Prince Edward School", "placeType": ["school"]}
+        mock_coll.return_value.find_one.return_value = poi
+        result = pg.find_nearest_place(-17.83, 31.05)
+        assert result == poi
+
+    @patch("py._places_geo.places_collection")
+    def test_uses_nearsphere_with_lon_lat_and_meters(self, mock_coll):
+        mock_coll.return_value.find_one.return_value = None
+        pg.find_nearest_place(-17.83, 31.05, 0.25)
+        query = mock_coll.return_value.find_one.call_args.args[0]
+        near = query["geo"]["$nearSphere"]
+        assert near["$geometry"]["coordinates"] == [31.05, -17.83]  # [lon, lat]
+        assert near["$maxDistance"] == 250  # 0.25 km -> 250 m
+
+    @patch("py._places_geo.places_collection")
+    def test_none_when_nothing_in_range(self, mock_coll):
+        mock_coll.return_value.find_one.return_value = None
+        assert pg.find_nearest_place(0, 0) is None
+
+    @patch("py._places_geo.places_collection")
+    def test_non_dict_result_becomes_none(self, mock_coll):
+        """A non-dict result (e.g. mock/missing index) must fall back to None."""
+        mock_coll.return_value.find_one.return_value = MagicMock()
+        assert pg.find_nearest_place(0, 0) is None
+
+    @patch("py._places_geo.places_collection")
+    def test_swallows_errors_returns_none(self, mock_coll):
+        """POI matching must never break resolution — errors fall back to None."""
+        mock_coll.return_value.find_one.side_effect = RuntimeError("no 2dsphere index")
+        assert pg.find_nearest_place(0, 0) is None
+
+
+# ---------------------------------------------------------------------------
+# upsert_placesgeo_city — mukoko_poi_type stamped into sourceProvenance
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertStampsPoiType:
+    @patch("py._places_geo.find_nearby_placesgeo", return_value=None)
+    @patch("py._places_geo.get_country_id", return_value="zw-parent")
+    @patch("py._places_geo.places_geo_collection")
+    def test_new_doc_stamps_poi_type(self, mock_coll, _parent, _dedup):
+        result = pg.upsert_placesgeo_city(
+            name="Prince Edward School", lat=-17.83, lon=31.05,
+            country_iso="ZW", mukoko_poi_type="school",
+        )
+        assert result["sourceProvenance"]["mukokoPoiType"] == "school"
+
+    @patch("py._places_geo.find_nearby_placesgeo", return_value=None)
+    @patch("py._places_geo.get_country_id", return_value="zw-parent")
+    @patch("py._places_geo.places_geo_collection")
+    def test_poi_type_omitted_when_none(self, mock_coll, _parent, _dedup):
+        result = pg.upsert_placesgeo_city(
+            name="Harare", lat=-17.83, lon=31.05, country_iso="ZW",
+        )
+        assert "mukokoPoiType" not in result["sourceProvenance"]
+
+    @patch("py._places_geo.find_nearby_placesgeo")
+    @patch("py._places_geo.get_country_id", return_value="zw-parent")
+    @patch("py._places_geo.places_geo_collection")
+    def test_patches_poi_type_onto_existing_doc(self, mock_coll, _parent, mock_dedup):
+        """A pre-existing doc missing a POI type gets it stamped alongside the slug."""
+        mock_dedup.return_value = {
+            "_id": "existing-uuid",
+            "slug": "prince-edward-existing",
+            "name": "Prince Edward School",
+            "sourceProvenance": {},
+        }
+        result = pg.upsert_placesgeo_city(
+            name="Prince Edward School", lat=-17.83, lon=31.05,
+            country_iso="ZW", mukoko_slug="prince-edward-school-zw",
+            mukoko_poi_type="school",
+        )
+        assert result["wasExisting"] is True
+        patch_set = mock_coll.return_value.update_one.call_args.args[1]["$set"]
+        assert patch_set["sourceProvenance.mukokoPoiType"] == "school"


### PR DESCRIPTION
## What

The platform's `places.places` POI catalog (OSM/Overpass/Fundi) was populated but unused by the weather app. This wires it into create-on-demand location resolution so a user's GPS/coords resolve to a **precise, named POI** when one is very close, and the POI type enriches the location payload.

## How POI matching works

1. GPS/coords come in via `GET /api/py/geo?autoCreate=true` or `POST /api/py/locations/add`.
2. After the existing Nominatim reverse-geocode (zoom=18), `_match_nearby_poi(lat, lon)` queries `places.places` for the **nearest POI within ≤250 m** (`POI_MATCH_RADIUS_KM`) via `$nearSphere` on the `geo` 2dsphere index (`_places_geo.find_nearest_place`).
3. If a **named** POI is that close, its name **replaces** the raw reverse-geocode name (richer + consistent with the platform POI catalog), and its type (school / hospital / market / park) is:
   - stamped onto `sourceProvenance.mukokoPoiType` (via `upsert_placesgeo_city`), and
   - surfaced as `poiType` on the returned location payload, so the location page + AI summary can mention it.
4. **Fallback:** the whole POI lookup is wrapped in try/except and returns `None` on any miss, empty result, or **missing 2dsphere index** — location resolution keeps its reverse-geocode result exactly as before.

This is **intentionally tight (≤250 m)** — it does NOT reintroduce coarse distance-snapping to far-away places. It only fires when the user is essentially standing on the POI.

## Changes

- **`api/py/_places_geo.py`** — `find_nearest_place`, `poi_type_from_place`, `POI_MATCH_RADIUS_KM`; `upsert_placesgeo_city` gains `mukoko_poi_type` (stamped into `sourceProvenance.mukokoPoiType`, also patched onto pre-existing docs).
- **`api/py/_locations.py`** — `_match_nearby_poi` refines both `geo_lookup` and `add_location`; `poiType` flows through to the response payload.
- **`api/py/_places_resolver.py`** + **`src/lib/places.ts`** — surface `poiType` from `sourceProvenance.mukokoPoiType`; TS mirrors `nearestPlace` + `poiTypeFromPlace` (2dsphere assumption on `places.places.geo`, guarded).
- **Tests** — TS (`poiTypeFromPlace`, adapter `poiType`) + pytest (`find_nearest_place`, `poi_type_from_place`, upsert POI stamping, `_match_nearby_poi`, `geo_lookup` POI refinement + fallback path).
- **CLAUDE.md** — documents the refinement + new helpers.

## Verification

- `npm test` — 1703 passed
- `python3 -m pytest tests/py/ -q` — 866 passed
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)