### PR TITLE
fix(pwa): auto-update installed Android PWA instead of serving stale shell

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,16 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // The service worker script must never be served stale — always
+        // revalidate so a new deploy's /sw.js is fetched, letting the
+        // ServiceWorkerUpdater detect the new version and auto-reload.
+        source: "/sw.js",
+        headers: [
+          { key: "Cache-Control", value: "no-cache, no-store, must-revalidate" },
+          { key: "Service-Worker-Allowed", value: "/" },
+        ],
+      },
+      {
         // Allow embed endpoints to be loaded from any origin
         source: "/embed/:path*",
         headers: [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { MineralsStripe } from "@/components/brand/MineralsStripe";
 import { ThemeProvider } from "@/components/brand/ThemeProvider";
 import { GoogleAnalytics } from "@/components/analytics/GoogleAnalytics";
 import { PWAInstallPrompt } from "@/components/weather/PWAInstallPrompt";
+import { ServiceWorkerUpdater } from "@/components/pwa/ServiceWorkerUpdater";
 import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
@@ -340,6 +341,7 @@ export default async function RootLayout({
             <PWAInstallPrompt />
           </ThemeProvider>
         </AuthKitProvider>
+        <ServiceWorkerUpdater />
         <Analytics />
       </body>
     </html>

--- a/src/components/pwa/ServiceWorkerUpdater.test.ts
+++ b/src/components/pwa/ServiceWorkerUpdater.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for ServiceWorkerUpdater — validates the update-detection + auto-reload
+ * logic and that it does NOT re-register the SW (@serwist/next already does).
+ * Reads source file directly (source-string checks, repo Vitest style).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const source = readFileSync(
+  resolve(__dirname, "ServiceWorkerUpdater.tsx"),
+  "utf-8",
+);
+const layoutSource = readFileSync(
+  resolve(__dirname, "../../app/layout.tsx"),
+  "utf-8",
+);
+const nextConfigSource = readFileSync(
+  resolve(__dirname, "../../../next.config.ts"),
+  "utf-8",
+);
+
+describe("ServiceWorkerUpdater — component structure", () => {
+  it("is a client component", () => {
+    expect(source).toContain('"use client"');
+  });
+
+  it("exports ServiceWorkerUpdater function", () => {
+    expect(source).toContain("export function ServiceWorkerUpdater");
+  });
+
+  it("renders null (no UI)", () => {
+    expect(source).toContain("return null");
+  });
+
+  it("does not depend on the store or RxDB", () => {
+    expect(source).not.toContain("useAppStore");
+    expect(source).not.toContain("rxdb");
+    expect(source).not.toContain("store");
+  });
+});
+
+describe("ServiceWorkerUpdater — does NOT re-register the SW", () => {
+  it("never calls register() — @serwist/next already registers the SW", () => {
+    expect(source).not.toContain(".register(");
+    expect(source).not.toContain("serviceWorker.register");
+  });
+});
+
+describe("ServiceWorkerUpdater — feature detection / defensiveness", () => {
+  it("guards on serviceWorker support", () => {
+    expect(source).toContain('"serviceWorker" in navigator');
+  });
+
+  it("guards against undefined navigator (SSR-safe)", () => {
+    expect(source).toContain('typeof navigator === "undefined"');
+  });
+
+  it("wraps side effects in try/catch", () => {
+    expect(source).toContain("try {");
+    expect(source).toContain("catch");
+  });
+});
+
+describe("ServiceWorkerUpdater — auto-reload on controller swap", () => {
+  it("listens for controllerchange", () => {
+    expect(source).toContain('"controllerchange"');
+  });
+
+  it("reloads the page when a new SW takes control", () => {
+    expect(source).toContain("window.location.reload()");
+  });
+
+  it("uses a module-level guard to reload at most once (no loops)", () => {
+    expect(source).toMatch(/let reloaded = false/);
+    expect(source).toContain("if (reloaded) return");
+    expect(source).toContain("reloaded = true");
+  });
+
+  it("skips the initial claim when there was no controller at page load", () => {
+    expect(source).toContain("hadControllerAtLoad");
+    // reads navigator.serviceWorker.controller (aliased to sw) at page load
+    expect(source).toContain("Boolean(sw.controller)");
+    expect(source).toContain("if (!hadControllerAtLoad) return");
+  });
+});
+
+describe("ServiceWorkerUpdater — update checks", () => {
+  it("calls registration.update() to check for a new SW", () => {
+    expect(source).toContain("getRegistration()");
+    expect(source).toContain(".update()");
+  });
+
+  it("re-checks when the document becomes visible", () => {
+    expect(source).toContain('"visibilitychange"');
+    expect(source).toContain('document.visibilityState === "visible"');
+  });
+
+  it("re-checks on window focus", () => {
+    expect(source).toContain('"focus"');
+  });
+
+  it("checks once on mount", () => {
+    expect(source).toContain("checkForUpdate()");
+  });
+
+  it("cleans up its listeners on unmount", () => {
+    expect(source).toContain("removeEventListener");
+  });
+});
+
+describe("ServiceWorkerUpdater — mounted in layout", () => {
+  it("is imported in the root layout", () => {
+    expect(layoutSource).toContain("ServiceWorkerUpdater");
+    expect(layoutSource).toContain(
+      '@/components/pwa/ServiceWorkerUpdater',
+    );
+  });
+
+  it("is rendered in the layout tree", () => {
+    expect(layoutSource).toContain("<ServiceWorkerUpdater />");
+  });
+});
+
+describe("next.config.ts — /sw.js is never cached", () => {
+  it("adds a no-store Cache-Control header for /sw.js", () => {
+    expect(nextConfigSource).toContain("/sw.js");
+    expect(nextConfigSource).toContain("no-cache, no-store, must-revalidate");
+  });
+
+  it("sets Service-Worker-Allowed to root scope", () => {
+    expect(nextConfigSource).toContain("Service-Worker-Allowed");
+  });
+
+  it("keeps the existing embed + API header blocks intact", () => {
+    expect(nextConfigSource).toContain("/embed/:path*");
+    expect(nextConfigSource).toContain("/api/:path*");
+  });
+});

--- a/src/components/pwa/ServiceWorkerUpdater.tsx
+++ b/src/components/pwa/ServiceWorkerUpdater.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+/**
+ * ServiceWorkerUpdater — makes the Serwist PWA auto-update instead of serving
+ * stale content until a hard refresh.
+ *
+ * Two problems this solves on Android (and desktop) PWAs:
+ *   (a) When a new version deploys, the new service worker activates (skipWaiting)
+ *       but the already-open page/PWA window doesn't reload — so the user keeps
+ *       seeing the old shell.
+ *   (b) An INSTALLED Android PWA doesn't re-check for a new SW when reopened, so
+ *       users never even discover the new version.
+ *
+ * This component does NOT register the service worker — `@serwist/next` already
+ * does that (register defaults to true). It only layers update-detection +
+ * auto-reload on top:
+ *   - On mount + whenever the document becomes visible again (visibilitychange)
+ *     + on window focus, it calls registration.update() to force a fresh check
+ *     of /sw.js. With skipWaiting the new SW activates immediately.
+ *   - A one-time guarded `controllerchange` listener reloads the page exactly
+ *     once when a NEW service worker takes control — but only on a genuine
+ *     controller *swap*, never on the first controllerchange fired during the
+ *     initial registration (when there was no prior controller at page load).
+ *
+ * Renders nothing. Fully defensive — no-ops when Service Workers are unsupported.
+ */
+
+import { useEffect } from "react";
+
+// Module-level guard: survives re-mounts, ensures we only ever reload once even
+// if multiple controllerchange events fire.
+let reloaded = false;
+
+export function ServiceWorkerUpdater() {
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+      return;
+    }
+
+    const sw = navigator.serviceWorker;
+
+    // Snapshot whether a controller already existed at page load. If it was
+    // null, the FIRST controllerchange is the initial registration taking
+    // control (clientsClaim) — reloading then would be a spurious reload on
+    // first visit. We only want to reload on a genuine controller *swap*.
+    const hadControllerAtLoad = Boolean(sw.controller);
+
+    const handleControllerChange = () => {
+      if (reloaded) return;
+      // Skip the very first controllerchange when there was no controller at
+      // page load — that's the initial claim, not a version swap.
+      if (!hadControllerAtLoad) return;
+      reloaded = true;
+      try {
+        window.location.reload();
+      } catch {
+        // no-op — reload is best-effort
+      }
+    };
+
+    // Ask the browser to re-check /sw.js for a newer worker. With skipWaiting
+    // set in the SW, a newer worker activates → fires controllerchange → reload.
+    const checkForUpdate = () => {
+      try {
+        sw.getRegistration()
+          .then((registration) => registration?.update())
+          .catch(() => {
+            // no-op — update check is best-effort
+          });
+      } catch {
+        // no-op — some browsers throw synchronously when unsupported
+      }
+    };
+
+    // Only re-check when the tab actually becomes visible (reopening an
+    // installed PWA fires this), not when it's being hidden.
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        checkForUpdate();
+      }
+    };
+
+    try {
+      sw.addEventListener("controllerchange", handleControllerChange);
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+      window.addEventListener("focus", checkForUpdate);
+      // Check once on mount so a page that was left open picks up a deploy.
+      checkForUpdate();
+    } catch {
+      // no-op — wiring listeners should never break the app
+    }
+
+    return () => {
+      try {
+        sw.removeEventListener("controllerchange", handleControllerChange);
+        document.removeEventListener("visibilitychange", handleVisibilityChange);
+        window.removeEventListener("focus", checkForUpdate);
+      } catch {
+        // no-op
+      }
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Problem

The app is a Serwist PWA. The service worker (`src/app/sw.ts`) already sets `skipWaiting`, `clientsClaim`, and `cleanupOutdatedCaches`, and `@serwist/next` auto-injects SW registration. But on Android (and desktop):

- **(a)** When a new version deploys, the new SW activates — but the already-open page / installed PWA window **doesn't reload**, so the user keeps seeing the old shell.
- **(b)** An **installed Android PWA doesn't re-check** for a new SW when reopened, so users never even discover the new version — stale until a hard refresh.

## Fix (update-detection + auto-reload only — does NOT re-register the SW)

1. **New client component** `src/components/pwa/ServiceWorkerUpdater.tsx` (`"use client"`, renders `null`):
   - **Update checks** — calls `navigator.serviceWorker.getRegistration().then(r => r?.update())` on mount, on `visibilitychange` → document becomes visible, and on `focus`. Reopening an installed PWA now forces a fresh fetch of `/sw.js`; with `skipWaiting` the new SW activates immediately.
   - **Auto-reload** — a one-time guarded `controllerchange` listener calls `window.location.reload()` **exactly once** when a new SW takes control. Guards against reload loops via a module-level `let reloaded = false` **and** skips the very first `controllerchange` (the initial `clientsClaim`) when there was no controller at page load — only a genuine controller *swap* reloads.
   - Fully defensive: SSR-safe, feature-detected, all side effects in try/catch, listeners cleaned up on unmount. No UI, no store/RxDB dependency.

2. **Mounted** in `src/app/layout.tsx` near the other providers/analytics. Renders nothing.

3. **`next.config.ts` `headers()`** — added a `/sw.js` route with `Cache-Control: no-cache, no-store, must-revalidate` + `Service-Worker-Allowed: /` so the browser always revalidates the worker script and never serves a stale SW. Existing embed/API header blocks left intact.

Runtime caching strategies in `sw.ts` are unchanged — the fix is update-detection + auto-reload, not cache removal.

## How the auto-update works end-to-end

Deploy ships new `/sw.js` → user reopens PWA / tab regains visibility → `registration.update()` fetches the fresh (non-cached) `/sw.js` → new SW installs and (via `skipWaiting`) activates → `controllerchange` fires → guarded listener reloads the page once → user sees the new version. No hard refresh needed.

## Verification

- `npm test` — 77 files, 1831 tests pass (incl. new co-located `ServiceWorkerUpdater.test.ts`, 22 tests)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — compiles, `(serwist) Bundling the service worker` succeeds, `public/sw.js` generated, all 185 pages generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)