### PR TITLE
fix(map): cache Tomorrow.io overlay tiles to stop 429 rate-limit spam

### DIFF
--- a/api/py/_tiles.py
+++ b/api/py/_tiles.py
@@ -5,19 +5,40 @@ Base map tiles are now served directly from MapTiler CDN using the
 NEXT_PUBLIC_MAPTILER_API_KEY client-side variable (no proxy needed).
 This proxy only handles Tomorrow.io weather overlay tiles to keep
 the Tomorrow.io API key server-side.
+
+Rate-limit survival (Tomorrow.io free tier is ~25 req/hour, 500/day, but a
+single map view loads ~16 overlay tiles and every pan/zoom loads more):
+
+  1. **Persistent MongoDB tile cache** — every proxied tile is cached in
+     ``weather.map_tile_cache`` keyed by ``{layer}/{z}/{x}/{y}/{bucket}`` where
+     ``bucket`` snaps the timestamp to the current hour (weather tiles refresh
+     hourly). A cache hit serves the stored bytes without ever touching
+     Tomorrow.io, so re-pans, nearby users, and repeat views are free. Docs
+     carry an ``expiresAt`` field with a TTL index (~90 min) for auto-cleanup.
+  2. **Aggressive CDN caching** — a strong ``Cache-Control`` header lets Vercel's
+     edge serve identical tile URLs without re-invoking the function at all.
+  3. **Graceful degradation** — on a 429 (or any non-200) with no fresh cache we
+     serve a stale cached tile if one exists, otherwise a 1×1 transparent PNG
+     (HTTP 200) so the map simply shows no overlay for that tile instead of
+     spamming the console with failures and killing the whole layer.
+
+SSRF protections (pinned origin, layer whitelist, range-checked coords,
+validated timestamp) are unchanged.
 """
 
 from __future__ import annotations
 
+import base64
 import logging
 import re
+from datetime import datetime, timezone, timedelta
 from typing import Optional
 
 import httpx
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 
-from ._db import get_api_key
+from ._db import get_api_key, stamp_platform_fields, weather_db
 
 router = APIRouter()
 
@@ -34,6 +55,27 @@ VALID_LAYERS = {
 TOMORROW_TILE_ORIGIN = "https://api.tomorrow.io"
 TIMESTAMP_RE = re.compile(r"^(?:now|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)$")
 
+#: Persistent tile-cache TTL — 90 minutes. Comfortably longer than the hourly
+#: tile refresh so a bucket's tiles stay cached for its whole lifetime, short
+#: enough that stale imagery is bounded.
+MAP_TILE_CACHE_TTL_SECONDS = 5400
+
+#: Strong CDN cache for real tiles — Vercel's edge serves identical tile URLs
+#: without re-invoking the function; nearby/repeat viewers never hit the origin.
+TILE_CACHE_CONTROL = "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800"
+
+#: Short cache for the transparent fallback + stale tiles so the edge recovers
+#: quickly once Tomorrow.io's quota resets (rather than caching an empty tile
+#: for a day).
+FALLBACK_CACHE_CONTROL = "public, max-age=300"
+
+#: A 1×1 fully transparent PNG. Returned (HTTP 200) when Tomorrow.io errors and
+#: no cached tile exists, so the overlay renders "nothing here" instead of a
+#: failed request.
+_TRANSPARENT_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
 _http_client: Optional[httpx.Client] = None
 
 
@@ -42,6 +84,126 @@ def _get_http() -> httpx.Client:
     if _http_client is None:
         _http_client = httpx.Client(timeout=8.0)
     return _http_client
+
+
+# ---------------------------------------------------------------------------
+# Persistent tile cache (weather.map_tile_cache)
+# ---------------------------------------------------------------------------
+
+
+def _map_tile_cache_collection():
+    """``weather.map_tile_cache`` — TTL-expiring cache of proxied overlay tiles."""
+    return weather_db()["map_tile_cache"]
+
+
+def _timestamp_bucket(timestamp: str) -> str:
+    """
+    Snap a tile timestamp to a stable ~1h cache bucket.
+
+    Tomorrow.io weather tiles update hourly, so ``"now"`` resolves to the
+    current UTC hour — every request within the same hour shares one cache key
+    and therefore one upstream fetch. An explicit ISO timestamp is already a
+    fixed point in time, so it's used verbatim.
+    """
+    if timestamp == "now":
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:00:00Z")
+    return timestamp
+
+
+def _cache_id(layer: str, z: int, x: int, y: int, bucket: str) -> str:
+    """Deterministic ``_id`` for a tile — repeat requests upsert one row."""
+    return f"{layer}/{z}/{x}/{y}/{bucket}"
+
+
+def _get_cached_tile(cache_id: str, *, allow_stale: bool = False) -> Optional[bytes]:
+    """
+    Read a cached tile's bytes, or ``None`` on miss / DB error.
+
+    With ``allow_stale=False`` (default) only non-expired docs are returned.
+    With ``allow_stale=True`` the ``expiresAt`` filter is dropped so a stale
+    tile can still be served when the upstream is failing. Any DB error is
+    swallowed — the caller falls through to Tomorrow.io / the transparent tile.
+    """
+    try:
+        query: dict = {"_id": cache_id}
+        if not allow_stale:
+            query["expiresAt"] = {"$gt": datetime.now(timezone.utc)}
+        doc = _map_tile_cache_collection().find_one(query)
+        if not doc:
+            return None
+        tile_b64 = doc.get("tile")
+        if not tile_b64:
+            return None
+        return base64.b64decode(tile_b64)
+    except Exception:
+        return None
+
+
+def _set_cached_tile(cache_id: str, layer: str, tile_bytes: bytes) -> None:
+    """
+    Upsert a tile into the cache using the deterministic ``_id``.
+
+    Dedup discipline (Phase 0E): the same ``_id`` is always upserted, so two
+    concurrent requests for the same tile end up with one row, not two. Cache
+    write failures never break the response — they're swallowed silently.
+    """
+    now = datetime.now(timezone.utc)
+    doc = {
+        "_id": cache_id,
+        "layer": layer,
+        "tile": base64.b64encode(tile_bytes).decode("ascii"),
+        "fetchedAt": now,
+        "expiresAt": now + timedelta(seconds=MAP_TILE_CACHE_TTL_SECONDS),
+    }
+    stamp_platform_fields(doc)
+    try:
+        _map_tile_cache_collection().update_one(
+            {"_id": cache_id}, {"$set": doc}, upsert=True
+        )
+    except Exception:
+        pass
+
+
+def _tile_response(content: bytes, layer: str, cache_status: str) -> Response:
+    """A real (or cached) PNG tile with strong CDN caching."""
+    return Response(
+        content=content,
+        media_type="image/png",
+        headers={
+            "Cache-Control": TILE_CACHE_CONTROL,
+            "X-Map-Layer": layer,
+            "X-Cache": cache_status,
+        },
+    )
+
+
+def _stale_tile_response(content: bytes, layer: str) -> Response:
+    """A stale cached PNG tile served during an upstream outage (short cache)."""
+    return Response(
+        content=content,
+        media_type="image/png",
+        headers={
+            "Cache-Control": FALLBACK_CACHE_CONTROL,
+            "X-Map-Layer": layer,
+            "X-Cache": "STALE",
+        },
+    )
+
+
+def _transparent_tile_response() -> Response:
+    """
+    A 1×1 transparent PNG (HTTP 200) served when Tomorrow.io errors and there's
+    no cached tile — the map shows no overlay for this tile instead of erroring.
+    """
+    return Response(
+        content=_TRANSPARENT_PNG,
+        media_type="image/png",
+        headers={
+            "Cache-Control": FALLBACK_CACHE_CONTROL,
+            "X-Cache": "MISS",
+            "X-Map-Tile": "empty",
+        },
+    )
 
 
 @router.get("/api/py/map-tiles")
@@ -57,6 +219,11 @@ async def proxy_map_tile(
 
     Proxy weather overlay tiles from Tomorrow.io, keeping the API key server-side.
     SSRF protection: pinned origin, whitelist layers, range-checked coords.
+
+    Serves from the persistent MongoDB tile cache on a hit (no upstream call);
+    on a miss fetches from Tomorrow.io, caches the result, and returns it. When
+    Tomorrow.io rate-limits (429) or errors, serves a stale cached tile if one
+    exists, otherwise a transparent 1×1 PNG so the layer degrades gracefully.
     """
     if layer not in VALID_LAYERS:
         raise HTTPException(status_code=400, detail="Invalid layer")
