### PR TITLE
refactor(db-init): drop country/province weather-DB silos (Phase 0G)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -698,6 +698,8 @@ Database seed data files are read by `/api/db-init` for one-time bootstrap:
 - `src/lib/seed-regions.ts` — supported geographic regions (bounding boxes + center points)
 - `src/lib/seed-seasons.ts` — country-specific season definitions for 50+ countries across Southern Africa, East Africa, West Africa, Central Africa, North Africa, Indian Ocean, and ASEAN. Each country covers all 12 months. Grouped by climate zone using `expand()` helper.
 
+**Countries & provinces are NOT seeded to the weather DB (Phase 0G).** `/api/db-init` no longer writes to `weather.countries` / `weather.provinces` — those silo collections are dropped. The canonical geographic hierarchy (54 countries / 567 provinces / 401 cities) lives in `places.placesGeo`, seeded by Fundi; reads go through `src/lib/places.ts` / `api/py/_places_resolver.py`. The static `COUNTRIES` / `PROVINCES` arrays in `src/lib/countries.ts` remain the display/flag source for `/explore/country`, breadcrumbs, and country/flag rendering — the `getAllCountries` / `getCountryByCode` / `getProvinceBySlug` / `getAllProvinces` / `getProvincesWithLocationCounts` readers in `db.ts` now source from those static arrays, not from any weather-DB collection.
+
 ### Weather Data
 
 **Tomorrow.io (primary):** `src/lib/tomorrow.ts` — Tomorrow.io API client, weather code mapping, and response normalization to the existing `WeatherData` interface.

--- a/src/app/api/db-init/db-init-route.test.ts
+++ b/src/app/api/db-init/db-init-route.test.ts
@@ -40,6 +40,12 @@ describe("/api/db-init route structure", () => {
     expect(source).not.toContain('from "@/lib/locations"');
   });
 
