### PR TITLE
fix: guard RxDB from crashing the page + make db-init index seeding resilient

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -33,6 +33,7 @@ import {
   stampPlatformFields,
   PLATFORM_SCHEMA_VERSION,
   DEFAULT_COUNTRY_CODE,
+  isIndexConflictError,
 } from "./db";
 import { REGIONS } from "./seed-regions";
 import { TAGS } from "./seed-tags";
@@ -655,5 +656,31 @@ describe("stampPlatformFields", () => {
     const a = stampPlatformFields({});
     const b = stampPlatformFields({});
     expect(a._id).not.toBe(b._id);
+  });
+});
+
+describe("isIndexConflictError", () => {
+  it("returns true for IndexOptionsConflict (85)", () => {
+    expect(isIndexConflictError({ code: 85 })).toBe(true);
+  });
+
+  it("returns true for IndexKeySpecsConflict (86)", () => {
+    expect(isIndexConflictError({ code: 86 })).toBe(true);
+  });
+
+  it("returns true for IndexAlreadyExists (68)", () => {
+    expect(isIndexConflictError({ code: 68 })).toBe(true);
+  });
+
+  it("returns false for a duplicate-key error (11000)", () => {
+    expect(isIndexConflictError({ code: 11000 })).toBe(false);
+  });
+
+  it("returns false for unrelated errors and non-error values", () => {
+    expect(isIndexConflictError({ code: 1 })).toBe(false);
+    expect(isIndexConflictError(new Error("boom"))).toBe(false);
+    expect(isIndexConflictError(null)).toBe(false);
+    expect(isIndexConflictError(undefined)).toBe(false);
+    expect(isIndexConflictError("nope")).toBe(false);
   });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -19,6 +19,12 @@
  *   - provinces       : Province/state display metadata
  */
 
+import type {
+  Collection,
+  Document,
+  IndexSpecification,
+  CreateIndexesOptions,
+} from "mongodb";
 import {
   weatherDb,
   placesDb,
@@ -236,85 +242,200 @@ function airportsCollection() {
 // Indexes — call once on app startup (idempotent)
 // ---------------------------------------------------------------------------
 
+/**
+ * MongoDB error codes for index conflicts.
+ *   85 (IndexOptionsConflict)  — an index with the same name exists but with
+ *        different options (e.g. requested `unique: true` but the existing one
+ *        is non-unique). This is the error that was aborting the whole seed.
+ *   86 (IndexKeySpecsConflict) — an index with the same name exists on a
+ *        different key spec.
+ *   68 (IndexAlreadyExists)    — an equivalent index already exists (benign).
+ */
+export function isIndexConflictError(err: unknown): boolean {
+  const code = (err as { code?: number } | null)?.code;
+  return code === 85 || code === 86 || code === 68;
+}
+
+/**
+ * MongoDB duplicate-key error (11000) — surfaces when trying to build a unique
+ * index over a collection that already contains duplicate values, so a
+ * drop-and-recreate to `unique` is genuinely unsafe.
+ */
+function isDuplicateKeyError(err: unknown): boolean {
+  return (err as { code?: number } | null)?.code === 11000;
+}
+
+/** Compute the default index name MongoDB assigns to a simple key spec. */
+function defaultIndexName(keys: IndexSpecification): string {
+  return Object.entries(keys as Record<string, unknown>)
+    .map(([field, direction]) => `${field}_${direction}`)
+    .join("_");
+}
+
+/**
+ * Create an index resiliently. A single conflicting or failing index must NEVER
+ * abort the whole `ensureIndexes` seed run (BUG 2). This helper:
+ *
+ *   1. Tries `createIndex` normally.
+ *   2. On an index-options/spec conflict (Mongo 85/86) for a UNIQUE index,
+ *      drop-and-recreate the index to reconcile the options. If that fails
+ *      because real duplicate values exist (11000), downgrade to a non-unique
+ *      index so reality is matched and seeding continues.
+ *   3. Any other error is logged and swallowed — never rethrown.
+ *
+ * Always resolves; never rejects.
+ */
+async function safeCreateIndex<T extends Document>(
+  collection: Collection<T>,
+  keys: IndexSpecification,
+  options?: CreateIndexesOptions,
+): Promise<void> {
+  try {
+    await collection.createIndex(keys, options);
+    return;
+  } catch (err) {
+    const namespace = collection.collectionName;
+
+    if (!isIndexConflictError(err)) {
+      // Non-conflict failure (e.g. transient): log and continue seeding.
+      logWarn({
+        source: "mongodb",
+        message: `ensureIndexes: skipped index on ${namespace}`,
+        error: err instanceof Error ? err : new Error(String(err)),
+        meta: { keys },
+      });
+      return;
+    }
+
+    // Conflict. If we genuinely need a unique index, try to reconcile it by
+    // dropping the existing (differently-optioned) index and recreating.
+    if (options?.unique) {
+      const indexName = options.name ?? defaultIndexName(keys);
+      try {
+        await collection.dropIndex(indexName);
+        await collection.createIndex(keys, options);
+        return;
+      } catch (recreateErr) {
+        if (isDuplicateKeyError(recreateErr)) {
+          // Real duplicate data — a unique index can't exist. Downgrade to a
+          // non-unique index so lookups stay fast and seeding proceeds.
+          const { unique: _unique, ...nonUnique } = options;
+          try {
+            await collection.createIndex(keys, nonUnique);
+          } catch {
+            /* give up on this one index — never abort the seed */
+          }
+          logWarn({
+            source: "mongodb",
+            message: `ensureIndexes: ${namespace}.${indexName} has duplicate values — created non-unique index instead of unique`,
+            meta: { keys },
+          });
+          return;
+        }
+        // Drop/recreate failed for another reason — log and continue.
+        logWarn({
+          source: "mongodb",
+          message: `ensureIndexes: could not reconcile unique index ${namespace}.${indexName}`,
+          error: recreateErr instanceof Error ? recreateErr : new Error(String(recreateErr)),
+          meta: { keys },
+        });
+        return;
+      }
+    }
+
+    // Non-unique conflict — the existing index is good enough. Log and move on.
+    logWarn({
+      source: "mongodb",
+      message: `ensureIndexes: index already exists with different options on ${namespace} — leaving existing index in place`,
+      meta: { keys },
+    });
+  }
+}
+
 export async function ensureIndexes(): Promise<void> {
-  await Promise.all([
+  // Each index is created independently and resiliently — one conflicting or
+  // failing index NEVER aborts the whole seed (so `weather.airports` and every
+  // other collection still gets seeded). `safeCreateIndex` never rejects, but
+  // we use `allSettled` as a belt-and-braces guard.
+  await Promise.allSettled([
     // Weather cache: one doc per location, auto-expire
-    weatherCacheCollection().createIndex({ locationSlug: 1 }, { unique: true }),
-    weatherCacheCollection().createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }),
+    safeCreateIndex(weatherCacheCollection(), { locationSlug: 1 }, { unique: true }),
+    safeCreateIndex(weatherCacheCollection(), { expiresAt: 1 }, { expireAfterSeconds: 0 }),
 
     // AI summaries: one doc per location, auto-expire
-    aiSummariesCollection().createIndex({ locationSlug: 1 }, { unique: true }),
-    aiSummariesCollection().createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }),
+    safeCreateIndex(aiSummariesCollection(), { locationSlug: 1 }, { unique: true }),
+    safeCreateIndex(aiSummariesCollection(), { expiresAt: 1 }, { expireAfterSeconds: 0 }),
 
     // Weather history: one doc per location per day, query by date range
-    weatherHistoryCollection().createIndex({ locationSlug: 1, date: -1 }, { unique: true }),
-    weatherHistoryCollection().createIndex({ recordedAt: 1 }),
+    safeCreateIndex(weatherHistoryCollection(), { locationSlug: 1, date: -1 }, { unique: true }),
+    safeCreateIndex(weatherHistoryCollection(), { recordedAt: 1 }),
 
     // Locations indexes — Phase 0F: weather.locations is dropped. Geo /
     // text indexes on `places.placesGeo` are managed by the platform.
 
     // Activities: by id (unique), by category, text search
-    activitiesCollection().createIndex({ id: 1 }, { unique: true }),
-    activitiesCollection().createIndex({ category: 1 }),
-    activitiesCollection().createIndex(
+    safeCreateIndex(activitiesCollection(), { id: 1 }, { unique: true }),
+    safeCreateIndex(activitiesCollection(), { category: 1 }),
+    safeCreateIndex(
+      activitiesCollection(),
       { label: "text", description: "text", category: "text" },
       { weights: { label: 10, description: 5, category: 3 }, name: "activity_text_search" },
     ),
 
     // API keys: one key per provider
-    apiKeysCollection().createIndex({ provider: 1 }, { unique: true }),
+    safeCreateIndex(apiKeysCollection(), { provider: 1 }, { unique: true }),
 
     // Rate limits: auto-expire counters for abuse prevention
-    rateLimitsCollection().createIndex({ key: 1 }, { unique: true }),
-    rateLimitsCollection().createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }),
+    safeCreateIndex(rateLimitsCollection(), { key: 1 }, { unique: true }),
+    safeCreateIndex(rateLimitsCollection(), { expiresAt: 1 }, { expireAfterSeconds: 0 }),
 
     // Countries: by code (unique), by region
-    countriesCollection().createIndex({ code: 1 }, { unique: true }),
-    countriesCollection().createIndex({ region: 1 }),
+    safeCreateIndex(countriesCollection(), { code: 1 }, { unique: true }),
+    safeCreateIndex(countriesCollection(), { region: 1 }),
 
     // Provinces: by slug (unique), by countryCode
-    provincesCollection().createIndex({ slug: 1 }, { unique: true }),
-    provincesCollection().createIndex({ countryCode: 1 }),
+    safeCreateIndex(provincesCollection(), { slug: 1 }, { unique: true }),
+    safeCreateIndex(provincesCollection(), { countryCode: 1 }),
 
     // Regions: by id (unique), by active flag
-    regionsCollection().createIndex({ id: 1 }, { unique: true }),
-    regionsCollection().createIndex({ active: 1 }),
+    safeCreateIndex(regionsCollection(), { id: 1 }, { unique: true }),
+    safeCreateIndex(regionsCollection(), { active: 1 }),
 
     // Tags: by slug (unique), by featured + order for explore page
-    tagsCollection().createIndex({ slug: 1 }, { unique: true }),
-    tagsCollection().createIndex({ featured: 1, order: 1 }),
+    safeCreateIndex(tagsCollection(), { slug: 1 }, { unique: true }),
+    safeCreateIndex(tagsCollection(), { featured: 1, order: 1 }),
 
     // Seasons: by countryCode for date lookups, TTL for AI-generated entries
-    seasonsCollection().createIndex({ countryCode: 1 }),
-    seasonsCollection().createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }),
+    safeCreateIndex(seasonsCollection(), { countryCode: 1 }),
+    safeCreateIndex(seasonsCollection(), { expiresAt: 1 }, { expireAfterSeconds: 0 }),
 
     // Activity categories: by id (unique), by order for display
-    activityCategoriesCollection().createIndex({ id: 1 }, { unique: true }),
-    activityCategoriesCollection().createIndex({ order: 1 }),
+    safeCreateIndex(activityCategoriesCollection(), { id: 1 }, { unique: true }),
+    safeCreateIndex(activityCategoriesCollection(), { order: 1 }),
 
     // Suitability rules: by key (unique) for lookups
-    suitabilityRulesCollection().createIndex({ key: 1 }, { unique: true }),
+    safeCreateIndex(suitabilityRulesCollection(), { key: 1 }, { unique: true }),
 
     // AI prompts: by promptKey (unique), by active + order for queries
-    aiPromptsCollection().createIndex({ promptKey: 1 }, { unique: true }),
-    aiPromptsCollection().createIndex({ active: 1, order: 1 }),
+    safeCreateIndex(aiPromptsCollection(), { promptKey: 1 }, { unique: true }),
+    safeCreateIndex(aiPromptsCollection(), { active: 1, order: 1 }),
 
     // AI suggested rules: by ruleId (unique), by active + category + order
-    aiSuggestedRulesCollection().createIndex({ ruleId: 1 }, { unique: true }),
-    aiSuggestedRulesCollection().createIndex({ active: 1, category: 1, order: 1 }),
+    safeCreateIndex(aiSuggestedRulesCollection(), { ruleId: 1 }, { unique: true }),
+    safeCreateIndex(aiSuggestedRulesCollection(), { active: 1, category: 1, order: 1 }),
 
     // METAR cache: one doc per ICAO station, auto-expire after 30 minutes
-    weatherDb().collection("metar_cache").createIndex({ icao: 1 }, { unique: true }),
-    weatherDb().collection("metar_cache").createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }),
+    safeCreateIndex(weatherDb().collection("metar_cache"), { icao: 1 }, { unique: true }),
+    safeCreateIndex(weatherDb().collection("metar_cache"), { expiresAt: 1 }, { expireAfterSeconds: 0 }),
 
     // Air quality cache: 1-hour TTL — _id is deterministic ({lat:.4f}_{lon:.4f}),
     // so the unique-by-_id index MongoDB provides for free is the only key index needed.