@@ -70,6 +237,14 @@ async def proxy_map_tile(
 
     if not TIMESTAMP_RE.match(timestamp):
         raise HTTPException(status_code=400, detail="Invalid timestamp")
+
+    bucket = _timestamp_bucket(timestamp)
+    cache_id = _cache_id(layer, z, x, y, bucket)
+
+    # 1. Serve from persistent cache if we have a fresh tile — no upstream call.
+    cached = _get_cached_tile(cache_id)
+    if cached is not None:
+        return _tile_response(cached, layer, "HIT")
 
     try:
         api_key = get_api_key("tomorrow")
@@ -86,27 +261,34 @@ async def proxy_map_tile(
         client = _get_http()
         resp = client.get(tile_url)
 
-        if resp.status_code == 429:
-            logger.warning("Tomorrow.io tile rate limited (429) for layer=%s z=%s", layer, z)
-            return Response(status_code=429)
-
+        # 2. Upstream error (429 rate limit or anything non-200) — degrade
+        #    gracefully: serve a stale cached tile if we have one, else a
+        #    transparent tile so the console isn't flooded and the layer survives.
         if resp.status_code != 200:
-            logger.warning(
-                "Tomorrow.io tile upstream error: status=%s layer=%s z/x/y=%s/%s/%s",
-                resp.status_code, layer, z, x, y,
-            )
-            return Response(status_code=resp.status_code)
+            if resp.status_code == 429:
+                logger.warning(
+                    "Tomorrow.io tile rate limited (429) for layer=%s z=%s", layer, z
+                )
+            else:
+                logger.warning(
+                    "Tomorrow.io tile upstream error: status=%s layer=%s z/x/y=%s/%s/%s",
+                    resp.status_code, layer, z, x, y,
+                )
+            stale = _get_cached_tile(cache_id, allow_stale=True)
+            if stale is not None:
+                return _stale_tile_response(stale, layer)
+            return _transparent_tile_response()
 
-        return Response(
-            content=resp.content,
-            media_type="image/png",
-            headers={
-                "Cache-Control": "public, max-age=300, s-maxage=300",
-                "X-Map-Layer": layer,
-            },
-        )
+        # 3. Fresh tile — persist to cache and return with strong CDN caching.
+        _set_cached_tile(cache_id, layer, resp.content)
+        return _tile_response(resp.content, layer, "MISS")
     except HTTPException:
         raise
     except Exception:
         logger.exception("Tomorrow.io tile proxy failed for layer=%s z/x/y=%s/%s/%s", layer, z, x, y)
-        return Response(status_code=502)
+        # Network/unexpected failure — serve a stale tile if we have one so the
+        # overlay survives a transient blip, otherwise a transparent tile.
+        stale = _get_cached_tile(cache_id, allow_stale=True)
+        if stale is not None:
+            return _stale_tile_response(stale, layer)
+        return _transparent_tile_response()

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -432,6 +432,11 @@ export async function ensureIndexes(): Promise<void> {
     // so the unique-by-_id index MongoDB provides for free is the only key index needed.
     safeCreateIndex(weatherDb().collection("air_quality_cache"), { expiresAt: 1 }, { expireAfterSeconds: 0 }),
 
+    // Map tile cache: ~90-min TTL — _id is deterministic ({layer}/{z}/{x}/{y}/{hourBucket}),
+    // so the unique-by-_id index MongoDB provides for free is the only key index needed.
+    // Drastically cuts Tomorrow.io overlay-tile calls (free tier is ~25 req/hour).
+    safeCreateIndex(weatherDb().collection("map_tile_cache"), { expiresAt: 1 }, { expireAfterSeconds: 0 }),
+
     // Airports: ICAO reference data for METAR/TAF. `_id` is the ICAO code
     // (unique for free); the 2dsphere index powers the $nearSphere
     // nearest-airport lookup in api/py/_airports.py.

--- a/tests/py/test_tiles.py
+++ b/tests/py/test_tiles.py
@@ -6,6 +6,8 @@ from MapTiler CDN using the NEXT_PUBLIC_MAPTILER_API_KEY client-side variable.
 
 from __future__ import annotations
 
+import base64
+from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -14,6 +16,11 @@ from fastapi import HTTPException
 from py._tiles import (
     VALID_LAYERS,
     TIMESTAMP_RE,
+    TILE_CACHE_CONTROL,
+    MAP_TILE_CACHE_TTL_SECONDS,
+    _TRANSPARENT_PNG,
+    _cache_id,
+    _timestamp_bucket,
     proxy_map_tile,
 )
 
@@ -123,10 +130,12 @@ class TestProxyMapTile:
         assert exc_info.value.status_code == 503
         assert "Map service unavailable" in exc_info.value.detail
 
+    @patch("py._tiles._get_cached_tile", return_value=None)
+    @patch("py._tiles._set_cached_tile")
     @patch("py._tiles._get_http")
     @patch("py._tiles.get_api_key")
     @pytest.mark.asyncio
-    async def test_successful_proxy_returns_png(self, mock_key, mock_http):
+    async def test_successful_proxy_returns_png(self, mock_key, mock_http, mock_set, mock_get):
         mock_key.return_value = "test-api-key"
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -136,42 +145,58 @@ class TestProxyMapTile:
         result = await proxy_map_tile(z=5, x=18, y=17, layer="temperature")
         assert result.media_type == "image/png"
         assert result.body == b"\x89PNG\r\n\x1a\n"
-        assert "max-age=300" in result.headers.get("cache-control", "")
+        # Fresh tiles carry the strong CDN cache header, not the old max-age=300.
+        assert "s-maxage=86400" in result.headers.get("cache-control", "")
+        assert "stale-while-revalidate" in result.headers.get("cache-control", "")
         assert result.headers.get("x-map-layer") == "temperature"
+        assert result.headers.get("x-cache") == "MISS"
+        # The fetched tile is persisted to the cache.
+        mock_set.assert_called_once()
 
+    @patch("py._tiles._get_cached_tile", return_value=None)
     @patch("py._tiles._get_http")
     @patch("py._tiles.get_api_key")
     @pytest.mark.asyncio
-    async def test_rate_limited_proxied(self, mock_key, mock_http):
+    async def test_rate_limited_returns_transparent_tile(self, mock_key, mock_http, mock_get):
+        """429 with no cache → transparent 1×1 PNG (HTTP 200), not a 429."""
         mock_key.return_value = "test-api-key"
         mock_response = MagicMock()
         mock_response.status_code = 429
         mock_http.return_value.get.return_value = mock_response
 
         result = await proxy_map_tile(z=5, x=18, y=17, layer="temperature")
-        assert result.status_code == 429
+        assert result.status_code == 200
+        assert result.media_type == "image/png"
+        assert result.body == _TRANSPARENT_PNG
+        assert result.headers.get("x-map-tile") == "empty"
 
+    @patch("py._tiles._get_cached_tile", return_value=None)
     @patch("py._tiles._get_http")
     @patch("py._tiles.get_api_key")
     @pytest.mark.asyncio
-    async def test_non_200_status_proxied(self, mock_key, mock_http):
+    async def test_non_200_status_returns_transparent_tile(self, mock_key, mock_http, mock_get):
+        """Any non-200 with no cache → transparent tile (HTTP 200)."""
         mock_key.return_value = "test-api-key"
         mock_response = MagicMock()
         mock_response.status_code = 500
         mock_http.return_value.get.return_value = mock_response
 
         result = await proxy_map_tile(z=5, x=18, y=17, layer="temperature")
-        assert result.status_code == 500
+        assert result.status_code == 200
+        assert result.body == _TRANSPARENT_PNG
 
     @patch("py._tiles._get_http")
     @patch("py._tiles.get_api_key")
     @pytest.mark.asyncio
-    async def test_exception_returns_502(self, mock_key, mock_http):
+    async def test_exception_returns_transparent_tile(self, mock_key, mock_http):
+        """A network exception with no cache → transparent tile (HTTP 200)."""
         mock_key.return_value = "test-api-key"
         mock_http.return_value.get.side_effect = Exception("Network error")
 
-        result = await proxy_map_tile(z=5, x=18, y=17, layer="temperature")
-        assert result.status_code == 502
+        with patch("py._tiles._get_cached_tile", return_value=None):
+            result = await proxy_map_tile(z=5, x=18, y=17, layer="temperature")
+        assert result.status_code == 200
+        assert result.body == _TRANSPARENT_PNG
 
     @patch("py._tiles._get_http")
     @patch("py._tiles.get_api_key")
@@ -190,3 +215,132 @@ class TestProxyMapTile:
         assert url.startswith("https://api.tomorrow.io/")
         assert "/5/18/17/windSpeed/now.png" in url
         assert "apikey=my-key" in url
+
+
+# ---------------------------------------------------------------------------
+# Cache key helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCacheHelpers:
+    def test_timestamp_bucket_now_snaps_to_current_hour(self):
+        bucket = _timestamp_bucket("now")
+        expected = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:00:00Z")
+        assert bucket == expected
+        # Bucket is minute/second agnostic — always ...T HH:00:00Z.
+        assert bucket.endswith(":00:00Z")
+
+    def test_timestamp_bucket_explicit_is_verbatim(self):
+        ts = "2026-01-15T12:00:00Z"
+        assert _timestamp_bucket(ts) == ts
+
+    def test_cache_id_is_deterministic(self):
+        a = _cache_id("temperature", 5, 18, 17, "2026-01-15T12:00:00Z")
+        b = _cache_id("temperature", 5, 18, 17, "2026-01-15T12:00:00Z")
+        assert a == b
+        assert a == "temperature/5/18/17/2026-01-15T12:00:00Z"
+
+    def test_cache_id_varies_by_layer_and_coords(self):
+        base = _cache_id("temperature", 5, 18, 17, "b")
+        assert _cache_id("windSpeed", 5, 18, 17, "b") != base
+        assert _cache_id("temperature", 6, 18, 17, "b") != base
+        assert _cache_id("temperature", 5, 19, 17, "b") != base
+
+
+# ---------------------------------------------------------------------------
+# Persistent tile cache — hit / miss / stale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTileCache:
+    async def test_cache_hit_serves_without_upstream_call(self):
+        """A fresh cached tile is served without ever hitting Tomorrow.io."""
+        tile_bytes = b"\x89PNG-cached"
+        mock_collection = MagicMock()
+        mock_collection.find_one.return_value = {
+            "_id": "temperature/5/18/17/bucket",
+            "tile": base64.b64encode(tile_bytes).decode("ascii"),
+            "expiresAt": datetime.now(timezone.utc),
+        }
+
+        with patch("py._tiles._map_tile_cache_collection", return_value=mock_collection):
+            with patch("py._tiles.get_api_key") as mock_key:
+                with patch("py._tiles._get_http") as mock_http:
+                    result = await proxy_map_tile(z=5, x=18, y=17, layer="temperature")
+
+        # Neither the API key nor the HTTP client should be touched on a hit.
+        mock_key.assert_not_called()
+        mock_http.assert_not_called()
+        assert result.status_code == 200
+        assert result.body == tile_bytes
+        assert result.headers.get("x-cache") == "HIT"
+        assert TILE_CACHE_CONTROL == result.headers.get("cache-control")
+
+    async def test_cache_miss_fetches_and_writes(self):
+        """On a miss, Tomorrow.io is fetched and the tile is written to cache."""
+        tile_bytes = b"\x89PNG-fresh"
+        mock_collection = MagicMock()
+        mock_collection.find_one.return_value = None  # miss
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = tile_bytes
+
+        with patch("py._tiles._map_tile_cache_collection", return_value=mock_collection):
+            with patch("py._tiles.get_api_key", return_value="test-key"):
+                with patch("py._tiles._get_http") as mock_http:
+                    mock_http.return_value.get.return_value = mock_response
+                    result = await proxy_map_tile(z=5, x=18, y=17, layer="temperature")
+
+        assert result.headers.get("x-cache") == "MISS"
+        assert result.body == tile_bytes
+        # Upsert persisted the tile under the deterministic _id.
+        assert mock_collection.update_one.called
+        args = mock_collection.update_one.call_args
+        assert args.kwargs["upsert"] is True
+        # Filter and the stored doc share the same deterministic _id.
+        assert args.args[0]["_id"] == "temperature/5/18/17/" + _timestamp_bucket("now")
+        assert args.args[1]["$set"]["_id"] == args.args[0]["_id"]
+        assert args.args[1]["$set"]["expiresAt"] > args.args[1]["$set"]["fetchedAt"]
+
+    async def test_rate_limit_serves_stale_when_available(self):
+        """429 with a stale cached tile → serve the stale tile, not transparent."""
+        stale_bytes = b"\x89PNG-stale"
+
+        def fake_get_cached(cache_id, *, allow_stale=False):
+            # Fresh lookup misses; stale lookup hits.
+            return stale_bytes if allow_stale else None
+
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+
+        with patch("py._tiles._get_cached_tile", side_effect=fake_get_cached):
+            with patch("py._tiles.get_api_key", return_value="test-key"):
+                with patch("py._tiles._get_http") as mock_http:
+                    mock_http.return_value.get.return_value = mock_response
+                    result = await proxy_map_tile(z=5, x=18, y=17, layer="temperature")
+
+        assert result.status_code == 200
+        assert result.body == stale_bytes
+        assert result.headers.get("x-cache") == "STALE"
+
+    async def test_cache_write_failure_does_not_break_response(self):
+        """A DB write error on cache-set must not fail the tile response."""
+        tile_bytes = b"\x89PNG-fresh"
+        mock_collection = MagicMock()
+        mock_collection.find_one.return_value = None
+        mock_collection.update_one.side_effect = Exception("db down")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = tile_bytes
+
+        with patch("py._tiles._map_tile_cache_collection", return_value=mock_collection):
+            with patch("py._tiles.get_api_key", return_value="test-key"):
+                with patch("py._tiles._get_http") as mock_http:
+                    mock_http.return_value.get.return_value = mock_response
+                    result = await proxy_map_tile(z=5, x=18, y=17, layer="temperature")
+
+        assert result.status_code == 200
+        assert result.body == tile_bytes


### PR DESCRIPTION
## Problem

The live weather map overlay tiles return **HTTP 429** — the browser console fills with `[weather-map] overlay tile failed to load … (429): /api/py/map-tiles?...&layer=cloudCover`, and the overlay layer blanks out.

**Root cause:** Tomorrow.io's free tier is only ~25 requests/hour / 500/day, but a single map view loads ~16 overlay tiles at once (and every pan/zoom loads more), so the quota is exhausted almost immediately.

## Fix — `api/py/_tiles.py`

1. **Persistent MongoDB tile cache** (`weather.map_tile_cache`) keyed by `{layer}/{z}/{x}/{y}/{hourBucket}` with a deterministic `_id` and ~90-min TTL, mirroring the existing `air_quality_cache` pattern (base64 tile bytes, `stamp_platform_fields`, upsert-by-`_id` dedup discipline). The timestamp is bucketed to the current UTC hour since weather tiles refresh hourly, so every request within the hour shares one cache key → **one upstream fetch**. Cache hits serve stored bytes with **zero** Tomorrow.io calls, so re-pans, nearby users, and repeat views are free.
2. **Aggressive CDN caching** — `Cache-Control: public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800` so Vercel's edge serves identical tile URLs without re-invoking the function.
3. **Graceful 429 / error handling** — on any non-200 (429 or upstream error) or a network exception: serve a **stale** cached tile if one exists, otherwise a **1×1 transparent PNG (HTTP 200)** with a short cache. The map simply shows no overlay for that tile instead of error-spamming the console and failing the whole layer.
4. **Unchanged:** layer whitelist, pinned-origin/coord-range/timestamp SSRF protections, and the 503-on-missing-API-key behaviour.

## Also

- `src/lib/db.ts` — added a `map_tile_cache` TTL index (`expireAfterSeconds: 0` on `expiresAt`) alongside `air_quality_cache`.
- `tests/py/test_tiles.py` — extended to cover cache **hit** (no upstream call) / **miss** (fetch + write), **429 → transparent tile**, **429 → stale tile when available**, cache-write-failure resilience, and the bucket / cache-key helpers. Existing 429/non-200 tests updated to assert the new transparent-tile behaviour.
- **Frontend** (`src/components/weather/map/*`): no change needed — the overlay is only re-added on layer/theme change (not on every pan/zoom), and the service worker already does `CacheFirst` on `/api/py/map-tiles` (500 entries / 24h). The proxy cache is the main fix.

## Verification

- `python3 -m pytest tests/py/ -q` → **916 passed**
- `npm test` → **1791 passed**
- `npx tsc --noEmit` → clean
- `npm run lint` → **0 errors** (pre-existing warnings only)

## Longer-term note

Tomorrow.io's free tier is fundamentally too low for tile maps. This PR makes the map survive the limit gracefully, but the real fix is a **paid Tomorrow.io tier** — or a **free radar source like RainViewer** for the precipitation layer. Recommend tracking that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
