### PR TITLE
feat(gauge): redesign condition gauges — bigger radial arc + multi-colour gradient

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -91,7 +91,7 @@ function MetricCardSkeleton({ className }: { className?: string }) {
       aria-label="Loading metric"
     >
       {/* Arc gauge placeholder */}
-      <Skeleton className="h-14 w-14 shrink-0 rounded-full" />
+      <Skeleton className="h-24 w-24 shrink-0 rounded-full" />
       <div className="flex flex-col items-center gap-1">
         <Skeleton className="h-3 w-20" />
         <Skeleton className="h-3 w-24" />

--- a/src/components/weather/AtmosphericSummary.test.ts
+++ b/src/components/weather/AtmosphericSummary.test.ts
@@ -8,6 +8,55 @@ import {
   feelsLikeGauge,
   precipitationGauge,
 } from "./AtmosphericSummary";
+import type { GaugeConfig } from "./MetricCard";
+
+// ── gradient ramps ───────────────────────────────────────────────────────────
+
+describe("gauge gradients", () => {
+  const cases: Array<[string, GaugeConfig]> = [
+    ["uv", uvGauge(6)],
+    ["humidity", humidityGauge(50)],
+    ["cloud", cloudGauge(50)],
+    ["wind", windGauge(25)],
+    ["pressure", pressureGauge(1010)],
+    ["feelsLike", feelsLikeGauge(30, 25)],
+    ["precipitation", precipitationGauge(5)],
+  ];
+
+  it("every gauge supplies a multi-colour gradient ramp", () => {
+    for (const [, cfg] of cases) {
+      expect(Array.isArray(cfg.gradient)).toBe(true);
+      expect(cfg.gradient!.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("gradient stops are CSS custom properties, never hardcoded hex", () => {
+    for (const [, cfg] of cases) {
+      for (const stop of cfg.gradient!) {
+        expect(stop).toMatch(/^var\(--/);
+        expect(stop).not.toMatch(/#/);
+      }
+    }
+  });
+
+  it("UV sweeps the full malachite→gold→terracotta→red→extreme severity ramp", () => {
+    expect(uvGauge(6).gradient).toEqual([
+      "var(--color-severity-low)",
+      "var(--color-severity-moderate)",
+      "var(--color-severity-high)",
+      "var(--color-severity-severe)",
+      "var(--color-severity-extreme)",
+    ]);
+  });
+
+  it("humidity uses a bespoke dry→comfortable→humid ramp (non-monotonic severity)", () => {
+    expect(humidityGauge(50).gradient).toEqual([
+      "var(--color-severity-moderate)",
+      "var(--color-severity-low)",
+      "var(--color-severity-cold)",
+    ]);
+  });
+});
 
 // ── uvGauge ────────────────────────────────────────────────────────────────
 

--- a/src/components/weather/AtmosphericSummary.tsx
+++ b/src/components/weather/AtmosphericSummary.tsx
@@ -25,43 +25,79 @@ interface Props {
 }
 
 // ── Gauge configurations ─────────────────────────────────────────────────────
-// Each metric gets a radial arc gauge showing where its value falls
-// on a severity-colored scale. The arc spans 270° (open at bottom).
+// Each metric gets a radial arc gauge showing where its value falls on a
+// severity-colored scale. The arc spans 270° (open at bottom) and is painted
+// with a multi-colour SVG gradient (`gradient`) resolved from the globals.css
+// mineral/severity CSS custom properties. `strokeClass` is retained for the
+// current-severity semantics and as the gradient fallback.
+
+// Gradient ramps (ordered CSS custom-property tokens). Severity-monotonic
+// metrics sweep the natural malachite→gold→terracotta→red ramp; non-monotonic
+// metrics (humidity, pressure) use a bespoke ramp that reads light→saturated.
+const SEVERITY_GRADIENT = [
+  "var(--color-severity-low)",
+  "var(--color-severity-moderate)",
+  "var(--color-severity-high)",
+  "var(--color-severity-severe)",
+];
+const SEVERITY_GRADIENT_EXTREME = [...SEVERITY_GRADIENT, "var(--color-severity-extreme)"];
+// Dry (warm) → comfortable (green) → humid (cool/blue).
+const HUMIDITY_GRADIENT = [
+  "var(--color-severity-moderate)",
+  "var(--color-severity-low)",
+  "var(--color-severity-cold)",
+];
+// Clear → partly → overcast.
+const CLOUD_GRADIENT = [
+  "var(--color-severity-low)",
+  "var(--color-severity-moderate)",
+  "var(--color-severity-high)",
+];
+// Low (unsettled) → normal → high pressure.
+const PRESSURE_GRADIENT = [
+  "var(--color-severity-moderate)",
+  "var(--color-severity-low)",
+  "var(--color-severity-moderate)",
+];
 
 /** UV Index: 0–11+ scale */
 export function uvGauge(uv: number): GaugeConfig {
   const percent = Math.min((uv / 11) * 100, 100);
-  if (uv <= 2) return { percent, strokeClass: "stroke-severity-low" };
-  if (uv <= 5) return { percent, strokeClass: "stroke-severity-moderate" };
-  if (uv <= 7) return { percent, strokeClass: "stroke-severity-high" };
-  if (uv <= 10) return { percent, strokeClass: "stroke-severity-severe" };
-  return { percent, strokeClass: "stroke-severity-extreme" };
+  const gradient = SEVERITY_GRADIENT_EXTREME;
+  if (uv <= 2) return { percent, strokeClass: "stroke-severity-low", gradient };
+  if (uv <= 5) return { percent, strokeClass: "stroke-severity-moderate", gradient };
+  if (uv <= 7) return { percent, strokeClass: "stroke-severity-high", gradient };
+  if (uv <= 10) return { percent, strokeClass: "stroke-severity-severe", gradient };
+  return { percent, strokeClass: "stroke-severity-extreme", gradient };
 }
 
 /** Humidity: 0–100%, comfort zone is 30–60% */
 export function humidityGauge(h: number): GaugeConfig {
   const percent = Math.min(h, 100);
-  if (h < 30) return { percent, strokeClass: "stroke-severity-moderate" };
-  if (h <= 60) return { percent, strokeClass: "stroke-severity-low" };
-  if (h <= 80) return { percent, strokeClass: "stroke-severity-moderate" };
-  return { percent, strokeClass: "stroke-severity-high" };
+  const gradient = HUMIDITY_GRADIENT;
+  if (h < 30) return { percent, strokeClass: "stroke-severity-moderate", gradient };
+  if (h <= 60) return { percent, strokeClass: "stroke-severity-low", gradient };
+  if (h <= 80) return { percent, strokeClass: "stroke-severity-moderate", gradient };
+  return { percent, strokeClass: "stroke-severity-high", gradient };
 }
 
 /** Cloud cover: 0–100% */
 export function cloudGauge(c: number): GaugeConfig {
   const percent = Math.min(c, 100);
-  if (c <= 50) return { percent, strokeClass: "stroke-severity-low" };
-  if (c <= 75) return { percent, strokeClass: "stroke-severity-moderate" };
-  return { percent, strokeClass: "stroke-severity-high" };
+  const gradient = CLOUD_GRADIENT;
+  if (c <= 50) return { percent, strokeClass: "stroke-severity-low", gradient };
+  if (c <= 75) return { percent, strokeClass: "stroke-severity-moderate", gradient };
+  return { percent, strokeClass: "stroke-severity-high", gradient };
 }
 
 /** Wind speed: 0–80+ km/h scale */
 export function windGauge(speed: number): GaugeConfig {
   const percent = Math.min((speed / 80) * 100, 100);
-  if (speed <= 19) return { percent, strokeClass: "stroke-severity-low" };
-  if (speed <= 38) return { percent, strokeClass: "stroke-severity-moderate" };
-  if (speed <= 61) return { percent, strokeClass: "stroke-severity-high" };
-  return { percent, strokeClass: "stroke-severity-severe" };
+  const gradient = SEVERITY_GRADIENT;
+  if (speed <= 19) return { percent, strokeClass: "stroke-severity-low", gradient };
+  if (speed <= 38) return { percent, strokeClass: "stroke-severity-moderate", gradient };
+  if (speed <= 61) return { percent, strokeClass: "stroke-severity-high", gradient };
+  return { percent, strokeClass: "stroke-severity-severe", gradient };
 }
 
 /** Pressure: 980–1040 hPa range mapped to gauge */
@@ -70,28 +106,31 @@ export function pressureGauge(p: number): GaugeConfig {
   const max = 1040;
   const clamped = Math.max(min, Math.min(p, max));
   const percent = ((clamped - min) / (max - min)) * 100;
-  if (p < 1000) return { percent, strokeClass: "stroke-severity-moderate" };
-  if (p <= 1020) return { percent, strokeClass: "stroke-severity-low" };
-  return { percent, strokeClass: "stroke-severity-moderate" };
+  const gradient = PRESSURE_GRADIENT;
+  if (p < 1000) return { percent, strokeClass: "stroke-severity-moderate", gradient };
+  if (p <= 1020) return { percent, strokeClass: "stroke-severity-low", gradient };
+  return { percent, strokeClass: "stroke-severity-moderate", gradient };
 }
 
 /** Precipitation: 0–20mm scale */
 export function precipitationGauge(p: number): GaugeConfig {
   const percent = Math.min((p / 20) * 100, 100);
-  if (p === 0) return { percent: 0, strokeClass: "stroke-severity-low" };
-  if (p < 2) return { percent, strokeClass: "stroke-severity-moderate" };
-  if (p < 10) return { percent, strokeClass: "stroke-severity-high" };
-  return { percent, strokeClass: "stroke-severity-severe" };
+  const gradient = SEVERITY_GRADIENT;
+  if (p === 0) return { percent: 0, strokeClass: "stroke-severity-low", gradient };
+  if (p < 2) return { percent, strokeClass: "stroke-severity-moderate", gradient };
+  if (p < 10) return { percent, strokeClass: "stroke-severity-high", gradient };
+  return { percent, strokeClass: "stroke-severity-severe", gradient };
 }
 
 /** Feels-like difference from actual */
 export function feelsLikeGauge(feelsLike: number, actual: number): GaugeConfig {
   const diff = Math.abs(feelsLike - actual);
   const percent = Math.min((diff / 15) * 100, 100);
-  if (diff <= 2) return { percent: Math.max(percent, 8), strokeClass: "stroke-severity-low" };
-  if (diff <= 5) return { percent, strokeClass: "stroke-severity-moderate" };
-  if (diff <= 10) return { percent, strokeClass: "stroke-severity-high" };
-  return { percent, strokeClass: "stroke-severity-severe" };
+  const gradient = SEVERITY_GRADIENT;
+  if (diff <= 2) return { percent: Math.max(percent, 8), strokeClass: "stroke-severity-low", gradient };
+  if (diff <= 5) return { percent, strokeClass: "stroke-severity-moderate", gradient };
+  if (diff <= 10) return { percent, strokeClass: "stroke-severity-high", gradient };
+  return { percent, strokeClass: "stroke-severity-severe", gradient };
 }
 
 // ── Main component ───────────────────────────────────────────────────────────
@@ -116,14 +155,14 @@ export function AtmosphericSummary({ current, lat, lon }: Props) {
         <MetricCard
           icon={<DropletIcon size={16} />}
           label="Humidity"
-          value={`${current.relative_humidity_2m}%`}
+          value={`${Math.round(current.relative_humidity_2m)}%`}
           context={humidityLabel(current.relative_humidity_2m)}
           gauge={humidityGauge(current.relative_humidity_2m)}
         />
         <MetricCard
           icon={<CloudIcon size={16} />}
           label="Cloud Cover"
-          value={`${current.cloud_cover}%`}
+          value={`${Math.round(current.cloud_cover)}%`}
           context={cloudLabel(current.cloud_cover)}
           gauge={cloudGauge(current.cloud_cover)}
         />

--- a/src/components/weather/MetricCard.test.ts
+++ b/src/components/weather/MetricCard.test.ts
@@ -1,19 +1,30 @@
 import { describe, it, expect } from "vitest";
+import {
+  gradientFromStrokeClass,
+  valueTextSizeClass,
+  ARC_RADIUS as ARC_RADIUS_EXPORT,
+  ARC_STROKE_WIDTH,
+  ARC_VIEWBOX,
+} from "./MetricCard";
 
 // ---------------------------------------------------------------------------
 // ArcGauge constants — mirrored from MetricCard.tsx for math validation
 // ---------------------------------------------------------------------------
 
-const ARC_RADIUS = 26;
-const ARC_CIRCUMFERENCE = 2 * Math.PI * ARC_RADIUS; // ~163.3628
+const ARC_RADIUS = 32;
+const ARC_CIRCUMFERENCE = 2 * Math.PI * ARC_RADIUS; // ~201.0619
 const ARC_SWEEP = 0.75; // 270° / 360°
-const ARC_LENGTH = ARC_CIRCUMFERENCE * ARC_SWEEP; // ~122.5221
+const ARC_LENGTH = ARC_CIRCUMFERENCE * ARC_SWEEP; // ~150.7964
 
 // ── ArcGauge math ──────────────────────────────────────────────────────────
 
 describe("ArcGauge math", () => {
+  it("exported ARC_RADIUS matches the mirrored constant", () => {
+    expect(ARC_RADIUS_EXPORT).toBe(ARC_RADIUS);
+  });
+
   it("ARC_CIRCUMFERENCE is 2πr", () => {
-    expect(ARC_CIRCUMFERENCE).toBeCloseTo(2 * Math.PI * 26, 4);
+    expect(ARC_CIRCUMFERENCE).toBeCloseTo(2 * Math.PI * 32, 4);
   });
 
   it("ARC_SWEEP covers 270° (three-quarter circle)", () => {
@@ -59,11 +70,17 @@ describe("ArcGauge math", () => {
 
 describe("ArcGauge ARIA contract", () => {
   it("aria-valuenow should be rounded integer of percent", () => {
-    // Mirrors Math.round(percent) in the component
+    // Mirrors Math.round(clampedPercent) in the component
     expect(Math.round(33.7)).toBe(34);
     expect(Math.round(0)).toBe(0);
     expect(Math.round(100)).toBe(100);
     expect(Math.round(66.4)).toBe(66);
+  });
+
+  it("percent is clamped to 0-100 before rounding", () => {
+    const clamp = (p: number) => Math.max(0, Math.min(p, 100));
+    expect(Math.round(clamp(-10))).toBe(0);
+    expect(Math.round(clamp(120))).toBe(100);
   });
 
   it("aria-valuemin is always 0", () => {
@@ -87,7 +104,6 @@ describe("ArcGauge ARIA contract", () => {
 
 describe("ArcGauge SVG geometry", () => {
   it("track strokeDasharray uses ARC_LENGTH and full circumference", () => {
-    // The track shows the 270° background arc
     const trackDash = `${ARC_LENGTH} ${ARC_CIRCUMFERENCE}`;
     expect(trackDash).toContain(ARC_LENGTH.toString());
     expect(trackDash).toContain(ARC_CIRCUMFERENCE.toString());
@@ -98,23 +114,99 @@ describe("ArcGauge SVG geometry", () => {
     const filledLength = (percent / 100) * ARC_LENGTH;
     const valueDash = `${filledLength} ${ARC_CIRCUMFERENCE}`;
     expect(valueDash).toBe(`${filledLength} ${ARC_CIRCUMFERENCE}`);
-    // filledLength should be less than ARC_LENGTH (60% < 100%)
     expect(filledLength).toBeLessThan(ARC_LENGTH);
   });
 
   it("rotation starts at 135° (bottom-left of the arc opening)", () => {
-    // 270° arc centered at bottom → starts 135° from 12 o'clock
     const rotation = 135;
     expect(rotation).toBe(135);
-    // The gap (90°) is at the bottom, so arc spans from 135° to 45° (clockwise)
   });
 
-  it("viewBox and radius are consistent", () => {
-    const viewBoxSize = 64;
-    const center = viewBoxSize / 2; // 32
-    expect(center).toBe(32);
-    // Radius 26 + strokeWidth 5/2 = 28.5, fits within viewBox 64×64
-    expect(ARC_RADIUS + 5 / 2).toBeLessThan(center);
+  it("viewBox and radius are consistent (arc + stroke fits within the box)", () => {
+    const center = ARC_VIEWBOX / 2; // 40
+    expect(center).toBe(40);
+    // Radius + half stroke must stay inside the viewBox half-extent.
+    expect(ARC_RADIUS + ARC_STROKE_WIDTH / 2).toBeLessThan(center);
+  });
+
+  it("gauge is larger than the previous 60px render (bigger visual anchor)", () => {
+    // The gauge now renders at 96px (h-24 w-24) — noticeably bigger.
+    expect(ARC_VIEWBOX).toBeGreaterThan(64);
+    expect(ARC_RADIUS).toBeGreaterThan(26);
+  });
+});
+
+// ── Gradient ramp derivation ────────────────────────────────────────────────
+
+describe("gradientFromStrokeClass", () => {
+  it("derives a multi-stop ramp ending at the class severity", () => {
+    const ramp = gradientFromStrokeClass("stroke-severity-severe");
+    expect(ramp.length).toBeGreaterThanOrEqual(2);
+    expect(ramp[0]).toBe("var(--color-severity-low)");
+    expect(ramp[ramp.length - 1]).toBe("var(--color-severity-severe)");
+  });
+
+  it("low severity still yields at least two stops for a visible sweep", () => {
+    const ramp = gradientFromStrokeClass("stroke-severity-low");
+    expect(ramp.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("extreme severity includes the full ramp", () => {
+    const ramp = gradientFromStrokeClass("stroke-severity-extreme");
+    expect(ramp[ramp.length - 1]).toBe("var(--color-severity-extreme)");
+    expect(ramp).toContain("var(--color-severity-high)");
+  });
+
+  it("pairs the cold token with low (cold isn't part of the linear ramp)", () => {
+    const ramp = gradientFromStrokeClass("stroke-severity-cold");
+    expect(ramp).toEqual(["var(--color-severity-low)", "var(--color-severity-cold)"]);
+  });
+
+  it("falls back to a two-stop ramp for unknown classes", () => {
+    const ramp = gradientFromStrokeClass("stroke-unknown");
+    expect(ramp.length).toBe(2);
+  });
+
+  it("all ramp stops reference CSS custom properties, not hardcoded hex", () => {
+    for (const cls of [
+      "stroke-severity-low",
+      "stroke-severity-moderate",
+      "stroke-severity-high",
+      "stroke-severity-severe",
+      "stroke-severity-extreme",
+    ]) {
+      for (const stop of gradientFromStrokeClass(cls)) {
+        expect(stop).toMatch(/^var\(--/);
+        expect(stop).not.toMatch(/#/);
+      }
+    }
+  });
+});
+
+// ── Value text sizing ───────────────────────────────────────────────────────
+
+describe("valueTextSizeClass", () => {
+  it("uses the largest size for short values", () => {
+    expect(valueTextSizeClass("16°")).toBe("text-2xl");
+    expect(valueTextSizeClass("94%")).toBe("text-2xl");
+    expect(valueTextSizeClass("858")).toBe("text-2xl");
+  });
+
+  it("steps down for 4-character values", () => {
+    expect(valueTextSizeClass("1013")).toBe("text-xl");
+    expect(valueTextSizeClass("12mm")).toBe("text-xl");
+  });
+
+  it("steps down further for longer values so text never collides with the arc", () => {
+    expect(valueTextSizeClass("0.5mm")).toBe("text-lg");
+    expect(valueTextSizeClass("100.0%")).toBe("text-lg");
+    expect(valueTextSizeClass("1013hPa")).toBe("text-sm");
+  });
+
+  it("returns a Tailwind text size class, never a hardcoded value", () => {
+    for (const v of ["1", "12", "123", "1234", "12345", "123456"]) {
+      expect(valueTextSizeClass(v)).toMatch(/^text-/);
+    }
   });
 });
 
@@ -127,25 +219,23 @@ describe("MetricCard props contract", () => {
     expect(defaultColor).toMatch(/^text-/); // Tailwind class
   });
 
-  it("gauge percent is bounded 0-100 for meaningful rendering", () => {
-    // Negative percent would produce negative filledLength (no visual bug, just no arc)
-    const negFill = (-10 / 100) * ARC_LENGTH;
-    expect(negFill).toBeLessThan(0);
-    // Over 100% would exceed the arc (visual overflow, but no crash)
-    const overFill = (120 / 100) * ARC_LENGTH;
-    expect(overFill).toBeGreaterThan(ARC_LENGTH);
+  it("gauge percent is clamped 0-100 for rendering", () => {
+    const clamp = (p: number) => Math.max(0, Math.min(p, 100));
+    expect(clamp(-10)).toBe(0);
+    expect(clamp(120)).toBe(100);
   });
 });
 
 // ── Exports ────────────────────────────────────────────────────────────────
 
 describe("MetricCard exports", () => {
-  it("exports ArcGauge, MetricCard, and GaugeConfig", async () => {
+  it("exports ArcGauge, MetricCard, GaugeConfig, and gradient helpers", async () => {
     const mod = await import("./MetricCard");
     expect(mod.ArcGauge).toBeDefined();
     expect(mod.MetricCard).toBeDefined();
-    // GaugeConfig is a type — just verify the module loads
     expect(typeof mod.ArcGauge).toBe("function");
     expect(typeof mod.MetricCard).toBe("function");
+    expect(typeof mod.gradientFromStrokeClass).toBe("function");
+    expect(typeof mod.valueTextSizeClass).toBe("function");
   });
 });

--- a/src/components/weather/MetricCard.tsx
+++ b/src/components/weather/MetricCard.tsx
@@ -1,68 +1,196 @@
+"use client"
+
 import * as React from "react"
+import { resolveColor } from "@/components/ui/chart"
 
 // ---------------------------------------------------------------------------
 // ArcGauge — radial arc gauge (270° sweep, open at bottom)
-// Uses stroke-dasharray on SVG circle for the filled arc.
+// Uses stroke-dasharray on an SVG circle for the filled arc. The filled arc
+// is painted with a multi-colour SVG <linearGradient> whose stops are the
+// metric's mineral/severity ramp, resolved from globals.css CSS custom
+// properties to concrete colours at render time (mirrors how the Chart.js
+// charts resolve `var(--…)` via resolveColor).
 // ---------------------------------------------------------------------------
+
+// Geometry — a bigger gauge so the arc is the visual anchor of each card and
+// the value text has generous room in the open centre.
+export const ARC_VIEWBOX = 80
+const ARC_CENTER = ARC_VIEWBOX / 2 // 40
+export const ARC_RADIUS = 32
+export const ARC_STROKE_WIDTH = 7
+const ARC_CIRCUMFERENCE = 2 * Math.PI * ARC_RADIUS // ~201.06
+const ARC_SWEEP = 0.75 // 270° / 360°
+const ARC_LENGTH = ARC_CIRCUMFERENCE * ARC_SWEEP // ~150.80
+const ARC_ROTATION = 135 // arc opening centred at the bottom
 
 export interface GaugeConfig {
   /** Value as percentage of the gauge (0-100) */
   percent: number
-  /** CSS class for the stroke color of the filled arc */
+  /** CSS class for the stroke color of the filled arc (severity semantics + fallback) */
   strokeClass: string
+  /**
+   * Optional ordered list of CSS custom-property references (e.g.
+   * `"var(--color-severity-low)"`) forming the multi-colour arc gradient.
+   * When omitted, a gradient is derived from `strokeClass` so every gauge
+   * still sweeps colour.
+   */
+  gradient?: string[]
 }
 
-const ARC_RADIUS = 26
-const ARC_CIRCUMFERENCE = 2 * Math.PI * ARC_RADIUS // ~163.36
-const ARC_SWEEP = 0.75 // 270° / 360°
-const ARC_LENGTH = ARC_CIRCUMFERENCE * ARC_SWEEP // ~122.52
+// Map a severity stroke class to its CSS custom-property token. Used to derive
+// a gradient when a gauge doesn't supply an explicit `gradient` ramp.
+const STROKE_TO_TOKEN: Record<string, string> = {
+  "stroke-severity-low": "var(--color-severity-low)",
+  "stroke-severity-moderate": "var(--color-severity-moderate)",
+  "stroke-severity-high": "var(--color-severity-high)",
+  "stroke-severity-severe": "var(--color-severity-severe)",
+  "stroke-severity-extreme": "var(--color-severity-extreme)",
+  "stroke-severity-cold": "var(--color-severity-cold)",
+}
 
-export function ArcGauge({ percent, strokeClass, value }: GaugeConfig & { value: string }) {
-  const filledLength = (percent / 100) * ARC_LENGTH
+// Ordered severity ramp — the natural malachite→gold→terracotta→red sweep.
+const SEVERITY_RAMP = [
+  "var(--color-severity-low)",
+  "var(--color-severity-moderate)",
+  "var(--color-severity-high)",
+  "var(--color-severity-severe)",
+  "var(--color-severity-extreme)",
+]
+
+/**
+ * Derive a multi-colour gradient ramp from a single severity stroke class.
+ * Produces the ramp from the lowest severity up to (and including) the
+ * class's own severity, so a "severe" gauge sweeps low→moderate→high→severe.
+ */
+export function gradientFromStrokeClass(strokeClass: string): string[] {
+  const token = STROKE_TO_TOKEN[strokeClass]
+  if (!token) return SEVERITY_RAMP.slice(0, 2)
+  // severity-cold isn't part of the linear ramp — pair it with low for a sweep.
+  if (token === "var(--color-severity-cold)") {
+    return ["var(--color-severity-low)", token]
+  }
+  const idx = SEVERITY_RAMP.indexOf(token)
+  if (idx <= 0) return SEVERITY_RAMP.slice(0, 2)
+  return SEVERITY_RAMP.slice(0, idx + 1)
+}
+
+/**
+ * Resolve a list of CSS custom-property tokens to concrete colours, keeping
+ * them in sync with the active theme. Resolves on mount and again whenever
+ * the document's `data-theme` attribute changes (SVG paint servers need
+ * concrete colour values, not `var(--…)` references).
+ */
+function useResolvedColors(tokens: string[]): string[] {
+  const key = tokens.join(",")
+  const [colors, setColors] = React.useState<string[]>(() => tokens.map(resolveColor))
+
+  React.useEffect(() => {
+    const resolve = () => setColors(key.split(",").map(resolveColor))
+    resolve()
+    if (typeof MutationObserver === "undefined") return
+    const observer = new MutationObserver(resolve)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    })
+    return () => observer.disconnect()
+  }, [key])
+
+  return colors
+}
+
+/**
+ * Pick a value text size that fits cleanly inside the gauge's open centre.
+ * Longer strings (e.g. "1013", "12mm") step down so the number never collides
+ * with the arc stroke.
+ */
+export function valueTextSizeClass(value: string): string {
+  const len = value.length
+  if (len <= 3) return "text-2xl"
+  if (len <= 4) return "text-xl"
+  if (len <= 6) return "text-lg"
+  return "text-sm"
+}
+
+export function ArcGauge({ percent, strokeClass, gradient, value }: GaugeConfig & { value: string }) {
+  const clampedPercent = Math.max(0, Math.min(percent, 100))
+  const filledLength = (clampedPercent / 100) * ARC_LENGTH
+
+  // A stable, unique gradient id so multiple gauges on the page don't collide.
+  const rawId = React.useId()
+  const gradientId = `arc-gauge-${rawId.replace(/:/g, "")}`
+
+  const tokens = React.useMemo(
+    () => gradient ?? gradientFromStrokeClass(strokeClass),
+    [gradient, strokeClass],
+  )
+  const resolved = useResolvedColors(tokens)
+  const stops = resolved.length > 0 ? resolved : tokens
 
   return (
     <div
-      className="relative flex shrink-0 items-center justify-center"
+      className="relative flex h-24 w-24 shrink-0 items-center justify-center"
       role="meter"
-      aria-valuenow={Math.round(percent)}
+      aria-valuenow={Math.round(clampedPercent)}
       aria-valuemin={0}
       aria-valuemax={100}
       aria-label={`${value}`}
     >
       <svg
-        width="60"
-        height="60"
-        viewBox="0 0 64 64"
-        className="overflow-visible"
+        viewBox={`0 0 ${ARC_VIEWBOX} ${ARC_VIEWBOX}`}
+        className="h-24 w-24 overflow-visible"
         aria-hidden="true"
       >
+        <defs>
+          {/* Horizontal ramp across the arc's width — the fill reveals more of
+              the ramp as the value grows, so severity reads left→right. */}
+          <linearGradient
+            id={gradientId}
+            gradientUnits="userSpaceOnUse"
+            x1={ARC_CENTER - ARC_RADIUS}
+            y1={ARC_CENTER}
+            x2={ARC_CENTER + ARC_RADIUS}
+            y2={ARC_CENTER}
+          >
+            {stops.map((color, i) => (
+              <stop
+                key={i}
+                offset={stops.length === 1 ? 1 : i / (stops.length - 1)}
+                stopColor={color}
+              />
+            ))}
+          </linearGradient>
+        </defs>
         {/* Track arc (background) */}
         <circle
-          cx="32"
-          cy="32"
+          cx={ARC_CENTER}
+          cy={ARC_CENTER}
           r={ARC_RADIUS}
           fill="none"
           className="stroke-text-tertiary/15"
-          strokeWidth="5"
+          strokeWidth={ARC_STROKE_WIDTH}
           strokeLinecap="round"
           strokeDasharray={`${ARC_LENGTH} ${ARC_CIRCUMFERENCE}`}
-          transform="rotate(135 32 32)"
+          transform={`rotate(${ARC_ROTATION} ${ARC_CENTER} ${ARC_CENTER})`}
         />
-        {/* Value arc (foreground) */}
+        {/* Value arc (foreground) — gradient stroke */}
         <circle
-          cx="32"
-          cy="32"
+          cx={ARC_CENTER}
+          cy={ARC_CENTER}
           r={ARC_RADIUS}
           fill="none"
-          className={`${strokeClass} transition-all duration-500`}
-          strokeWidth="5"
+          stroke={`url(#${gradientId})`}
+          className="transition-all duration-500"
+          strokeWidth={ARC_STROKE_WIDTH}
           strokeLinecap="round"
           strokeDasharray={`${filledLength} ${ARC_CIRCUMFERENCE}`}
-          transform="rotate(135 32 32)"
+          transform={`rotate(${ARC_ROTATION} ${ARC_CENTER} ${ARC_CENTER})`}
         />
       </svg>
-      {/* Value text centered in the arc */}
-      <span className="absolute inset-0 flex items-center justify-center text-base font-bold text-text-primary">
+      {/* Value text — centred above the arc, sized to fit the open area */}
+      <span
+        className={`pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-3 text-center font-bold leading-none tabular-nums text-text-primary ${valueTextSizeClass(value)}`}
+      >
         {value}
       </span>
     </div>


### PR DESCRIPTION
## Summary

Redesigns the **Conditions** metric-card gauges (`ArcGauge` in `MetricCard.tsx`, rendered by `AtmosphericSummary.tsx`) to fix three reported problems: the gauge was too small, the value text collided with the arc stroke, and the arc was a single flat colour.

## Changes

### 1. Bigger gauge (visual anchor)
- Arc now renders at **96px** (`viewBox 80`, radius `32`, stroke `7`) — up from 60px / radius 26. Geometry constants are exported so the tests validate against them.

### 2. Value text no longer collides with the arc
- The number sits in an absolutely-centred span with `z-10` + `pointer-events-none` **above** the arc, horizontally centred.
- New `valueTextSizeClass()` steps the font down for longer strings (`text-2xl` → `text-sm`) so values like `1013` or `0.5mm` fit the open centre.
- Humidity & cloud values are now `Math.round`ed — no more cramped `94.53%`.

### 3. Multi-colour gradient arc
- The filled arc is painted with an in-component SVG `<linearGradient>` whose stops are the metric's mineral/severity ramp.
- Colours are resolved from the existing **globals.css** CSS custom properties to concrete values via `resolveColor` (the same mechanism the Chart.js charts use — SVG paint servers need concrete colours). Ramps stay **theme-reactive** via a `data-theme` `MutationObserver`.
- Ramps: UV / wind / precipitation / feels-like sweep the severity ramp (malachite→gold→terracotta→red→extreme); humidity & pressure use bespoke light→saturated ramps. Any gauge without an explicit ramp (e.g. the AQI card's loading/error states) derives one from `strokeClass`, so nothing else needed touching.

## Contract & constraints preserved
- **ARIA intact**: `role="meter"`, `aria-valuenow` (rounded, clamped 0–100), `aria-valuemin/max`, `aria-label` — verified by `MetricCard.test.ts`.
- **No hardcoded hex** in the component — every colour resolves from existing tokens. No `globals.css` edits.
- `MetricCardSkeleton` bumped to match the larger gauge (prevents layout shift).

## Verification
- `npm test` — **1784 passed** (75 files), includes new gradient/text-fit coverage
- `npx tsc --noEmit` — 0 errors
- `npx eslint` (changed files) — 0 errors, 0 warnings
- `npm run build` — succeeds

## Before / after (gauge)
- **Before**: 60px arc, single flat severity colour, value text (e.g. `94.53%`) overlapping the stroke.
- **After**: 96px arc, multi-colour severity/mineral gradient stroke, rounded value cleanly centred above the arc and auto-sized to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)