### PR TITLE
fix(auth): return to app instantly after sign-in (defer persons upsert)

### DIFF
--- a/src/app/callback/route.ts
+++ b/src/app/callback/route.ts
@@ -8,28 +8,36 @@
  *
  * The route runs in the Node.js runtime (default) so MongoDB is reachable.
  * Configure WorkOS dashboard "Redirect URI" to point at this path.
+ *
+ * The `identity.persons` mirror is deferred with `after()` so it runs AFTER
+ * the redirect response is flushed. Awaiting the (multi-write, sometimes
+ * cold-start) MongoDB upsert made sign-in hang before returning to the app.
+ * The user is already authenticated by the time we redirect; the mirror is
+ * best-effort and retried on the next request if it fails.
  */
 
+import { after } from "next/server";
 import { handleAuth } from "@workos-inc/authkit-nextjs";
 import { upsertPlatformPerson, type WorkOSUser } from "@/lib/auth";
 import { logError } from "@/lib/observability";
 
 export const GET = handleAuth({
   returnPathname: "/",
-  onSuccess: async ({ user }) => {
+  onSuccess: ({ user }) => {
     if (!user) return;
-    try {
-      await upsertPlatformPerson(user as unknown as WorkOSUser);
-    } catch (err) {
-      // Never block sign-in on a platform-write failure. The user is already
-      // authenticated via WorkOS; we'll retry the upsert on the next request.
-      logError({
-        source: "mongodb",
-        severity: "high",
-        message: "Failed to upsert identity.persons on WorkOS callback",
-        error: err,
-        meta: { workosUserId: (user as { id?: string }).id },
-      });
-    }
+    // Non-blocking: redirect first, mirror the user afterwards.
+    after(async () => {
+      try {
+        await upsertPlatformPerson(user as unknown as WorkOSUser);
+      } catch (err) {
+        logError({
+          source: "mongodb",
+          severity: "high",
+          message: "Failed to upsert identity.persons on WorkOS callback",
+          error: err,
+          meta: { workosUserId: (user as { id?: string }).id },
+        });
+      }
+    });
   },
 });


### PR DESCRIPTION
Sign-in was hanging before returning to the app because the WorkOS `/callback` awaited the multi-write `identity.persons` upsert (cold-start MongoDB) inside `onSuccess` before redirecting. Deferred it with `next/server` `after()` so the redirect flushes instantly; the platform-person mirror runs after the response (retried next request on failure). Redirect URI confirmed correct (`https://weather.mukoko.com/callback`).