-    weatherDb().collection("air_quality_cache").createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }),
+    safeCreateIndex(weatherDb().collection("air_quality_cache"), { expiresAt: 1 }, { expireAfterSeconds: 0 }),
 
     // Airports: ICAO reference data for METAR/TAF. `_id` is the ICAO code
     // (unique for free); the 2dsphere index powers the $nearSphere
     // nearest-airport lookup in api/py/_airports.py.
-    airportsCollection().createIndex({ location: "2dsphere" }),
+    safeCreateIndex(airportsCollection(), { location: "2dsphere" }),
   ]);
 }
 

--- a/src/lib/rxdb/bridge.ts
+++ b/src/lib/rxdb/bridge.ts
@@ -106,10 +106,50 @@ function readLegacyPrefs(): LegacyState | null {
 }
 
 /**
+ * Persist preferences to the legacy localStorage key.
+ *
+ * Used as the fallback persistence layer when RxDB is unavailable (private
+ * browsing, DB9, quota, etc.) so `selectedForecastModel` and every other
+ * preference still survive reloads via Zustand + localStorage. When RxDB is
+ * healthy this is never called (RxDB owns persistence and clears this key
+ * during migration), so the two paths never fight.
+ */
+function writeLegacyPrefs(updates: Partial<Omit<PreferencesDocType, "id">>): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    const raw = localStorage.getItem(LEGACY_PREFS_KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    const state = { ...(parsed?.state ?? {}), ...updates };
+    localStorage.setItem(LEGACY_PREFS_KEY, JSON.stringify({ ...parsed, state }));
+  } catch {
+    // localStorage unavailable/full — nothing more we can do.
+  }
+}
+
+/** Hydrate Zustand from legacy localStorage (RxDB-unavailable fallback path). */
+function hydrateFromLegacy(callbacks: BridgeCallbacks): void {
+  const legacy = readLegacyPrefs();
+  if (!legacy) return;
+  try {
+    callbacks.applyToStore(legacy as Partial<PreferencesDocType>);
+  } catch {
+    // applyToStore should never throw, but guard anyway.
+  }
+}
+
+/**
  * Migrate legacy localStorage preferences to RxDB.
  * Safe to call multiple times — no-ops if RxDB already has data.
  */
 export async function migrateLocalStorageToRxDB(): Promise<void> {
+  try {
+    await _doMigrate();
+  } catch {
+    // Migration is best-effort — legacy localStorage stays intact on failure.
+  }
+}
+
+async function _doMigrate(): Promise<void> {
   const col = await preferencesCollection();
   if (!col) return;
 
@@ -177,57 +217,72 @@ export function initRxDBBridge(callbacks: BridgeCallbacks): Promise<void> {
 }
 
 async function _doInitBridge(callbacks: BridgeCallbacks): Promise<void> {
-  const col = await preferencesCollection();
-  if (!col) {
-    // Allow retry on next call — IndexedDB may become available later
+  try {
+    const col = await preferencesCollection();
+    if (!col) {
+      // RxDB unavailable — hydrate from legacy localStorage so preferences
+      // (theme, selectedForecastModel, …) still work this session, and allow
+      // a retry on the next call (IndexedDB may become available later).
+      hydrateFromLegacy(callbacks);
+      _initPromise = null;
+      return;
+    }
+
+    // Step 1: Migrate legacy data
+    await migrateLocalStorageToRxDB();
+
+    const deviceId = getDeviceId();
+
+    // Step 2: Ensure preferences doc exists
+    let doc = await col.findOne(deviceId).exec();
+    if (!doc) {
+      const currentPrefs = callbacks.getCurrentPrefs();
+      await col.upsert({
+        id: deviceId,
+        ...currentPrefs,
+        updatedAt: Date.now(),
+      });
+      doc = await col.findOne(deviceId).exec();
+    }
+
+    // Step 3: Hydrate Zustand from RxDB
+    if (doc) {
+      callbacks.applyToStore({
+        theme: doc.theme,
+        selectedLocation: doc.selectedLocation,
+        savedLocations: doc.savedLocations,
+        locationLabels: doc.locationLabels as Record<string, string>,
+        selectedActivities: doc.selectedActivities,
+        hasOnboarded: doc.hasOnboarded,
+        selectedForecastModel: doc.selectedForecastModel,
+      });
+    }
+
+    // Step 4: Subscribe to RxDB changes (multi-tab sync via leader election)
+    const query = col.findOne(deviceId);
+    _subscription = query.$.subscribe((rxDoc) => {
+      if (!rxDoc) return;
+      try {
+        callbacks.applyToStore({
+          theme: rxDoc.theme,
+          selectedLocation: rxDoc.selectedLocation,
+          savedLocations: rxDoc.savedLocations,
+          locationLabels: rxDoc.locationLabels as Record<string, string>,
+          selectedActivities: rxDoc.selectedActivities,
+          hasOnboarded: rxDoc.hasOnboarded,
+          selectedForecastModel: rxDoc.selectedForecastModel,
+        });
+      } catch {
+        // never let a subscription callback bubble into RxDB internals
+      }
+    });
+  } catch (err) {
+    // Any RxDB failure (DB9, schema conflict, storage error) must never crash
+    // the app — fall back to localStorage-hydrated Zustand and allow retry.
+    console.warn("[RxDB] bridge init failed — using localStorage fallback:", String(err));
+    hydrateFromLegacy(callbacks);
     _initPromise = null;
-    return;
   }
-
-  // Step 1: Migrate legacy data
-  await migrateLocalStorageToRxDB();
-
-  const deviceId = getDeviceId();
-
-  // Step 2: Ensure preferences doc exists
-  let doc = await col.findOne(deviceId).exec();
-  if (!doc) {
-    const currentPrefs = callbacks.getCurrentPrefs();
-    await col.upsert({
-      id: deviceId,
-      ...currentPrefs,
-      updatedAt: Date.now(),
-    });
-    doc = await col.findOne(deviceId).exec();
-  }
-
-  // Step 3: Hydrate Zustand from RxDB
-  if (doc) {
-    callbacks.applyToStore({
-      theme: doc.theme,
-      selectedLocation: doc.selectedLocation,
-      savedLocations: doc.savedLocations,
-      locationLabels: doc.locationLabels as Record<string, string>,
-      selectedActivities: doc.selectedActivities,
-      hasOnboarded: doc.hasOnboarded,
-      selectedForecastModel: doc.selectedForecastModel,
-    });
-  }
-
-  // Step 4: Subscribe to RxDB changes (multi-tab sync via leader election)
-  const query = col.findOne(deviceId);
-  _subscription = query.$.subscribe((rxDoc) => {
-    if (!rxDoc) return;
-    callbacks.applyToStore({
-      theme: rxDoc.theme,
-      selectedLocation: rxDoc.selectedLocation,
-      savedLocations: rxDoc.savedLocations,
-      locationLabels: rxDoc.locationLabels as Record<string, string>,
-      selectedActivities: rxDoc.selectedActivities,
-      hasOnboarded: rxDoc.hasOnboarded,
-      selectedForecastModel: rxDoc.selectedForecastModel,
-    });
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -240,28 +295,37 @@ async function _doInitBridge(callbacks: BridgeCallbacks): Promise<void> {
 export async function updatePreferences(
   updates: Partial<Omit<PreferencesDocType, "id">>,
 ): Promise<void> {
-  const col = await preferencesCollection();
-  if (!col) return;
+  try {
+    const col = await preferencesCollection();
+    if (!col) {
+      // RxDB unavailable — persist to localStorage so the preference survives.
+      writeLegacyPrefs(updates);
+      return;
+    }
 
-  const deviceId = getDeviceId();
-  const doc = await col.findOne(deviceId).exec();
+    const deviceId = getDeviceId();
+    const doc = await col.findOne(deviceId).exec();
 
-  if (doc) {
-    await doc.patch({ ...updates, updatedAt: Date.now() });
-  } else {
-    // Shouldn't happen after init, but handle gracefully
-    await col.upsert({
-      id: deviceId,
-      theme: "system",
-      selectedLocation: "",
-      savedLocations: [],
-      locationLabels: {},
-      selectedActivities: [],
-      hasOnboarded: false,
-      selectedForecastModel: "best_match",
-      ...updates,
-      updatedAt: Date.now(),
-    });
+    if (doc) {
+      await doc.patch({ ...updates, updatedAt: Date.now() });
+    } else {
+      // Shouldn't happen after init, but handle gracefully
+      await col.upsert({
+        id: deviceId,
+        theme: "system",
+        selectedLocation: "",
+        savedLocations: [],
+        locationLabels: {},
+        selectedActivities: [],
+        hasOnboarded: false,
+        selectedForecastModel: "best_match",
+        ...updates,
+        updatedAt: Date.now(),
+      });
+    }
+  } catch {
+    // RxDB write failed — fall back to localStorage, never throw to the caller.
+    writeLegacyPrefs(updates);
   }
 }
 

--- a/src/lib/rxdb/collections.ts
+++ b/src/lib/rxdb/collections.ts
@@ -38,19 +38,24 @@ export async function weatherCacheCollection() {
  * Get cached weather data for a location (returns null if expired or missing).
  */
 export async function getCachedWeather(slug: string): Promise<{ data: string; provider: string } | null> {
-  const col = await weatherCacheCollection();
-  if (!col) return null;
+  try {
+    const col = await weatherCacheCollection();
+    if (!col) return null;
 
-  const doc = await col.findOne(slug).exec();
-  if (!doc) return null;
+    const doc = await col.findOne(slug).exec();
+    if (!doc) return null;
 
-  // Check TTL
-  if (Date.now() > doc.expiresAt) {
-    await doc.remove();
+    // Check TTL
+    if (Date.now() > doc.expiresAt) {
+      await doc.remove();
+      return null;
+    }
+
+    return { data: doc.data, provider: doc.provider };
+  } catch {
+    // RxDB unavailable/errored — treat as cache miss.
     return null;
   }
-
-  return { data: doc.data, provider: doc.provider };
 }
 
 /**
@@ -62,17 +67,21 @@ export async function cacheWeather(
   provider: string,
   ttlMs: number = 15 * 60 * 1000,
 ): Promise<void> {
-  const col = await weatherCacheCollection();
-  if (!col) return;
+  try {
+    const col = await weatherCacheCollection();
+    if (!col) return;
 
-  const now = Date.now();
-  await col.upsert({
-    slug,
-    data,
-    provider,
-    cachedAt: now,
-    expiresAt: now + ttlMs,
-  });
+    const now = Date.now();
+    await col.upsert({
+      slug,
+      data,
+      provider,
+      cachedAt: now,
+      expiresAt: now + ttlMs,
+    });
+  } catch {
+    // RxDB unavailable/errored — caching is best-effort, never throw.
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -91,18 +100,22 @@ export async function weatherHintsCollection() {
  * Get a cached weather hint for a location (null if expired/missing).
  */
 export async function getCachedHint(slug: string) {
-  const col = await weatherHintsCollection();
-  if (!col) return null;
+  try {
+    const col = await weatherHintsCollection();
+    if (!col) return null;
 
-  const doc = await col.findOne(slug).exec();
-  if (!doc) return null;
+    const doc = await col.findOne(slug).exec();
+    if (!doc) return null;
 
-  if (Date.now() - doc.timestamp > HINT_MAX_AGE_MS) {
-    await doc.remove();
+    if (Date.now() - doc.timestamp > HINT_MAX_AGE_MS) {
+      await doc.remove();
+      return null;
+    }
+
+    return { sceneType: doc.sceneType, weatherCode: doc.weatherCode, isDay: doc.isDay, timestamp: doc.timestamp };
+  } catch {
     return null;
   }
-
-  return { sceneType: doc.sceneType, weatherCode: doc.weatherCode, isDay: doc.isDay, timestamp: doc.timestamp };
 }
 
 /**
@@ -112,23 +125,27 @@ export async function cacheHint(
   slug: string,
   hint: { sceneType: string; weatherCode: number; isDay: boolean },
 ): Promise<void> {
-  const col = await weatherHintsCollection();
-  if (!col) return;
+  try {
+    const col = await weatherHintsCollection();
+    if (!col) return;
 
-  await col.upsert({
-    slug,
-    ...hint,
-    timestamp: Date.now(),
-  });
+    await col.upsert({
+      slug,
+      ...hint,
+      timestamp: Date.now(),
+    });
 
-  // Evict oldest if over cap
-  const allDocs = await col.find().exec();
-  if (allDocs.length > HINT_MAX_ENTRIES) {
-    const sorted = [...allDocs].sort((a, b) => a.timestamp - b.timestamp);
-    const toRemove = sorted.slice(0, sorted.length - HINT_MAX_ENTRIES);
-    for (const doc of toRemove) {
-      await doc.remove();
+    // Evict oldest if over cap
+    const allDocs = await col.find().exec();
+    if (allDocs.length > HINT_MAX_ENTRIES) {
+      const sorted = [...allDocs].sort((a, b) => a.timestamp - b.timestamp);
+      const toRemove = sorted.slice(0, sorted.length - HINT_MAX_ENTRIES);
+      for (const doc of toRemove) {
+        await doc.remove();
+      }
     }
+  } catch {
+    // best-effort — never throw from a hint write
   }
 }
 
@@ -145,11 +162,15 @@ export async function suitabilityRulesCollection() {
  * Get all cached suitability rules. Returns empty array if none cached.
  */
 export async function getCachedRules(): Promise<Array<{ key: string; conditions: string; updatedAt: number }>> {
-  const col = await suitabilityRulesCollection();
-  if (!col) return [];
+  try {
+    const col = await suitabilityRulesCollection();
+    if (!col) return [];
 
-  const docs = await col.find().exec();
-  return docs.map((d) => ({ key: d.key, conditions: d.conditions, updatedAt: d.updatedAt }));
+    const docs = await col.find().exec();
+    return docs.map((d) => ({ key: d.key, conditions: d.conditions, updatedAt: d.updatedAt }));
+  } catch {
+    return [];
+  }
 }
 
 /**
@@ -158,11 +179,15 @@ export async function getCachedRules(): Promise<Array<{ key: string; conditions:
 export async function cacheSuitabilityRules(
   rules: Array<{ key: string; conditions: string }>,
 ): Promise<void> {
-  const col = await suitabilityRulesCollection();
-  if (!col) return;
+  try {
+    const col = await suitabilityRulesCollection();
+    if (!col) return;
 
-  const now = Date.now();
-  for (const rule of rules) {
-    await col.upsert({ ...rule, updatedAt: now });
+    const now = Date.now();
+    for (const rule of rules) {
+      await col.upsert({ ...rule, updatedAt: now });
+    }
+  } catch {
+    // best-effort — never throw from a rules write
   }
 }

--- a/src/lib/rxdb/database.ts
+++ b/src/lib/rxdb/database.ts
@@ -35,21 +35,46 @@ export type MukokoDatabase = RxDatabase<MukokoCollections>;
 
 // ---------------------------------------------------------------------------
 // Singleton
+//
+// RxDB is an OPTIONAL enhancement layer. It must NEVER crash the app — every
+// failure mode (DB9 duplicate-database creation, schema-version conflict,
+// StrictMode double-mount, IndexedDB unavailable in private browsing, etc.)
+// resolves to `null` so callers seamlessly fall back to Zustand/localStorage.
+//
+// `getDatabase()` caches a single promise that resolves to `MukokoDatabase |
+// null` and NEVER rejects — guaranteeing no unhandled rejection can bubble
+// into React render.
 // ---------------------------------------------------------------------------
 
-let dbPromise: Promise<MukokoDatabase> | null = null;
+let dbPromise: Promise<MukokoDatabase | null> | null = null;
 
 /**
  * Get (or create) the RxDB database instance.
- * Returns null on server — caller must guard.
+ * Returns null on the server, or whenever RxDB is unavailable/failed.
+ * Idempotent + singleton — the underlying init runs at most once.
  */
 export async function getDatabase(): Promise<MukokoDatabase | null> {
   if (typeof window === "undefined") return null;
 
   if (!dbPromise) {
-    dbPromise = createDb();
+    // createDbSafe never rejects, so the cached promise never rejects either.
+    dbPromise = createDbSafe();
   }
   return dbPromise;
+}
+
+/** Wraps createDb so any failure resolves to null instead of throwing. */
+async function createDbSafe(): Promise<MukokoDatabase | null> {
+  try {
+    return await createDb();
+  } catch (err: unknown) {
+    // App still works; preferences fall back to Zustand + localStorage.
+    console.warn(
+      "[RxDB] Failed to initialise database, using in-memory/localStorage fallback:",
+      String(err),
+    );
+    return null;
+  }
 }
 
 async function createDb(): Promise<MukokoDatabase> {
@@ -58,26 +83,33 @@ async function createDb(): Promise<MukokoDatabase> {
       return await _initDb();
     } catch (err: unknown) {
       const msg = String(err);
+      // DB9 = "database created twice with the same name" / schema-version
+      // conflict — common under React StrictMode double-mount or a stale
+      // IndexedDB from a previous schema version. Wipe + retry once.
       const isDB9 = msg.includes("DB9");
       if (isDB9 && attempt === 0) {
-        // DB9: stale v16 database or multiInstance conflict.
-        // Wipe via native IndexedDB then retry once.
-        await new Promise<void>((resolve) => {
-          const req = indexedDB.deleteDatabase("mukoko_weather");
-          req.onsuccess = () => resolve();
-          req.onerror = () => resolve();
-          req.onblocked = () => resolve();
-        });
-        dbPromise = null;
+        await wipeIndexedDb("mukoko_weather");
         continue;
       }
-      // On second attempt or non-DB9 error — give up gracefully.
-      // App still works; preferences just won't persist via RxDB.
-      console.warn("[RxDB] Failed to initialise database, using in-memory fallback:", msg);
+      // Give up gracefully — createDbSafe swallows this and returns null.
       throw err;
     }
   }
-  throw new Error("unreachable");
+  throw new Error("[RxDB] unreachable init state");
+}
+
+/** Best-effort native IndexedDB delete — never throws, always resolves. */
+async function wipeIndexedDb(name: string): Promise<void> {
+  try {
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase(name);
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      req.onblocked = () => resolve();
+    });
+  } catch {
+    // indexedDB itself unavailable — nothing to wipe.
+  }
 }
 
 async function _initDb(): Promise<MukokoDatabase> {
@@ -85,7 +117,7 @@ async function _initDb(): Promise<MukokoDatabase> {
     name: "mukoko_weather",
     storage: getRxStorageDexie(),
     multiInstance: false, // single-tab app — avoids DB9 leader-election conflicts
-    ignoreDuplicate: true,
+    ignoreDuplicate: true, // singleton guard — swallow "duplicate DB" (DB9) races
   });
 
   await db.addCollections({
@@ -108,12 +140,16 @@ async function _initDb(): Promise<MukokoDatabase> {
 }
 
 /**
- * Destroy the database (for testing / cleanup).
+ * Destroy the database (for testing / cleanup). Never throws.
  */
 export async function destroyDatabase(): Promise<void> {
-  if (dbPromise) {
+  if (!dbPromise) return;
+  try {
     const db = await dbPromise;
-    await db.close();
+    if (db) await db.close();
+  } catch {
+    // ignore — best-effort teardown
+  } finally {
     dbPromise = null;
   }
 }

--- a/src/lib/rxdb/replication.ts
+++ b/src/lib/rxdb/replication.ts
@@ -162,9 +162,15 @@ async function refreshSuitabilityRules(): Promise<void> {
  * Call once after RxDB bridge is initialized.
  */
 export async function startReplication(): Promise<void> {
-  await startPrefsReplication();
+  // Replication is an optional sync enhancement — any RxDB/replication failure
+  // must never crash the app or bubble into render.
+  try {
+    await startPrefsReplication();
+  } catch (err) {
+    console.warn("[RxDB] prefs replication failed to start:", String(err));
+  }
 
-  // Initial rules fetch
+  // Initial rules fetch (already internally guarded)
   await refreshSuitabilityRules();
 
   // Periodic rules refresh
@@ -177,8 +183,13 @@ export async function startReplication(): Promise<void> {
  * Stop all replication (for cleanup/testing).
  */
 export async function stopReplication(): Promise<void> {
-  if (prefsReplication) {
-    await prefsReplication.cancel();
+  try {
+    if (prefsReplication) {
+      await prefsReplication.cancel();
+      prefsReplication = null;
+    }
+  } catch {
+    // best-effort teardown
     prefsReplication = null;
   }
 


### PR DESCRIPTION
## Summary

Fixes two production bugs. I own `src/lib/rxdb/*`, `src/lib/store.ts`, `src/lib/db.ts`.

### BUG 1 (critical) — RxDB DB9 crashed the location page
The local-first RxDB layer threw an uncaught **RxDB Error DB9** on load, cascading so the multi-model comparison + minutely nowcast sections (and hero) stuck as loading skeletons.

**Root cause:** `getDatabase()` cached a *rejected* promise on init failure (DB9 = database created twice / schema-version conflict, common under React StrictMode double-mount). Every downstream `preferencesCollection()` / `updatePreferences()` call then rejected, and the fire-and-forget setter writes produced unhandled rejections that broke the client tree during hydration.

**Fix — RxDB is now a fully optional enhancement that can never throw into render:**
- `getDatabase()` is a singleton resolving to `MukokoDatabase | null` that **never rejects** — `createDbSafe()` swallows all failures. `ignoreDuplicate: true` + a one-shot IndexedDB wipe/retry handle the DB9 duplicate-DB race.
- Every collection read/write helper wrapped in try/catch (cache miss / no-op on error, never a throw).
- Bridge init, migration, change-subscription, and `updatePreferences` wrapped in try/catch. When RxDB is unavailable, preferences (theme, `selectedForecastModel`, saved locations…) **fall back to Zustand + a localStorage mirror**, so they still hydrate and persist across reloads seamlessly.
- Replication start/stop guarded.

The multi-model + minutely sections read `selectedForecastModel` from Zustand and fetch via `/api/py/weather` — both independent of RxDB — so they now render normally.

### BUG 2 — /api/db-init aborted on an index conflict (blocked all seeding, incl. airports)
`ensureIndexes` created a **unique** `locationSlug_1` while a **non-unique** one already existed → Mongo `IndexOptionsConflict` → the whole `Promise.all` rejected before seeding, so `weather.airports` never seeded and aviation was empty.

**Fix:** every index is now created via a resilient `safeCreateIndex()` helper using `Promise.allSettled`:
- Catches per-index conflicts (Mongo **85/86/68**, via `isIndexConflictError`) so one bad index never aborts the seed.
- For a genuinely-required unique index: drop-and-recreate to reconcile options; if real duplicate data exists (`11000`), **downgrade to non-unique** to match reality and keep seeding.
- All other failures are logged (`logWarn`) and swallowed.

## Verification
- `npm test` — 1772 passed (added `isIndexConflictError` unit tests)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (only pre-existing warnings)
- `npm run build` — succeeds

No Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)