### PR TITLE
feat(maps+aviation): surface cloud information in maps and aviation

### DIFF
--- a/src/app/[location]/map/MapDashboard.tsx
+++ b/src/app/[location]/map/MapDashboard.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { Header } from "@/components/layout/Header";
 import { MapSkeleton } from "@/components/weather/map/MapSkeleton";
 import { WeatherLayerPanel } from "@/components/weather/map/WeatherLayerPanel";
+import { DEFAULT_LAYER } from "@/lib/map-layers";
 import type { WeatherLocation } from "@/lib/locations";
 
 const MapLibreMap = dynamic(
@@ -18,7 +19,7 @@ interface MapDashboardProps {
 }
 
 export function MapDashboard({ location }: MapDashboardProps) {
-  const [activeLayer, setActiveLayer] = useState<string | null>("precipitationIntensity");
+  const [activeLayer, setActiveLayer] = useState<string | null>(DEFAULT_LAYER);
 
   const handleLayerChange = useCallback((layerId: string | null) => {
     setActiveLayer(layerId);

--- a/src/components/weather/AviationWeather.test.ts
+++ b/src/components/weather/AviationWeather.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveCeilingFt,
+  deriveCloudBaseFt,
+  summarizeCloudCover,
+} from "./AviationWeather";
+
+interface CloudLayer {
+  cover: string;
+  base_ft: number | null;
+}
+
+const layers = (...pairs: [string, number | null][]): CloudLayer[] =>
+  pairs.map(([cover, base_ft]) => ({ cover, base_ft }));
+
+describe("deriveCeilingFt", () => {
+  it("returns null for a clear sky (no layers)", () => {
+    expect(deriveCeilingFt([])).toBeNull();
+  });
+
+  it("returns null when only FEW/SCT layers exist (no ceiling)", () => {
+    expect(deriveCeilingFt(layers(["FEW", 2000], ["SCT", 4000]))).toBeNull();
+  });
+
+  it("returns the lowest BKN/OVC base as the ceiling", () => {
+    expect(deriveCeilingFt(layers(["SCT", 2000], ["BKN", 3500], ["OVC", 8000]))).toBe(3500);
+  });
+
+  it("treats OVC as a ceiling", () => {
+    expect(deriveCeilingFt(layers(["OVC", 900]))).toBe(900);
+  });
+
+  it("ignores BKN/OVC layers with an unknown base", () => {
+    expect(deriveCeilingFt(layers(["BKN", null], ["OVC", 1200]))).toBe(1200);
+  });
+});
+
+describe("deriveCloudBaseFt", () => {
+  it("returns null for a clear sky", () => {
+    expect(deriveCloudBaseFt([])).toBeNull();
+  });
+
+  it("returns the lowest base across all layers (including FEW/SCT)", () => {
+    expect(deriveCloudBaseFt(layers(["FEW", 1800], ["BKN", 3500]))).toBe(1800);
+  });
+
+  it("skips layers with a null base", () => {
+    expect(deriveCloudBaseFt(layers(["FEW", null], ["SCT", 4200]))).toBe(4200);
+  });
+});
+
+describe("summarizeCloudCover", () => {
+  it("reports Clear for no layers", () => {
+    expect(summarizeCloudCover([])).toBe("Clear");
+  });
+
+  it("reports the densest layer's label", () => {
+    expect(summarizeCloudCover(layers(["FEW", 2000], ["OVC", 5000]))).toBe("Overcast");
+    expect(summarizeCloudCover(layers(["FEW", 2000], ["SCT", 4000]))).toBe("Scattered");
+    expect(summarizeCloudCover(layers(["BKN", 3000]))).toBe("Broken");
+  });
+
+  it("maps sky-clear codes to a clear label", () => {
+    expect(summarizeCloudCover(layers(["SKC", null]))).toBe("Sky clear");
+  });
+
+  it("falls back to the raw code for unknown covers", () => {
+    expect(summarizeCloudCover(layers(["XYZ", 1000]))).toBe("XYZ");
+  });
+});

--- a/src/components/weather/AviationWeather.tsx
+++ b/src/components/weather/AviationWeather.tsx
@@ -69,6 +69,66 @@ function formatClouds(clouds: CloudLayer[]): string {
     .join(", ");
 }
 
+/**
+ * Cloud-cover codes that constitute a *ceiling* for aviation — the lowest
+ * BKN (broken) or OVC (overcast) layer. FEW/SCT layers do not form a ceiling.
+ */
+const CEILING_COVERS = new Set(["BKN", "OVC"]);
+
+/** Ranking of cloud-cover codes by density (sky clear → overcast). */
+const COVER_RANK: Record<string, number> = {
+  SKC: 0, CLR: 0, NCD: 0, NSC: 0,
+  FEW: 1, SCT: 2, BKN: 3, OVC: 4, VV: 5,
+};
+
+const COVER_LABELS: Record<string, string> = {
+  SKC: "Sky clear", CLR: "Clear", NCD: "No cloud", NSC: "No sig. cloud",
+  FEW: "Few", SCT: "Scattered", BKN: "Broken", OVC: "Overcast",
+  VV: "Vertical vis.",
+};
+
+/**
+ * Cloud ceiling in feet — the lowest broken/overcast layer base. Returns null
+ * when no BKN/OVC layer is present (aviation "unlimited" ceiling). Critical for
+ * VFR/MVFR/IFR/LIFR flight-category determination.
+ */
+export function deriveCeilingFt(clouds: CloudLayer[]): number | null {
+  let ceiling: number | null = null;
+  for (const c of clouds) {
+    if (CEILING_COVERS.has(c.cover) && c.base_ft !== null) {
+      if (ceiling === null || c.base_ft < ceiling) ceiling = c.base_ft;
+    }
+  }
+  return ceiling;
+}
+
+/**
+ * Lowest cloud base (feet) across *all* reported layers, or null when the sky
+ * is clear / no bases are reported.
+ */
+export function deriveCloudBaseFt(clouds: CloudLayer[]): number | null {
+  let base: number | null = null;
+  for (const c of clouds) {
+    if (c.base_ft !== null && (base === null || c.base_ft < base)) base = c.base_ft;
+  }
+  return base;
+}
+
+/** Human-readable overall cloud cover, taken from the densest reported layer. */
+export function summarizeCloudCover(clouds: CloudLayer[]): string {
+  if (!clouds.length) return "Clear";
+  let densest = clouds[0];
+  for (const c of clouds) {
+    if ((COVER_RANK[c.cover] ?? -1) > (COVER_RANK[densest.cover] ?? -1)) densest = c;
+  }
+  return COVER_LABELS[densest.cover] ?? densest.cover;
+}
+
+/** Format a feet altitude for display, e.g. 2500 → "2,500 ft". */
+function formatFt(ft: number | null): string {
+  return ft === null ? "—" : `${ft.toLocaleString("en-GB")} ft`;
+}
+
 function formatTime(iso: string): string {
   try {
     return new Intl.DateTimeFormat("en-GB", {
@@ -202,6 +262,54 @@ export function AviationWeather({ slug: _slug, icao, nearby }: Props) {
 
         {!loading && !error && data && (
           <>
+        {/* Clouds & Ceiling — prominent aviation summary for the latest METAR.
+            Cloud ceiling (lowest BKN/OVC layer) is the driver of the VFR/MVFR/
+            IFR/LIFR flight category (computed server-side in _metar.py). */}
+        {data.metar.length > 0 && (() => {
+          const latest = data.metar[0];
+          const ceiling = deriveCeilingFt(latest.clouds);
+          const base = deriveCloudBaseFt(latest.clouds);
+          const cover = summarizeCloudCover(latest.clouds);
+          return (
+            <div className="mt-4 acacia" aria-labelledby={`clouds-heading-${icao}`}>
+              <div className="flex items-center justify-between gap-2">
+                <h3
+                  id={`clouds-heading-${icao}`}
+                  className="text-sm font-semibold text-text-secondary uppercase tracking-wide"
+                >
+                  Clouds &amp; Ceiling
+                </h3>
+                <span
+                  className={`inline-flex items-center justify-center rounded-[var(--radius-input)] px-2 py-0.5 text-xs font-bold min-w-[3rem] ${FLIGHT_CATEGORY_STYLES[latest.flight_category] ?? "bg-surface-dim text-text-secondary"}`}
+                  aria-label={`Flight category: ${latest.flight_category}`}
+                >
+                  {latest.flight_category}
+                </span>
+              </div>
+              <dl className="mt-3 grid grid-cols-3 gap-3">
+                <div>
+                  <dt className="text-xs text-text-tertiary">Cloud Cover</dt>
+                  <dd className="mt-0.5 text-base font-semibold text-text-primary">{cover}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-text-tertiary">Cloud Base</dt>
+                  <dd className="mt-0.5 text-base font-semibold text-text-primary">{formatFt(base)}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-text-tertiary">Ceiling</dt>
+                  <dd className="mt-0.5 text-base font-semibold text-text-primary">
+                    {ceiling === null ? "Unlimited" : formatFt(ceiling)}
+                  </dd>
+                </div>
+              </dl>
+              <p className="mt-2 text-xs text-text-tertiary">
+                Ceiling is the lowest broken (BKN) or overcast (OVC) layer — the primary
+                driver of the flight category.
+              </p>
+            </div>
+          );
+        })()}
+
         {/* TAF */}
         <div className="mt-4">
           <h3 className="text-sm font-semibold text-text-secondary uppercase tracking-wide mb-2">TAF</h3>

--- a/src/components/weather/map/MapLibreMap.tsx
+++ b/src/components/weather/map/MapLibreMap.tsx
@@ -62,6 +62,11 @@ export function MapLibreMap({
   const weatherLayerRef = useRef<string | null>(weatherLayer);
   weatherLayerRef.current = weatherLayer;
   const [overlayError, setOverlayError] = useState(false);
+  // The MapTiler base tiles load client-side directly from the CDN using
+  // NEXT_PUBLIC_MAPTILER_API_KEY. When the key is missing the style request
+  // fails and the map renders as a blank surface — surface that explicitly
+  // instead of a silent empty area so it's obvious the key needs configuring.
+  const [baseMapMissingKey] = useState(() => !MAPTILER_KEY);
   const theme = useAppStore((s) => s.theme);
 
   const isDark =
@@ -72,6 +77,9 @@ export function MapLibreMap({
 
   useEffect(() => {
     if (!containerRef.current) return;
+    // Without a MapTiler key the base style can't load — skip init and show the
+    // notice below rather than letting MapLibre repeatedly fail on a broken URL.
+    if (baseMapMissingKey) return;
 
     let map: MapLibreGLMap;
 
@@ -147,7 +155,19 @@ export function MapLibreMap({
   return (
     <div className={cn("relative", className)}>
       <div ref={containerRef} className="absolute inset-0" aria-hidden="true" />
-      {overlayError && (
+      {baseMapMissingKey && (
+        <div
+          role="status"
+          className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 bg-surface-base p-6 text-center"
+        >
+          <p className="text-sm font-semibold text-text-primary">Map unavailable</p>
+          <p className="max-w-xs text-xs text-text-tertiary">
+            The base map key is not configured. Set NEXT_PUBLIC_MAPTILER_API_KEY to enable
+            the interactive weather map.
+          </p>
+        </div>
+      )}
+      {overlayError && !baseMapMissingKey && (
         <div
           role="status"
           className="pointer-events-none absolute left-1/2 top-3 z-10 -translate-x-1/2 rounded-[var(--radius-button)] border border-severity-high/30 bg-surface-card/95 px-3 py-1.5 text-xs font-medium text-severity-high shadow-lg backdrop-blur-sm"

--- a/src/components/weather/map/WeatherLayerPanel.tsx
+++ b/src/components/weather/map/WeatherLayerPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback } from "react";
+import { CloudRain, Cloud, Thermometer, Wind, Droplets, Ban, type LucideIcon } from "lucide-react";
 import { MAP_LAYERS } from "@/lib/map-layers";
 import { cn } from "@/lib/utils";
 import { trackEvent } from "@/lib/analytics";
@@ -10,6 +11,15 @@ interface WeatherLayerPanelProps {
   onLayerChange: (layerId: string | null) => void;
   locationSlug: string;
 }
+
+/** Map a MapLayer.icon name → its lucide-react component. */
+const LAYER_ICONS: Record<string, LucideIcon> = {
+  CloudRain,
+  Cloud,
+  Thermometer,
+  Wind,
+  Droplets,
+};
 
 export function WeatherLayerPanel({
   activeLayer,
@@ -25,17 +35,17 @@ export function WeatherLayerPanel({
     [activeLayer, onLayerChange, locationSlug],
   );
 
+  const activeMeta = MAP_LAYERS.find((l) => l.id === activeLayer);
+
   return (
     <div
-      className="pointer-events-auto flex flex-col gap-1 rounded-[var(--radius-card)] border border-primary/10 bg-surface-card/90 p-2 shadow-lg backdrop-blur-sm"
+      className="pointer-events-auto flex flex-col items-center gap-1 rounded-[var(--radius-card)] border border-primary/10 bg-surface-card/90 p-1.5 shadow-lg backdrop-blur-sm"
       role="group"
       aria-label="Weather overlay layers"
     >
-      <p className="hidden px-2 pb-1 text-xs font-semibold uppercase tracking-wider text-text-tertiary sm:block">
-        Overlay
-      </p>
       {MAP_LAYERS.map((layer) => {
         const isActive = activeLayer === layer.id;
+        const Icon = LAYER_ICONS[layer.icon] ?? Cloud;
         return (
           <button
             key={layer.id}
@@ -43,33 +53,45 @@ export function WeatherLayerPanel({
             onClick={() => handleSelect(layer.id)}
             aria-pressed={isActive}
             aria-label={layer.description}
+            title={layer.label}
             className={cn(
-              "flex min-h-[var(--touch-target-min)] items-center gap-2 rounded-[var(--radius-button)] px-3 py-2 text-sm font-medium transition-colors",
+              "flex h-10 w-10 items-center justify-center rounded-[var(--radius-button)] transition-colors",
               isActive
                 ? layer.style.badge
                 : "text-text-secondary hover:bg-surface-dim hover:text-text-primary",
             )}
           >
-            <span
-              className={cn(
-                "inline-block h-2.5 w-2.5 shrink-0 rounded-full",
-                isActive ? "bg-current" : layer.style.text,
-              )}
-              aria-hidden="true"
-            />
-            <span className="hidden sm:inline">{layer.label}</span>
+            <Icon className="h-5 w-5" aria-hidden="true" />
           </button>
         );
       })}
-      {activeLayer && (
-        <button
-          type="button"
-          onClick={() => onLayerChange(null)}
-          className="mt-1 rounded-[var(--radius-button)] px-3 py-1.5 text-xs text-text-tertiary transition-colors hover:bg-surface-dim hover:text-text-secondary"
-        >
-          Clear
-        </button>
-      )}
+
+      {/* Clear / no overlay */}
+      <button
+        type="button"
+        onClick={() => onLayerChange(null)}
+        aria-pressed={activeLayer === null}
+        aria-label="No overlay"
+        title="No overlay"
+        disabled={activeLayer === null}
+        className={cn(
+          "flex h-10 w-10 items-center justify-center rounded-[var(--radius-button)] transition-colors",
+          activeLayer === null
+            ? "bg-surface-dim text-text-tertiary"
+            : "text-text-tertiary hover:bg-surface-dim hover:text-text-secondary",
+        )}
+      >
+        <Ban className="h-5 w-5" aria-hidden="true" />
+      </button>
+
+      {/* Tiny caption of the active layer, so the icon meaning is discoverable
+          without relying on hover (touch devices have no hover). */}
+      <span
+        className="max-w-[3.25rem] pt-0.5 text-center text-[0.625rem] font-medium leading-tight text-text-tertiary"
+        aria-hidden="true"
+      >
+        {activeMeta ? activeMeta.label : "Off"}
+      </span>
     </div>
   );
 }

--- a/src/lib/map-layers.test.ts
+++ b/src/lib/map-layers.test.ts
@@ -22,6 +22,7 @@ describe("MAP_LAYERS", () => {
       expect(layer.id).toBeTruthy();
       expect(layer.label).toBeTruthy();
       expect(layer.description).toBeTruthy();
+      expect(layer.icon).toBeTruthy();
       expect(layer.style).toBeDefined();
       expect(layer.style.bg).toBeTruthy();
       expect(layer.style.border).toBeTruthy();
@@ -51,6 +52,12 @@ describe("MAP_LAYERS", () => {
 describe("DEFAULT_LAYER", () => {
   it("is a valid layer ID", () => {
     expect(MAP_LAYERS.some((l) => l.id === DEFAULT_LAYER)).toBe(true);
+  });
+
+  it("defaults to a reliably-rendering (non-time-indexed) overlay, not precipitation", () => {
+    // Precipitation radar tiles can 400 without a valid recent timestamp, so the
+    // map opens on cloud cover to avoid an error banner on first paint.
+    expect(DEFAULT_LAYER).toBe("cloudCover");
   });
 });
 

--- a/src/lib/map-layers.ts
+++ b/src/lib/map-layers.ts
@@ -16,6 +16,12 @@ export interface MapLayer {
   id: string;
   label: string;
   description: string;
+  /**
+   * Lucide icon name for the compact overlay icon group. Resolved to a
+   * `lucide-react` component in `WeatherLayerPanel` (kept out of this data
+   * module so it stays a plain, testable config with no React imports).
+   */
+  icon: string;
   /** Mineral color CSS classes for the layer toggle button */
   style: {
     bg: string;
@@ -30,6 +36,7 @@ export const MAP_LAYERS: MapLayer[] = [
     id: "precipitationIntensity",
     label: "Rain",
     description: "Precipitation intensity radar",
+    icon: "CloudRain",
     style: {
       bg: "bg-mineral-cobalt/10",
       border: "border-mineral-cobalt/30",
@@ -41,6 +48,7 @@ export const MAP_LAYERS: MapLayer[] = [
     id: "cloudCover",
     label: "Cloud",
     description: "Cloud cover satellite",
+    icon: "Cloud",
     style: {
       bg: "bg-text-tertiary/10",
       border: "border-text-tertiary/30",
@@ -52,6 +60,7 @@ export const MAP_LAYERS: MapLayer[] = [
     id: "temperature",
     label: "Temp",
     description: "Temperature map",
+    icon: "Thermometer",
     style: {
       bg: "bg-mineral-terracotta/10",
       border: "border-mineral-terracotta/30",
@@ -63,6 +72,7 @@ export const MAP_LAYERS: MapLayer[] = [
     id: "windSpeed",
     label: "Wind",
     description: "Wind speed and direction",
+    icon: "Wind",
     style: {
       bg: "bg-mineral-malachite/10",
       border: "border-mineral-malachite/30",
@@ -74,6 +84,7 @@ export const MAP_LAYERS: MapLayer[] = [
     id: "humidity",
     label: "Humidity",
     description: "Relative humidity",
+    icon: "Droplets",
     style: {
       bg: "bg-mineral-tanzanite/10",
       border: "border-mineral-tanzanite/30",
@@ -83,7 +94,14 @@ export const MAP_LAYERS: MapLayer[] = [
   },
 ];
 
-export const DEFAULT_LAYER = "precipitationIntensity";
+/**
+ * Cloud cover is the default overlay — it renders reliably (a non-time-indexed
+ * Tomorrow.io field, like temperature) whereas the precipitation radar tile can
+ * 400 without a valid recent timestamp. Defaulting to a known-good layer means
+ * the map opens with a working overlay instead of an error banner. Cloud is also
+ * the most flight-relevant layer (see aviation ceilings work).
+ */
+export const DEFAULT_LAYER = "cloudCover";
 
 export function getMapLayerById(id: string): MapLayer | undefined {
   return MAP_LAYERS.find((l) => l.id === id);


### PR DESCRIPTION
## Why
Cloud information is critical for aviation — cloud **ceiling** (lowest BKN/OVC layer) determines the VFR/MVFR/IFR/LIFR flight category — so this PR surfaces cloud data prominently across both the weather **map** and the **aviation planner**.

## Maps
- **Cloud Cover overlay** confirmed present and selectable. The tile proxy already whitelists `cloudCover` (`api/py/_tiles.py` `VALID_LAYERS`) — no Python change needed.
- **Compact icon overlay switcher**: `WeatherLayerPanel` redesigned from a large vertical text-pill stack into a small vertical **icon group** (lucide icons: rain, cloud, thermometer, wind, humidity droplet + a "no overlay" icon). Active layer highlighted with its mineral badge; hover `title` + a tiny caption of the active layer (touch devices have no hover).
- **Working default overlay**: the map now opens on **Cloud Cover** instead of precipitation. The precipitation radar tile can return HTTP 400 without a valid recent timestamp (temperature/cloud are non-time-indexed and render reliably), so opening on cloud avoids the "Weather layer unavailable" banner on first paint. Precipitation stays selectable.
- **Blank base-map guard**: when `NEXT_PUBLIC_MAPTILER_API_KEY` is missing, the map now shows an explicit "Map unavailable — key not configured" notice instead of a silent blank cream surface, and skips MapLibre init (no repeated failed style requests).

## Aviation
- `AviationWeather`: new prominent **"Clouds & Ceiling"** summary for the latest METAR — cloud cover, cloud base, and ceiling — alongside the flight-category badge. Ceiling already drives the server-computed flight category (`api/py/_metar.py` `_compute_flight_category`), so the badge already factors it; this makes the driver visible.
- New pure, tested helpers: `deriveCeilingFt`, `deriveCloudBaseFt`, `summarizeCloudCover`.

## Findings for the coordinator's map reports
1. **Blank base map** — root cause is a missing `NEXT_PUBLIC_MAPTILER_API_KEY` (no `.env.local` present), not a code bug. Added a visible notice so it's diagnosable; the fix is configuring the env key.
2. **Overlay switcher** — redesigned to the requested compact vertical icon group.
3. **Precipitation 400 on open** — defaulted the map to a known-good layer (Cloud) as the graceful fallback. The upstream precipitation 400 (likely Tomorrow.io requiring a valid recent timestamp for the time-indexed radar tile) was left unmodified since it can't be verified without the live key/network.

## Tests / verification
- `npm test` — 1780 passing
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — succeeds
- New/updated tests: `map-layers.test.ts` (icon field + default layer), `AviationWeather.test.ts` (cloud/ceiling helpers)

No hardcoded hex/inline styles; mineral tokens used for the layer badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)