+  it("does NOT sync countries/provinces (Phase 0G — silos dropped, use placesGeo)", () => {
+    expect(source).not.toContain("syncCountries");
+    expect(source).not.toContain("syncProvinces");
+    expect(source).not.toContain('from "@/lib/countries"');
+  });
+
   it("drops the legacy weather.locations collection idempotently", () => {
     expect(source).toContain('dropCollection("locations")');
     expect(source).toContain("ns not found");

--- a/src/app/api/db-init/route.ts
+++ b/src/app/api/db-init/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
-import { ensureIndexes, syncActivities, syncCountries, syncProvinces, syncRegions, syncTags, syncSeasons, syncSuitabilityRules, syncActivityCategories, syncAIPrompts, syncAISuggestedRules, syncAirports, setApiKey } from "@/lib/db";
+import { ensureIndexes, syncActivities, syncRegions, syncTags, syncSeasons, syncSuitabilityRules, syncActivityCategories, syncAIPrompts, syncAISuggestedRules, syncAirports, setApiKey } from "@/lib/db";
 import { weatherDb } from "@/lib/mongo";
 import { ACTIVITIES } from "@/lib/activities";
-import { COUNTRIES, PROVINCES } from "@/lib/countries";
 import { REGIONS } from "@/lib/seed-regions";
 import { TAGS } from "@/lib/seed-tags";
 import { SEASONS } from "@/lib/seed-seasons";
@@ -53,14 +52,14 @@ export async function POST(request: Request) {
     }
 
     await ensureIndexes();
-    // Countries must exist before provinces (provinces reference country codes).
-    await syncCountries(COUNTRIES);
-    // Remaining syncs write to independent collections — run all in parallel.
+    // Sync reference seed data to independent collections — run all in parallel.
     // Phase 0F: location seeding is gone. Mukoko-weather no longer maintains
     // its own siloed `weather.locations` collection — location reads go
     // through `places.placesGeo` via `src/lib/places.ts`.
+    // Phase 0G: country/province seeding is gone too — the canonical geographic
+    // hierarchy lives in `places.placesGeo` (Fundi-seeded); display/flag data
+    // comes from the static COUNTRIES/PROVINCES arrays in `src/lib/countries.ts`.
     await Promise.all([
-      syncProvinces(PROVINCES),
       syncRegions(REGIONS),
       syncTags(TAGS),
       syncSeasons(SEASONS),
@@ -100,8 +99,6 @@ export async function POST(request: Request) {
     return NextResponse.json({
       success: true,
       indexes: "created",
-      countries: COUNTRIES.length,
-      provinces: PROVINCES.length,
       activities: ACTIVITIES.length,
       categories: CATEGORIES.length,
       suitabilityRules: SUITABILITY_RULES.length,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -38,7 +38,7 @@ import { fetchWeatherFromTomorrow, TomorrowRateLimitError } from "./tomorrow";
 import { logWarn, logError } from "./observability";
 import type { WeatherLocation } from "./locations";
 import type { Activity, ActivityCategory } from "./activities";
-import { generateProvinceSlug, type Country, type Province } from "./countries";
+import { generateProvinceSlug, COUNTRIES, PROVINCES, type Country, type Province } from "./countries";
 import type { RegionDoc } from "./seed-regions";
 import type { TagDoc } from "./seed-tags";
 import type { SeasonDoc } from "./seed-seasons";
@@ -175,14 +175,6 @@ function activitiesCollection() {
 
 export function rateLimitsCollection() {
   return weatherDb().collection<{ key: string; count: number; expiresAt: Date }>("rate_limits");
-}
-
-function countriesCollection() {
-  return weatherDb().collection<CountryDoc>("countries");
-}
-
-function provincesCollection() {
-  return weatherDb().collection<ProvinceDoc>("provinces");
 }
 
 function regionsCollection() {
@@ -389,13 +381,10 @@ export async function ensureIndexes(): Promise<void> {
     safeCreateIndex(rateLimitsCollection(), { key: 1 }, { unique: true }),
     safeCreateIndex(rateLimitsCollection(), { expiresAt: 1 }, { expireAfterSeconds: 0 }),
 
-    // Countries: by code (unique), by region
-    safeCreateIndex(countriesCollection(), { code: 1 }, { unique: true }),
-    safeCreateIndex(countriesCollection(), { region: 1 }),
-
-    // Provinces: by slug (unique), by countryCode
-    safeCreateIndex(provincesCollection(), { slug: 1 }, { unique: true }),
-    safeCreateIndex(provincesCollection(), { countryCode: 1 }),
+    // Phase 0G: `weather.countries` / `weather.provinces` are dropped. The
+    // canonical geographic hierarchy lives in `places.placesGeo` (Fundi-seeded);
+    // display/flag data comes from the static COUNTRIES/PROVINCES arrays in
+    // `src/lib/countries.ts`. No indexes are managed here anymore.
 
     // Regions: by id (unique), by active flag
     safeCreateIndex(regionsCollection(), { id: 1 }, { unique: true }),
@@ -1326,54 +1315,34 @@ export async function getActivityCategoryById(id: string): Promise<ActivityCateg
 
 // ---------------------------------------------------------------------------
 // Country operations
+//
+// Phase 0G: `weather.countries` is dropped. Country display/flag/region data
+// comes from the static COUNTRIES array in `src/lib/countries.ts`; the
+// canonical geographic hierarchy lives in `places.placesGeo` (Fundi-seeded).
+// These readers keep their async signatures + CountryDoc return shape so every
+// existing caller (`/explore/country`, breadcrumbs, `[location]/page.tsx`)
+// works unchanged.
 // ---------------------------------------------------------------------------
-
-export async function syncCountries(countries: Country[]): Promise<void> {
-  const now = new Date();
-  const bulkOps = countries.map((c) => ({
-    updateOne: {
-      filter: { code: c.code },
-      update: { $set: { ...c, updatedAt: now } },
-      upsert: true,
-    },
-  }));
-  if (bulkOps.length > 0) {
-    await countriesCollection().bulkWrite(bulkOps);
-  }
-}
-
-export async function upsertCountry(country: Country): Promise<void> {
-  await countriesCollection().updateOne(
-    { code: country.code },
-    {
-      // Always update mutable fields; use $setOnInsert for region so curated
-      // seed data (e.g. "Southern Africa") is never overwritten by "Unknown"
-      // from a geocoding call.
-      $set: { name: country.name, supported: country.supported, updatedAt: new Date() },
-      $setOnInsert: { region: country.region },
-    },
-    { upsert: true },
-  );
-}
 
 /**
  * Returns countries that have at least one location in the static seed
- * catalog. Phase 0F: derives from the static LOCATIONS list (no longer joins
- * against weather.locations, which is dropped).
+ * catalog. Phase 0F/0G: derives entirely from the static LOCATIONS +
+ * COUNTRIES arrays (no weather-DB collection).
  */
 export async function getAllCountries(): Promise<CountryDoc[]> {
   const seededCountries = new Set(
     LOCATIONS.map((l) => (l.country ?? "").toUpperCase()).filter(Boolean),
   );
-  const all = await countriesCollection()
-    .find({ code: { $in: [...seededCountries] } })
-    .sort({ region: 1, name: 1 })
-    .toArray();
-  return all;
+  const now = new Date();
+  return COUNTRIES.filter((c) => seededCountries.has(c.code.toUpperCase()))
+    .sort((a, b) => a.region.localeCompare(b.region) || a.name.localeCompare(b.name))
+    .map((c) => ({ ...c, updatedAt: now }));
 }
 
 export async function getCountryByCode(code: string): Promise<CountryDoc | null> {
-  return countriesCollection().findOne({ code: code.toUpperCase() });
+  const upper = code.toUpperCase();
+  const country = COUNTRIES.find((c) => c.code.toUpperCase() === upper);
+  return country ? { ...country, updatedAt: new Date() } : null;
 }
 
 /** Get a country with the count of its locations (from the static seed catalog). */
@@ -1391,48 +1360,12 @@ export async function getCountryWithStats(
 
 // ---------------------------------------------------------------------------
 // Province operations
+//
+// Phase 0G: `weather.provinces` is dropped. Province display data comes from
+// the static PROVINCES array in `src/lib/countries.ts`; the canonical
+// geographic hierarchy lives in `places.placesGeo` (Fundi-seeded). Readers keep
+// their async signatures + ProvinceDoc return shape for caller compatibility.
 // ---------------------------------------------------------------------------
-
-export async function syncProvinces(provinces: Province[]): Promise<void> {
-  const now = new Date();
-  const bulkOps = provinces.map((p) => ({
-    updateOne: {
-      filter: { slug: p.slug },
-      update: { $set: { ...p, updatedAt: now } },
-      upsert: true,
-    },
-  }));
-  if (bulkOps.length > 0) {
-    await provincesCollection().bulkWrite(bulkOps);
-  }
-}
-
-export async function upsertProvince(province: Province): Promise<void> {
-  await provincesCollection().updateOne(
-    { slug: province.slug },
-    {
-      // name uses $setOnInsert so geocoded data never overwrites curated seed names.
-      // syncProvinces() (db-init) always uses $set and will overwrite with seeded data.
-      $set: { countryCode: province.countryCode, updatedAt: new Date() },
-      $setOnInsert: { name: province.name },
-    },
-    { upsert: true },
-  );
-}
-
-/**
- * Get provinces for a country without location counts.
- * Use `getProvincesWithLocationCounts` instead when rendering province cards
- * that need to show how many locations each province has (avoids N+1 queries).
- * This simpler version is useful when you only need the province list itself
- * (e.g., admin tools, data migration scripts).
- */
-export async function getProvincesByCountry(countryCode: string): Promise<ProvinceDoc[]> {
-  return provincesCollection()
-    .find({ countryCode: countryCode.toUpperCase() })
-    .sort({ name: 1 })
-    .toArray();
-}
 
 export async function getLocationsByCountry(countryCode: string): Promise<LocationDoc[]> {
   const now = new Date();
@@ -1452,14 +1385,18 @@ export async function getLocationsByProvince(provinceSlug: string): Promise<Loca
     .map((loc) => ({ ...loc, updatedAt: now })) as LocationDoc[];
 }
 
-/** Get a single province by its slug */
+/** Get a single province by its slug (from the static PROVINCES catalog) */
 export async function getProvinceBySlug(slug: string): Promise<ProvinceDoc | null> {
-  return provincesCollection().findOne({ slug });
+  const province = PROVINCES.find((p) => p.slug === slug);
+  return province ? { ...province, updatedAt: new Date() } : null;
 }
 
-/** Get all provinces (for sitemap generation) */
+/** Get all provinces (for sitemap generation) from the static PROVINCES catalog */
 export async function getAllProvinces(): Promise<ProvinceDoc[]> {
-  return provincesCollection().find({}).sort({ countryCode: 1, name: 1 }).toArray();
+  const now = new Date();
+  return [...PROVINCES]
+    .sort((a, b) => a.countryCode.localeCompare(b.countryCode) || a.name.localeCompare(b.name))
+    .map((p) => ({ ...p, updatedAt: now }));
 }
 
 /**
@@ -1488,11 +1425,11 @@ export async function getProvincesWithLocationCounts(
   countryCode: string,
 ): Promise<(ProvinceDoc & { locationCount: number })[]> {
   const upper = countryCode.toUpperCase();
+  const now = new Date();
 
-  const provinces = await provincesCollection()
-    .find({ countryCode: upper })
-    .sort({ name: 1 })
-    .toArray();
+  const provinces = PROVINCES.filter((p) => p.countryCode.toUpperCase() === upper)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((p) => ({ ...p, updatedAt: now }));
 
   const countMap = new Map<string, number>();
   for (const loc of LOCATIONS) {


### PR DESCRIPTION
## Summary

`POST /api/db-init` kept resurrecting the legacy `weather.countries` / `weather.provinces` **silo** collections on every deploy — even though they were dropped in Phase 0G. The canonical geographic hierarchy (54 countries / 567 provinces / 401 cities) lives in `places.placesGeo` (Fundi-seeded); display/flag data comes from the static `COUNTRIES` / `PROVINCES` arrays in `src/lib/countries.ts`. This PR stops db-init from recreating the silos and re-points the last DB readers at the static arrays.

## Changes

- **`src/app/api/db-init/route.ts`** — removed the `syncCountries(COUNTRIES)` + `syncProvinces(PROVINCES)` calls, the now-unused `COUNTRIES` / `PROVINCES` import, and the `countries` / `provinces` counts from the response JSON.
- **`src/lib/db.ts`** — removed `syncCountries`, `syncProvinces`, `upsertCountry`, `upsertProvince`, `getProvincesByCountry`, the `countriesCollection` / `provincesCollection` accessors, and the country/province index creations in `ensureIndexes`. **Kept the resilient `safeCreateIndex` / `isIndexConflictError` helper from #56 intact** — only the country/province index lines were removed.
- **`src/lib/db.ts` readers** — `getAllCountries`, `getCountryByCode`, `getProvinceBySlug`, `getAllProvinces`, `getProvincesWithLocationCounts` now source from the static `COUNTRIES` / `PROVINCES` arrays instead of the dropped weather-DB collections. Signatures and `CountryDoc` / `ProvinceDoc` return shapes are unchanged, so `/explore/country`, `/explore/country/[code]`, `/explore/country/[code]/[province]`, breadcrumbs, sitemap, and country/flag display keep working with **no page changes**. (`getCountryWithStats` already delegated to `getCountryByCode` + static `LOCATIONS`, so it needed no edit.)
- Legit weather reference seeds (activities, categories, tags, seasons, suitability rules, ai_prompts, ai_suggested_rules, airports) left exactly as-is.
- Added a db-init route test asserting countries/provinces are **not** synced, and a CLAUDE.md note documenting placesGeo as the source of truth.

## Nothing reads the silos anymore

`grep -rn "countriesCollection\|provincesCollection\|syncCountries\|syncProvinces" src/` → **no matches**. All country/province reads resolve from the static `countries.ts` arrays (display/flag) or `placesGeo` (via `places.ts`).

## Verification

- `npm test` — 1792 passed (76 files)
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors
- `npm run build` — compiles, all pages generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)