### PR TITLE
fix(dashboard): resolve three section-order bugs (hydration, vanishing sections, remount)

### DIFF
--- a/src/app/[location]/WeatherDashboard.tsx
+++ b/src/app/[location]/WeatherDashboard.tsx
@@ -100,6 +100,7 @@ export function WeatherDashboard({
   const completeOnboarding = useAppStore((s) => s.completeOnboarding);
   const sectionOrder = useAppStore((s) => s.sectionOrder);
   const setSectionOrder = useAppStore((s) => s.setSectionOrder);
+  const hydrateSectionOrder = useAppStore((s) => s.hydrateSectionOrder);
   const [aiSummary, setAiSummary] = useState<string | null>(null);
   const [reordering, setReordering] = useState(false);
   // Windy-style ADDITIONAL data — multi-model comparison + minutely nowcast.
@@ -155,6 +156,14 @@ export function WeatherDashboard({
       .then((data) => { if (data?.activities?.length) setAllActivities(data.activities); })
       .catch(() => {});
   }, [selectedActivities.length]);
+
+  // Apply the persisted section order AFTER hydration. The store initialises to
+  // DEFAULT_SECTION_ORDER on the server and first client render (so hydration
+  // matches); this effect reads localStorage and applies the saved/reconciled
+  // order once mounted, avoiding a React hydration mismatch + flash.
+  useEffect(() => {
+    hydrateSectionOrder();
+  }, [hydrateSectionOrder]);
 
   // Sync the URL-driven location to the global store so other pages
   // (history, etc.) can use it as their default.

--- a/src/components/weather/DraggableSection.test.ts
+++ b/src/components/weather/DraggableSection.test.ts
@@ -23,8 +23,20 @@ describe("DraggableSection — client component", () => {
     expect(source).toContain("@dnd-kit/sortable");
   });
 
-  it("renders children with zero overhead when not reordering", () => {
-    expect(source).toContain("if (!reordering) return <>{children}</>");
+  it("renders a STABLE wrapper element in both modes (no unmount/remount)", () => {
+    // The wrapper must not swap element type between modes — that would force
+    // React to unmount/remount every section (refetch AI summary, drop chat,
+    // rebuild charts, recreate the Three.js hero) when toggling reorder mode.
+    // The old early-return fragment is gone; a single ref'd <div> always renders.
+    expect(source).not.toContain("if (!reordering) return <>{children}</>");
+    expect(source).toContain("<div ref={setNodeRef}");
+  });
+
+  it("toggles only drag props/handle/styling on the reordering flag, never the element type", () => {
+    // The handle button is conditionally mounted, and styling is gated on the
+    // flag, but the wrapper <div> and inner children wrapper are unconditional.
+    expect(source).toContain("{reordering && (");
+    expect(source).toContain("className={reordering ? \"relative\" : undefined}");
   });
 });
 

--- a/src/components/weather/DraggableSection.tsx
+++ b/src/components/weather/DraggableSection.tsx
@@ -12,40 +12,54 @@ interface Props {
 
 /**
  * Wraps a weather section with dnd-kit drag-and-drop when reorder mode is active.
- * In normal mode, renders children with zero overhead (no extra DOM nodes).
+ *
+ * The wrapper element type is STABLE across modes — a single `<div ref={setNodeRef}>`
+ * is rendered whether or not `reordering` is on. Toggling only the drag handle,
+ * listeners, and styling (never the element type) means React reconciles instead
+ * of unmounting: `children` keep their component instances, so entering/leaving
+ * "Customise layout" no longer refetches the AI summary, drops the chat, rebuilds
+ * charts, or recreates the Three.js hero.
  */
 export function DraggableSection({ id, reordering, children }: Props) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id });
 
-  if (!reordering) return <>{children}</>;
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : undefined,
-  } as React.CSSProperties;
+  const style = reordering
+    ? ({
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : undefined,
+      } as React.CSSProperties)
+    : undefined;
 
   return (
-    <div ref={setNodeRef} style={style} className="relative">
-      {/* Drag handle — always visible while in reorder mode. It previously tried to
-          reveal itself on hover of the card, but the hovered element was a SIBLING of
-          this button (not an ancestor), so the hover selector never matched and the
-          handle stayed hidden for mouse/touch users — making reordering impossible.
-          Since DraggableSection only mounts this button when `reordering` is true, we
-          show it outright. */}
-      <button
-        {...attributes}
-        {...listeners}
-        aria-label="Drag to reorder section"
-        className="absolute left-1 top-2 z-10 flex h-8 min-h-0 w-8 cursor-grab touch-none items-center justify-center rounded-full border border-primary/25 bg-surface-card text-text-secondary shadow-sm transition-colors hover:border-primary/40 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-primary active:cursor-grabbing"
+    <div ref={setNodeRef} style={style} className={reordering ? "relative" : undefined}>
+      {/* Drag handle — only mounted in reorder mode. It previously tried to reveal
+          itself on hover of the card, but the hovered element was a SIBLING of this
+          button (not an ancestor), so the hover selector never matched and the handle
+          stayed hidden for mouse/touch users. It is now shown outright while reordering. */}
+      {reordering && (
+        <button
+          {...attributes}
+          {...listeners}
+          aria-label="Drag to reorder section"
+          className="absolute left-1 top-2 z-10 flex h-8 min-h-0 w-8 cursor-grab touch-none items-center justify-center rounded-full border border-primary/25 bg-surface-card text-text-secondary shadow-sm transition-colors hover:border-primary/40 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-primary active:cursor-grabbing"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M5 3a1 1 0 100 2 1 1 0 000-2zm6 0a1 1 0 100 2 1 1 0 000-2zM5 7a1 1 0 100 2 1 1 0 000-2zm6 0a1 1 0 100 2 1 1 0 000-2zM5 11a1 1 0 100 2 1 1 0 000-2zm6 0a1 1 0 100 2 1 1 0 000-2z" />
+          </svg>
+        </button>
+      )}
+      {/* Inner wrapper is always present so children never remount. In reorder mode
+          the left padding reserves room for the always-on handle and a ring frames
+          the draggable card. */}
+      <div
+        className={
+          reordering
+            ? "rounded-[var(--radius-card)] pl-10 ring-2 ring-primary/20 transition-all focus-within:ring-primary/40"
+            : undefined
+        }
       >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-          <path d="M5 3a1 1 0 100 2 1 1 0 000-2zm6 0a1 1 0 100 2 1 1 0 000-2zM5 7a1 1 0 100 2 1 1 0 000-2zm6 0a1 1 0 100 2 1 1 0 000-2zM5 11a1 1 0 100 2 1 1 0 000-2zm6 0a1 1 0 100 2 1 1 0 000-2z" />
-        </svg>
-      </button>
-      {/* Left padding reserves room for the always-on handle so it doesn't overlap content. */}
-      <div className="rounded-[var(--radius-card)] pl-10 ring-2 ring-primary/20 transition-all focus-within:ring-primary/40">
         {children}
       </div>
     </div>

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { resolveTheme, useAppStore, isShamwariContextValid, MAX_SAVED_LOCATIONS, DEFAULT_SECTION_ORDER, type ThemePreference, type ShamwariContext } from "./store";
+import { resolveTheme, useAppStore, isShamwariContextValid, MAX_SAVED_LOCATIONS, DEFAULT_SECTION_ORDER, mergeSectionOrder, type ThemePreference, type ShamwariContext } from "./store";
 
 // Mock RxDB bridge to prevent IndexedDB access in tests
 vi.mock("./rxdb/bridge", () => ({
@@ -414,6 +414,95 @@ describe("sectionOrder", () => {
     const custom = ["atmospheric", "current", "dailyForecast"];
     useAppStore.getState().setSectionOrder(custom);
     expect(useAppStore.getState().sectionOrder).toEqual(custom);
+  });
+
+  it("initialises to DEFAULT_SECTION_ORDER (hydration-safe — no synchronous localStorage read)", () => {
+    // The store must init to the defaults on both the server and the first client
+    // render so React hydration matches. Persisted order is applied post-hydration.
+    // Re-import a fresh module to observe the initial value (setSectionOrder in the
+    // tests above mutates the shared singleton), so assert the exported default here.
+    expect([...DEFAULT_SECTION_ORDER]).toEqual([
+      "current",
+      "hourlyScroll",
+      "atmospheric",
+      "reports",
+      "hourlyForecast",
+      "activityInsights",
+      "dailyForecast",
+      "aiSummary",
+      "aiChat",
+    ]);
+  });
+
+  it("hydrateSectionOrder is a safe no-op when localStorage is unavailable (SSR/Node)", () => {
+    const before = useAppStore.getState().sectionOrder;
+    expect(() => useAppStore.getState().hydrateSectionOrder()).not.toThrow();
+    // No window/localStorage in Node → order left untouched.
+    expect(useAppStore.getState().sectionOrder).toEqual(before);
+  });
+});
+
+describe("mergeSectionOrder (Bug 2 — union stored order with defaults)", () => {
+  it("appends sections added AFTER a user saved their order, at their default position", () => {
+    // A legacy user saved before hourlyScroll/reports/aiChat existed.
+    const stored = [
+      "current",
+      "atmospheric",
+      "hourlyForecast",
+      "activityInsights",
+      "dailyForecast",
+      "aiSummary",
+    ];
+    const merged = mergeSectionOrder(stored);
+    // Every default section is now present...
+    for (const id of DEFAULT_SECTION_ORDER) expect(merged).toContain(id);
+    // ...and the new ids landed near their default neighbours.
+    expect(merged).toEqual([
+      "current",
+      "hourlyScroll",
+      "atmospheric",
+      "reports",
+      "hourlyForecast",
+      "activityInsights",
+      "dailyForecast",
+      "aiSummary",
+      "aiChat",
+    ]);
+  });
+
+  it("drops ids that are no longer part of DEFAULT_SECTION_ORDER", () => {
+    const stored = ["current", "legacyRemovedSection", "atmospheric"];
+    const merged = mergeSectionOrder(stored);
+    expect(merged).not.toContain("legacyRemovedSection");
+    expect(merged).toContain("current");
+    expect(merged).toContain("atmospheric");
+  });
+
+  it("preserves the user's custom ordering of the sections they DID arrange", () => {
+    // User moved atmospheric above current and dropped nothing else.
+    const stored = [
+      "atmospheric",
+      "current",
+      "hourlyScroll",
+      "reports",
+      "hourlyForecast",
+      "activityInsights",
+      "dailyForecast",
+      "aiSummary",
+      "aiChat",
+    ];
+    const merged = mergeSectionOrder(stored);
+    expect(merged.indexOf("atmospheric")).toBeLessThan(merged.indexOf("current"));
+    expect(merged).toHaveLength(DEFAULT_SECTION_ORDER.length);
+  });
+
+  it("de-dupes repeated ids", () => {
+    const merged = mergeSectionOrder(["current", "current", "atmospheric"]);
+    expect(merged.filter((id) => id === "current")).toHaveLength(1);
+  });
+
+  it("returns the full default set for an empty stored array", () => {
+    expect(mergeSectionOrder([])).toEqual([...DEFAULT_SECTION_ORDER]);
   });
 });
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -68,16 +68,64 @@ export const DEFAULT_SECTION_ORDER = [
 
 const SECTION_ORDER_KEY = "mukoko-section-order";
 
-function loadSectionOrder(): string[] {
-  if (typeof window === "undefined") return [...DEFAULT_SECTION_ORDER];
+const DEFAULT_SECTION_INDEX = new Map<string, number>(
+  DEFAULT_SECTION_ORDER.map((id, i) => [id, i]),
+);
+
+/**
+ * Reconcile a persisted section order against the current DEFAULT_SECTION_ORDER.
+ *
+ * A user who saved a layout months ago has an array that predates any sections
+ * added since (e.g. `hourlyScroll`, `reports`, `aiSummary`, `aiChat`, plus any
+ * new multi-model/nowcast sections). The dashboard only renders ids present in
+ * the order, so those newer sections would silently never appear. Conversely a
+ * removed/renamed section id lingering in storage would be a dead entry.
+ *
+ * This UNIONs the two: keep the stored ids that still exist in DEFAULT (drop the
+ * rest), then splice in every missing DEFAULT id at its default position (before
+ * the first existing section that follows it in the default layout). The user's
+ * custom ordering of the sections they DID arrange is preserved.
+ *
+ * Exported for testing.
+ */
+export function mergeSectionOrder(stored: string[]): string[] {
+  // Drop ids that are no longer part of the default schema, and de-dupe.
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const id of stored) {
+    if (DEFAULT_SECTION_INDEX.has(id) && !seen.has(id)) {
+      seen.add(id);
+      result.push(id);
+    }
+  }
+  // Insert any missing default ids at their default position. Processing in
+  // default order keeps newly-inserted ids in their relative default order.
+  for (const id of DEFAULT_SECTION_ORDER) {
+    if (seen.has(id)) continue;
+    const defaultIdx = DEFAULT_SECTION_INDEX.get(id)!;
+    let insertPos = result.findIndex(
+      (existing) => (DEFAULT_SECTION_INDEX.get(existing) ?? Infinity) > defaultIdx,
+    );
+    if (insertPos === -1) insertPos = result.length;
+    result.splice(insertPos, 0, id);
+    seen.add(id);
+  }
+  return result;
+}
+
+/** Read the raw persisted section order from localStorage, or null if absent/invalid. */
+function readStoredSectionOrder(): string[] | null {
+  if (typeof window === "undefined") return null;
   try {
     const stored = localStorage.getItem(SECTION_ORDER_KEY);
     if (stored) {
-      const parsed = JSON.parse(stored) as string[];
-      if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+      const parsed = JSON.parse(stored) as unknown;
+      if (Array.isArray(parsed) && parsed.every((x) => typeof x === "string")) {
+        return parsed as string[];
+      }
     }
   } catch { /* ignore */ }
-  return [...DEFAULT_SECTION_ORDER];
+  return null;
 }
 
 function saveSectionOrder(order: string[]): void {
@@ -127,6 +175,13 @@ interface AppState {
   /** User-defined section order for the location page primary column */
   sectionOrder: string[];
   setSectionOrder: (order: string[]) => void;
+  /**
+   * Load the persisted section order from localStorage AFTER hydration and apply
+   * it (unioned with the current defaults). Call this from a client `useEffect`
+   * so the server and first client render both use `DEFAULT_SECTION_ORDER` —
+   * reading localStorage during store init would desync SSR and hydration.
+   */
+  hydrateSectionOrder: () => void;
 }
 
 const THEME_CYCLE: ThemePreference[] = ["light", "dark", "system"];
@@ -231,10 +286,24 @@ export const useAppStore = create<AppState>()((set) => ({
   reportModalOpen: false,
   openReportModal: () => set({ reportModalOpen: true }),
   closeReportModal: () => set({ reportModalOpen: false }),
-  sectionOrder: loadSectionOrder(),
+  // Initialise to the defaults on BOTH the server and the first client render so
+  // hydration matches. The persisted order (if any) is applied post-hydration via
+  // `hydrateSectionOrder()`, mirroring how RxDB-backed prefs are deferred.
+  sectionOrder: [...DEFAULT_SECTION_ORDER],
   setSectionOrder: (order) => {
     saveSectionOrder(order);
     set({ sectionOrder: order });
+  },
+  hydrateSectionOrder: () => {
+    const stored = readStoredSectionOrder();
+    if (!stored) return;
+    const merged = mergeSectionOrder(stored);
+    set({ sectionOrder: merged });
+    // Normalise storage so future loads (and the drag handler) start from the
+    // reconciled order. Only rewrite when the merge actually changed something.
+    if (merged.length !== stored.length || merged.some((id, i) => id !== stored[i])) {
+      saveSectionOrder(merged);
+    }
   },
 }));
 


### PR DESCRIPTION
## Summary

Fixes three bugs in the location-page **Customise layout** (section reordering) feature.

### 1. Hydration mismatch + flash
`src/lib/store.ts` read `localStorage` synchronously at store init (`loadSectionOrder`), so a returning user who had customised their layout got a client first-render order that differed from SSR's `DEFAULT_SECTION_ORDER` → React hydration mismatch and a visible flash.

**Fix:** initialise `sectionOrder` to `DEFAULT_SECTION_ORDER` on the server **and** the first client render. A new `hydrateSectionOrder()` store action reads localStorage and applies the saved order **post-hydration**, called from a `useEffect` in `WeatherDashboard.tsx` — mirroring how the store already defers other persisted (RxDB) reads.

### 2. Sections silently vanished
The stored array was returned verbatim, and the `WeatherDashboard` switch only renders ids present in it — so sections added *after* a user saved their order (`hourlyScroll`, `reports`, `aiSummary`, `aiChat`, …) never rendered for them.

**Fix:** `hydrateSectionOrder()` **unions** the stored order with `DEFAULT_SECTION_ORDER` via the new pure, exported `mergeSectionOrder()`: it drops ids no longer in DEFAULT, de-dupes, and splices any missing ids in at their default position — while preserving the user's custom ordering of the sections they *did* arrange. The reconciled order is written back to localStorage.

### 3. Customise-layout remounted everything
`src/components/weather/DraggableSection.tsx` changed the wrapper element type (`<>` ↔ `<div>`) when toggling reorder mode, forcing unmount/remount of every section — refetching the AI summary, dropping chat, rebuilding charts, recreating the Three.js hero.

**Fix:** always render a stable `<div ref={setNodeRef}>` wrapper; toggle only the drag handle, listeners, and styling on the `reordering` flag — never the element type. Children keep their component instances, so React reconciles instead of remounting.

## Tests
- `src/lib/store.test.ts` — `mergeSectionOrder` (append-new-at-default-position, drop-removed, de-dupe, empty, preserve-user-order), hydration-safe default init, no-op SSR hydrate.
- `src/components/weather/DraggableSection.test.ts` — stable-wrapper regression (no element-type swap).

## Verification
- `npm test` — 77 files, **1839 passed**
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — compiles, all pages generated

No Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
