### PR TITLE
fix(hero): make weather animation visible + clearer, fix faint weather icons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -878,13 +878,16 @@ body {
       );
   }
   /* .weaver-scrim — readability veil over the animation so the hero text keeps
-     APCA-safe contrast. Heavier on the left where the temperature/labels sit. */
+     APCA-safe contrast. Strong on the left third where the big temperature and
+     labels sit, then fades to FULLY TRANSPARENT past ~66% so the animated
+     weather scene reads clearly on the open right side of the card (behind the
+     condition icon / empty sky) instead of being washed out edge-to-edge. */
   .weaver-scrim {
     background: linear-gradient(
-      100deg,
-      color-mix(in srgb, var(--color-surface-card) 78%, transparent) 0%,
-      color-mix(in srgb, var(--color-surface-card) 45%, transparent) 55%,
-      color-mix(in srgb, var(--color-surface-card) 30%, transparent) 100%
+      104deg,
+      color-mix(in srgb, var(--color-surface-card) 74%, transparent) 0%,
+      color-mix(in srgb, var(--color-surface-card) 42%, transparent) 40%,
+      transparent 66%
     );
   }
 

--- a/src/lib/weather-icons.tsx
+++ b/src/lib/weather-icons.tsx
@@ -8,17 +8,19 @@ interface IconProps {
 }
 
 /*
- * Weather condition icons — refreshed to a modern two-tone treatment: a soft
- * currentColor fill under a crisp 1.75px outline, with solid accents (sun core,
- * lightning bolt). Everything is driven by `currentColor` so the icons inherit
- * the mineral/severity token applied by the consumer — no hardcoded colours.
- * Shared cloud silhouette keeps the family visually consistent.
+ * Weather condition icons — a modern two-tone treatment: a soft currentColor
+ * fill under a bold 2.25px outline, with solid accents (sun core, lightning
+ * bolt). The heavier stroke + stronger fill keep them high-contrast and legible
+ * on the cream surface at hero, hourly-strip, and metric-card sizes. Everything
+ * is driven by `currentColor` so the icons inherit the mineral/severity token
+ * applied by the consumer — no hardcoded colours. Shared cloud silhouette keeps
+ * the family visually consistent.
  */
 
 export function SunIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="12" cy="12" r="4.25" fill="currentColor" fillOpacity="0.18" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="4.25" fill="currentColor" fillOpacity="0.26" />
       <path d="M12 2.5v2.25" /><path d="M12 19.25v2.25" />
       <path d="m5.1 5.1 1.6 1.6" /><path d="m17.3 17.3 1.6 1.6" />
       <path d="M2.5 12h2.25" /><path d="M19.25 12h2.25" />
@@ -29,8 +31,8 @@ export function SunIcon({ className = "", size = 24 }: IconProps) {
 
 export function MoonIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" fill="currentColor" fillOpacity="0.18" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" fill="currentColor" fillOpacity="0.26" />
       <path d="M17 4.5v2.5" /><path d="M18.25 5.75h-2.5" />
     </svg>
   );
@@ -38,27 +40,27 @@ export function MoonIcon({ className = "", size = 24 }: IconProps) {
 
 export function CloudIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" fill="currentColor" fillOpacity="0.15" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" fill="currentColor" fillOpacity="0.24" />
     </svg>
   );
 }
 
 export function CloudSunIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="12" cy="8" r="3" fill="currentColor" fillOpacity="0.18" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="8" r="3" fill="currentColor" fillOpacity="0.26" />
       <path d="M12 1.75v1.5" /><path d="m5.9 4.4 1.05 1.05" /><path d="M18.1 4.4l-1.05 1.05" />
       <path d="M20.25 11.5h1.5" /><path d="M2.25 11.5h1.5" />
-      <path d="M13 22H7a5 5 0 1 1 4.9-6H13a3 3 0 0 1 0 6Z" fill="currentColor" fillOpacity="0.15" />
+      <path d="M13 22H7a5 5 0 1 1 4.9-6H13a3 3 0 0 1 0 6Z" fill="currentColor" fillOpacity="0.24" />
     </svg>
   );
 }
 
 export function CloudRainIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" fill="currentColor" fillOpacity="0.15" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" fill="currentColor" fillOpacity="0.24" />
       <path d="M16 15v4" /><path d="M8 15v4" /><path d="M12 17v4" />
     </svg>
   );
@@ -66,8 +68,8 @@ export function CloudRainIcon({ className = "", size = 24 }: IconProps) {
 
 export function CloudDrizzleIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" fill="currentColor" fillOpacity="0.15" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" fill="currentColor" fillOpacity="0.24" />
       <path d="M8 19v1.5" /><path d="M16 19v1.5" /><path d="M12 20.5V22" />
     </svg>
   );
@@ -75,8 +77,8 @@ export function CloudDrizzleIcon({ className = "", size = 24 }: IconProps) {
 
 export function CloudLightningIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M6 16.326A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 .5 8.973" fill="currentColor" fillOpacity="0.15" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 16.326A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 .5 8.973" fill="currentColor" fillOpacity="0.24" />
       <path d="m13 12-3 5h4l-3 5" fill="currentColor" fillOpacity="0.9" stroke="none" />
     </svg>
   );
@@ -84,8 +86,8 @@ export function CloudLightningIcon({ className = "", size = 24 }: IconProps) {
 
 export function CloudFogIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" fill="currentColor" fillOpacity="0.15" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" fill="currentColor" fillOpacity="0.24" />
       <path d="M16 17H7" /><path d="M17 21H9" />
     </svg>
   );
@@ -93,11 +95,11 @@ export function CloudFogIcon({ className = "", size = 24 }: IconProps) {
 
 export function CloudSunRainIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="12" cy="8" r="3" fill="currentColor" fillOpacity="0.18" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="8" r="3" fill="currentColor" fillOpacity="0.26" />
       <path d="M12 1.75v1.5" /><path d="m5.9 4.4 1.05 1.05" /><path d="M18.1 4.4l-1.05 1.05" />
       <path d="M20.25 11.5h1.5" /><path d="M2.25 11.5h1.5" />
-      <path d="M13 22H7a5 5 0 1 1 4.9-6H13a3 3 0 0 1 0 6Z" fill="currentColor" fillOpacity="0.15" />
+      <path d="M13 22H7a5 5 0 1 1 4.9-6H13a3 3 0 0 1 0 6Z" fill="currentColor" fillOpacity="0.24" />
       <path d="M8 20v2" /><path d="M11 20v2" />
     </svg>
   );
@@ -105,8 +107,8 @@ export function CloudSunRainIcon({ className = "", size = 24 }: IconProps) {
 
 export function CloudHailIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" fill="currentColor" fillOpacity="0.15" />
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242" fill="currentColor" fillOpacity="0.24" />
       <circle cx="8" cy="16" r="0.9" fill="currentColor" stroke="none" />
       <circle cx="16" cy="16" r="0.9" fill="currentColor" stroke="none" />
       <circle cx="12" cy="18" r="0.9" fill="currentColor" stroke="none" />
@@ -119,7 +121,7 @@ export function CloudHailIcon({ className = "", size = 24 }: IconProps) {
 
 export function SnowflakeIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
       <line x1="2.5" x2="21.5" y1="12" y2="12" />
       <line x1="12" x2="12" y1="2.5" y2="21.5" />
       <line x1="5.5" x2="18.5" y1="5.5" y2="18.5" />
@@ -132,7 +134,7 @@ export function SnowflakeIcon({ className = "", size = 24 }: IconProps) {
 
 export function WindIcon({ className = "", size = 24 }: IconProps) {
   return (
-    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round">
       <path d="M17.7 7.7a2.5 2.5 0 1 1 1.8 4.3H2" />
       <path d="M9.6 4.6A2 2 0 1 1 11 8H2" />
       <path d="M12.6 19.4A2 2 0 1 0 14 16H2" />

--- a/src/lib/weather-scenes/scenes/clear.ts
+++ b/src/lib/weather-scenes/scenes/clear.ts
@@ -21,9 +21,9 @@ export function buildClearScene(
     // Sun
     const sunGeo = new THREE.SphereGeometry(4, geoDetail, geoDetail);
     const sunMat = new THREE.MeshBasicMaterial({
-      color: 0xffcc33,
+      color: 0xffc233,
       transparent: true,
-      opacity: 0.35,
+      opacity: 0.6,
     });
     const sun = new THREE.Mesh(sunGeo, sunMat);
     sun.position.set(6, 6, -12);
@@ -35,7 +35,7 @@ export function buildClearScene(
     const glowMat = new THREE.MeshBasicMaterial({
       color: 0xffdd66,
       transparent: true,
-      opacity: 0.1,
+      opacity: 0.24,
       side: THREE.DoubleSide,
     });
     const glow = new THREE.Mesh(glowGeo, glowMat);
@@ -44,7 +44,7 @@ export function buildClearScene(
     disposables.push(glowGeo, glowMat);
 
     // Dust motes
-    const DUST_COUNT = isMobile ? 30 : 80;
+    const DUST_COUNT = isMobile ? 45 : 110;
     const dustPos = new Float32Array(DUST_COUNT * 3);
     for (let i = 0; i < DUST_COUNT; i++) {
       dustPos[i * 3] = (Math.random() - 0.5) * 40;
@@ -55,9 +55,9 @@ export function buildClearScene(
     dustGeo.setAttribute("position", new THREE.BufferAttribute(dustPos, 3));
     const dustMat = new THREE.PointsMaterial({
       color: 0xffd700,
-      size: 0.15,
+      size: 0.19,
       transparent: true,
-      opacity: 0.4,
+      opacity: 0.6,
     });
     const dust = new THREE.Points(dustGeo, dustMat);
     scene.add(dust);
@@ -65,8 +65,8 @@ export function buildClearScene(
 
     return {
       update(elapsed) {
-        sunMat.opacity = 0.35 + Math.sin(elapsed * 1.2) * 0.08;
-        glowMat.opacity = 0.1 + Math.sin(elapsed * 0.8) * 0.03;
+        sunMat.opacity = 0.6 + Math.sin(elapsed * 1.2) * 0.1;
+        glowMat.opacity = 0.24 + Math.sin(elapsed * 0.8) * 0.06;
         // Gentle float
         const pos = dustGeo.attributes.position as InstanceType<typeof THREE.BufferAttribute>;
         for (let i = 0; i < DUST_COUNT; i++) {
@@ -85,9 +85,9 @@ export function buildClearScene(
   // Night scene
   const moonGeo = new THREE.SphereGeometry(3, geoDetail, geoDetail);
   const moonMat = new THREE.MeshBasicMaterial({
-    color: 0xc0c0d0,
+    color: 0xd2d2e0,
     transparent: true,
-    opacity: 0.3,
+    opacity: 0.55,
   });
   const moon = new THREE.Mesh(moonGeo, moonMat);
   moon.position.set(-5, 7, -12);
@@ -95,7 +95,7 @@ export function buildClearScene(
   disposables.push(moonGeo, moonMat);
 
   // Stars
-  const STAR_COUNT = isMobile ? 40 : 100;
+  const STAR_COUNT = isMobile ? 70 : 150;
   const starPos = new Float32Array(STAR_COUNT * 3);
   for (let i = 0; i < STAR_COUNT; i++) {
     starPos[i * 3] = (Math.random() - 0.5) * 50;
@@ -106,9 +106,9 @@ export function buildClearScene(
   starGeo.setAttribute("position", new THREE.BufferAttribute(starPos, 3));
   const starMat = new THREE.PointsMaterial({
     color: 0xffffff,
-    size: 0.1,
+    size: 0.14,
     transparent: true,
-    opacity: 0.7,
+    opacity: 0.9,
   });
   const stars = new THREE.Points(starGeo, starMat);
   scene.add(stars);
@@ -116,8 +116,8 @@ export function buildClearScene(
 
   return {
     update(elapsed) {
-      moonMat.opacity = 0.3 + Math.sin(elapsed * 0.8) * 0.05;
-      starMat.opacity = 0.5 + Math.sin(elapsed * 2) * 0.2;
+      moonMat.opacity = 0.55 + Math.sin(elapsed * 0.8) * 0.07;
+      starMat.opacity = 0.72 + Math.sin(elapsed * 2) * 0.22;
     },
     dispose() {
       for (const d of disposables) d.dispose();

--- a/src/lib/weather-scenes/scenes/cloudy.ts
+++ b/src/lib/weather-scenes/scenes/cloudy.ts
@@ -25,10 +25,10 @@ export function buildCloudyScene(
   const upperGeo = new THREE.BufferGeometry();
   upperGeo.setAttribute("position", new THREE.BufferAttribute(upperPos, 3));
   const upperMat = new THREE.PointsMaterial({
-    color: isDay ? 0xcccccc : 0x555566,
-    size: 1.8,
+    color: isDay ? 0xd4d4d4 : 0x666678,
+    size: 2.0,
     transparent: true,
-    opacity: 0.25,
+    opacity: 0.42,
   });
   const upper = new THREE.Points(upperGeo, upperMat);
   scene.add(upper);
@@ -45,10 +45,10 @@ export function buildCloudyScene(
   const midGeo = new THREE.BufferGeometry();
   midGeo.setAttribute("position", new THREE.BufferAttribute(midPos, 3));
   const midMat = new THREE.PointsMaterial({
-    color: isDay ? 0xbbbbbb : 0x444455,
-    size: 1.4,
+    color: isDay ? 0xc4c4c4 : 0x555568,
+    size: 1.6,
     transparent: true,
-    opacity: 0.2,
+    opacity: 0.34,
   });
   const mid = new THREE.Points(midGeo, midMat);
   scene.add(mid);
@@ -73,7 +73,7 @@ export function buildCloudyScene(
       mpos.needsUpdate = true;
 
       // Subtle opacity pulse
-      upperMat.opacity = 0.25 + Math.sin(elapsed * 0.5) * 0.03;
+      upperMat.opacity = 0.42 + Math.sin(elapsed * 0.5) * 0.05;
     },
     dispose() {
       for (const d of disposables) d.dispose();

--- a/src/lib/weather-scenes/scenes/fog.ts
+++ b/src/lib/weather-scenes/scenes/fog.ts
@@ -28,10 +28,10 @@ export function buildFogScene(
   const fogGeo = new THREE.BufferGeometry();
   fogGeo.setAttribute("position", new THREE.BufferAttribute(fogPos, 3));
   const fogMat = new THREE.PointsMaterial({
-    color: isDay ? 0xdddddd : 0x666677,
-    size: 2.0,
+    color: isDay ? 0xe4e4e4 : 0x77778a,
+    size: 2.3,
     transparent: true,
-    opacity: 0.12,
+    opacity: 0.26,
   });
   const fogParticles = new THREE.Points(fogGeo, fogMat);
   scene.add(fogParticles);
@@ -48,10 +48,10 @@ export function buildFogScene(
   const mistGeo = new THREE.BufferGeometry();
   mistGeo.setAttribute("position", new THREE.BufferAttribute(mistPos, 3));
   const mistMat = new THREE.PointsMaterial({
-    color: isDay ? 0xeeeeee : 0x555566,
-    size: 0.8,
+    color: isDay ? 0xf4f4f4 : 0x66667a,
+    size: 0.95,
     transparent: true,
-    opacity: 0.15,
+    opacity: 0.3,
   });
   const mist = new THREE.Points(mistGeo, mistMat);
   scene.add(mist);
@@ -78,7 +78,7 @@ export function buildFogScene(
       mpos.needsUpdate = true;
 
       // Opacity undulates slowly
-      fogMat.opacity = 0.12 + Math.sin(elapsed * 0.3) * 0.02;
+      fogMat.opacity = 0.26 + Math.sin(elapsed * 0.3) * 0.04;
     },
     dispose() {
       for (const d of disposables) d.dispose();

--- a/src/lib/weather-scenes/scenes/partly-cloudy.ts
+++ b/src/lib/weather-scenes/scenes/partly-cloudy.ts
@@ -19,9 +19,9 @@ export function buildPartlyCloudyScene(
   // Sun or moon
   const bodyGeo = new THREE.SphereGeometry(3, geoDetail, geoDetail);
   const bodyMat = new THREE.MeshBasicMaterial({
-    color: isDay ? 0xffaa33 : 0xc0c0d0,
+    color: isDay ? 0xffaa33 : 0xd2d2e0,
     transparent: true,
-    opacity: 0.2,
+    opacity: 0.42,
   });
   const body = new THREE.Mesh(bodyGeo, bodyMat);
   body.position.set(isDay ? 6 : -5, 6, -10);
@@ -33,7 +33,7 @@ export function buildPartlyCloudyScene(
   const glowMat = new THREE.MeshBasicMaterial({
     color: isDay ? 0xffcc66 : 0x8888bb,
     transparent: true,
-    opacity: 0.06,
+    opacity: 0.18,
     side: THREE.DoubleSide,
   });
   const glow = new THREE.Mesh(glowGeo, glowMat);
@@ -42,7 +42,7 @@ export function buildPartlyCloudyScene(
   disposables.push(glowGeo, glowMat);
 
   // Cloud clusters
-  const CLOUD_COUNT = isMobile ? 15 : 30;
+  const CLOUD_COUNT = isMobile ? 22 : 42;
   const cloudPos = new Float32Array(CLOUD_COUNT * 3);
   for (let i = 0; i < CLOUD_COUNT; i++) {
     cloudPos[i * 3] = (Math.random() - 0.5) * 40;
@@ -52,10 +52,10 @@ export function buildPartlyCloudyScene(
   const cloudGeo = new THREE.BufferGeometry();
   cloudGeo.setAttribute("position", new THREE.BufferAttribute(cloudPos, 3));
   const cloudMat = new THREE.PointsMaterial({
-    color: isDay ? 0xffffff : 0x8888aa,
-    size: 1.4,
+    color: isDay ? 0xffffff : 0x9a9ac0,
+    size: 1.6,
     transparent: true,
-    opacity: 0.2,
+    opacity: 0.36,
   });
   const clouds = new THREE.Points(cloudGeo, cloudMat);
   scene.add(clouds);
@@ -72,10 +72,10 @@ export function buildPartlyCloudyScene(
   const breezeGeo = new THREE.BufferGeometry();
   breezeGeo.setAttribute("position", new THREE.BufferAttribute(breezePos, 3));
   const breezeMat = new THREE.PointsMaterial({
-    color: isDay ? 0xdddddd : 0x6666aa,
-    size: 0.08,
+    color: isDay ? 0xdddddd : 0x7f7fbb,
+    size: 0.11,
     transparent: true,
-    opacity: 0.3,
+    opacity: 0.5,
   });
   const breeze = new THREE.Points(breezeGeo, breezeMat);
   scene.add(breeze);
@@ -83,7 +83,7 @@ export function buildPartlyCloudyScene(
 
   return {
     update(elapsed) {
-      bodyMat.opacity = 0.2 + Math.sin(elapsed * 1.0) * 0.05;
+      bodyMat.opacity = 0.42 + Math.sin(elapsed * 1.0) * 0.08;
 
       // Clouds drift right
       const cpos = cloudGeo.attributes.position as InstanceType<typeof THREE.BufferAttribute>;

--- a/src/lib/weather-scenes/scenes/rain.ts
+++ b/src/lib/weather-scenes/scenes/rain.ts
@@ -15,7 +15,7 @@ export function buildRainScene(
   scene.fog = new THREE.FogExp2(isDay ? 0x6688aa : 0x0c1018, 0.02);
 
   // Cloud layer
-  const CLOUD_COUNT = isMobile ? 15 : 30;
+  const CLOUD_COUNT = isMobile ? 22 : 40;
   const cloudPos = new Float32Array(CLOUD_COUNT * 3);
   for (let i = 0; i < CLOUD_COUNT; i++) {
     cloudPos[i * 3] = (Math.random() - 0.5) * 40;
@@ -25,17 +25,17 @@ export function buildRainScene(
   const cloudGeo = new THREE.BufferGeometry();
   cloudGeo.setAttribute("position", new THREE.BufferAttribute(cloudPos, 3));
   const cloudMat = new THREE.PointsMaterial({
-    color: isDay ? 0xaaaaaa : 0x444455,
-    size: 1.5,
+    color: isDay ? 0xbfc6d0 : 0x556070,
+    size: 1.7,
     transparent: true,
-    opacity: 0.2,
+    opacity: 0.34,
   });
   const clouds = new THREE.Points(cloudGeo, cloudMat);
   scene.add(clouds);
   disposables.push(cloudGeo, cloudMat);
 
   // Rain particles
-  const RAIN_COUNT = isMobile ? 120 : 300;
+  const RAIN_COUNT = isMobile ? 190 : 440;
   const rainPos = new Float32Array(RAIN_COUNT * 3);
   const rainVel = new Float32Array(RAIN_COUNT);
   for (let i = 0; i < RAIN_COUNT; i++) {
@@ -47,10 +47,10 @@ export function buildRainScene(
   const rainGeo = new THREE.BufferGeometry();
   rainGeo.setAttribute("position", new THREE.BufferAttribute(rainPos, 3));
   const rainMat = new THREE.PointsMaterial({
-    color: isDay ? 0x6699cc : 0x4477aa,
-    size: 0.12,
+    color: isDay ? 0x5b8fd6 : 0x6fa0d8,
+    size: 0.17,
     transparent: true,
-    opacity: 0.55,
+    opacity: 0.85,
   });
   const rain = new THREE.Points(rainGeo, rainMat);
   scene.add(rain);
@@ -82,7 +82,7 @@ export function buildRainScene(
       cpos.needsUpdate = true;
 
       // Pulsing cloud opacity
-      cloudMat.opacity = 0.2 + Math.sin(elapsed * 0.6) * 0.04;
+      cloudMat.opacity = 0.34 + Math.sin(elapsed * 0.6) * 0.05;
     },
     dispose() {
       for (const d of disposables) d.dispose();

--- a/src/lib/weather-scenes/scenes/snow.ts
+++ b/src/lib/weather-scenes/scenes/snow.ts
@@ -17,7 +17,7 @@ export function buildSnowScene(
   scene.fog = new THREE.FogExp2(isDay ? 0xd0d8e8 : 0x101828, 0.015);
 
   // Snowflakes — larger and slower than rain
-  const SNOW_COUNT = isMobile ? 60 : 150;
+  const SNOW_COUNT = isMobile ? 95 : 210;
   const snowPos = new Float32Array(SNOW_COUNT * 3);
   const snowVel = new Float32Array(SNOW_COUNT);
   const snowSway = new Float32Array(SNOW_COUNT);
@@ -32,9 +32,9 @@ export function buildSnowScene(
   snowGeo.setAttribute("position", new THREE.BufferAttribute(snowPos, 3));
   const snowMat = new THREE.PointsMaterial({
     color: 0xffffff,
-    size: 0.25, // bigger than rain
+    size: 0.32, // bigger than rain
     transparent: true,
-    opacity: 0.7,
+    opacity: 0.92,
   });
   const snow = new THREE.Points(snowGeo, snowMat);
   scene.add(snow);
@@ -56,9 +56,9 @@ export function buildSnowScene(
   // Dim sun/moon behind clouds
   const bodyGeo = new THREE.SphereGeometry(2, geoDetail, geoDetail);
   const bodyMat = new THREE.MeshBasicMaterial({
-    color: isDay ? 0xaabbcc : 0x8888aa,
+    color: isDay ? 0xbccadb : 0x9a9ac0,
     transparent: true,
-    opacity: 0.1,
+    opacity: 0.22,
   });
   const body = new THREE.Mesh(bodyGeo, bodyMat);
   body.position.set(5, 8, -15);
@@ -80,7 +80,7 @@ export function buildSnowScene(
       pos.needsUpdate = true;
 
       // Gentle opacity pulse on ground
-      groundMat.opacity = 0.08 + Math.sin(elapsed * 0.4) * 0.02;
+      groundMat.opacity = 0.14 + Math.sin(elapsed * 0.4) * 0.03;
     },
     dispose() {
       for (const d of disposables) d.dispose();

--- a/src/lib/weather-scenes/scenes/thunderstorm.ts
+++ b/src/lib/weather-scenes/scenes/thunderstorm.ts
@@ -26,17 +26,17 @@ export function buildThunderstormScene(
   const cloudGeo = new THREE.BufferGeometry();
   cloudGeo.setAttribute("position", new THREE.BufferAttribute(cloudPos, 3));
   const cloudMat = new THREE.PointsMaterial({
-    color: 0x333344,
-    size: 2.0,
+    color: 0x3d3d52,
+    size: 2.2,
     transparent: true,
-    opacity: 0.3,
+    opacity: 0.45,
   });
   const clouds = new THREE.Points(cloudGeo, cloudMat);
   scene.add(clouds);
   disposables.push(cloudGeo, cloudMat);
 
   // Heavy rain
-  const RAIN_COUNT = isMobile ? 150 : 350;
+  const RAIN_COUNT = isMobile ? 210 : 480;
   const rainPos = new Float32Array(RAIN_COUNT * 3);
   const rainVel = new Float32Array(RAIN_COUNT);
   for (let i = 0; i < RAIN_COUNT; i++) {
@@ -48,10 +48,10 @@ export function buildThunderstormScene(
   const rainGeo = new THREE.BufferGeometry();
   rainGeo.setAttribute("position", new THREE.BufferAttribute(rainPos, 3));
   const rainMat = new THREE.PointsMaterial({
-    color: 0x5577aa,
-    size: 0.14,
+    color: 0x6f93c8,
+    size: 0.18,
     transparent: true,
-    opacity: 0.5,
+    opacity: 0.78,
   });
   const rain = new THREE.Points(rainGeo, rainMat);
   scene.add(rain);
@@ -98,12 +98,12 @@ export function buildThunderstormScene(
         if (flashIntensity < 0) flashIntensity = 0;
         flashLight.intensity = flashIntensity * 2;
         // Flash brightens clouds and rain momentarily
-        cloudMat.opacity = 0.3 + flashIntensity * 0.4;
-        rainMat.opacity = 0.5 + flashIntensity * 0.3;
+        cloudMat.opacity = 0.45 + flashIntensity * 0.4;
+        rainMat.opacity = 0.78 + flashIntensity * 0.2;
       } else {
         flashLight.intensity = 0;
-        cloudMat.opacity = 0.3 + Math.sin(elapsed * 0.4) * 0.03;
-        rainMat.opacity = 0.5;
+        cloudMat.opacity = 0.45 + Math.sin(elapsed * 0.4) * 0.04;
+        rainMat.opacity = 0.78;
       }
     },
     dispose() {

--- a/src/lib/weather-scenes/scenes/windy.ts
+++ b/src/lib/weather-scenes/scenes/windy.ts
@@ -19,9 +19,9 @@ export function buildWindyScene(
   // Sun/moon — low visibility
   const bodyGeo = new THREE.SphereGeometry(2.5, isMobile ? 8 : 16, isMobile ? 8 : 16);
   const bodyMat = new THREE.MeshBasicMaterial({
-    color: isDay ? 0xddcc88 : 0x8888aa,
+    color: isDay ? 0xe0cf8c : 0x9a9ac0,
     transparent: true,
-    opacity: 0.12,
+    opacity: 0.3,
   });
   const body = new THREE.Mesh(bodyGeo, bodyMat);
   body.position.set(5, 7, -12);
@@ -39,17 +39,17 @@ export function buildWindyScene(
   const cloudGeo = new THREE.BufferGeometry();
   cloudGeo.setAttribute("position", new THREE.BufferAttribute(cloudPos, 3));
   const cloudMat = new THREE.PointsMaterial({
-    color: isDay ? 0xcccccc : 0x555566,
-    size: 1.5,
+    color: isDay ? 0xd4d4d4 : 0x666678,
+    size: 1.7,
     transparent: true,
-    opacity: 0.2,
+    opacity: 0.34,
   });
   const clouds = new THREE.Points(cloudGeo, cloudMat);
   scene.add(clouds);
   disposables.push(cloudGeo, cloudMat);
 
   // Wind debris particles — fast horizontal movement
-  const DEBRIS_COUNT = isMobile ? 40 : 100;
+  const DEBRIS_COUNT = isMobile ? 60 : 140;
   const debrisPos = new Float32Array(DEBRIS_COUNT * 3);
   const debrisSpeed = new Float32Array(DEBRIS_COUNT);
   for (let i = 0; i < DEBRIS_COUNT; i++) {
@@ -61,10 +61,10 @@ export function buildWindyScene(
   const debrisGeo = new THREE.BufferGeometry();
   debrisGeo.setAttribute("position", new THREE.BufferAttribute(debrisPos, 3));
   const debrisMat = new THREE.PointsMaterial({
-    color: isDay ? 0x8b7355 : 0x665544,
-    size: 0.15,
+    color: isDay ? 0x9a7f5c : 0x7a6650,
+    size: 0.19,
     transparent: true,
-    opacity: 0.45,
+    opacity: 0.7,
   });
   const debris = new THREE.Points(debrisGeo, debrisMat);
   scene.add(debris);
@@ -96,7 +96,7 @@ export function buildWindyScene(
       dpos.needsUpdate = true;
 
       // Sun flickers behind fast clouds
-      bodyMat.opacity = 0.12 + Math.sin(elapsed * 3) * 0.04;
+      bodyMat.opacity = 0.3 + Math.sin(elapsed * 3) * 0.06;
     },
     dispose() {
       for (const d of disposables) d.dispose();


### PR DESCRIPTION
## Summary

The condition-based Three.js hero background in the CurrentConditions card rendered but read as **not working** and **not clear enough**, and the weather condition icons rendered faint on the cream surface. This PR fixes all three without touching the (already-sound) mount/visibility logic.

### 1. Hero animation visibility + clarity
- **`.weaver-scrim` (globals.css)** — the readability veil was painted opaque **edge-to-edge** (surface-card 78%→45%→30%) directly over the animated canvas, washing the scene out everywhere. It now keeps the strong veil on the **left third** (behind the oversized temperature + labels, so text stays APCA-safe) and fades to **fully transparent past ~66%**, so the animated weather scene reads clearly on the open right side of the card (behind the condition icon / empty sky).
- **`weather-scenes/scenes/*` (all 8)** — raised particle **opacity, size and density** and lifted sun/moon/glow/cloud opacities so each scene is obviously animated but still tasteful: rain, clear (day + night), partly-cloudy, cloudy, thunderstorm, snow, fog, windy.
- Performance discipline unchanged: renderer DPR still capped at 1 for the hero, dispose-on-unmount intact, IntersectionObserver/visibility pause logic untouched, and `prefers-reduced-motion` still shows the static mineral gradient only.

### 2. Faint weather icons
- **`weather-icons.tsx`** — the two-tone weather condition icons (sun, moon, cloud, rain, drizzle, lightning, fog, hail, snowflake, etc.) used a thin **1.75px** outline and low **0.15–0.18** fill opacity. Bumped stroke to **2.25px** and fill opacity to **0.24–0.26** so they read clearly at hero, hourly-strip and metric-card sizes. Export names/signatures unchanged (all three consumers already pass the high-contrast `text-primary` token).

## Constraints honoured
- No hardcoded hex in components; raw hex confined to the documented WebGL scene-builder exception. globals.css edit is limited to the hero-animation `.weaver-scrim` block (no nav styles touched).
- Error isolation and reduced-motion fallback preserved.

## Verification
- `npm test` — 1767 passed (75 files)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm run build` — compiles, all pages generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)