### PR TITLE
fix: stop embed API + aviation planner silently showing Harare weather

### DIFF
--- a/src/app/api/embed/current/route.test.ts
+++ b/src/app/api/embed/current/route.test.ts
@@ -130,6 +130,17 @@ describe("route structure", () => {
     expect(source).toContain("/api/py/locations");
   });
 
+  it("unwraps the { location: {…} } wrapper from the locations endpoint", () => {
+    // The locations endpoint returns `{ location: {…} }`, not a bare doc.
+    // Reading `loc.lat` directly would be undefined → NaN → a silent Harare
+    // fallback for every non-Harare slug embed. Guard that the unwrap stays.
+    expect(source).toContain("?.location");
+  });
+
+  it("resolves weather by the resolved lat/lon (never a hardcoded default)", () => {
+    expect(source).toContain("/api/py/weather?lat=${lat}&lon=${lon}");
+  });
+
   it("does not shared-cache IP-derived responses", () => {
     expect(source).toContain("private, max-age=300");
     expect(source).toContain("Cache-Control");

--- a/src/app/api/embed/current/route.ts
+++ b/src/app/api/embed/current/route.ts
@@ -87,10 +87,19 @@ export async function GET(req: NextRequest): Promise<Response> {
     source = "coords";
   } else if (slug && /^[a-z0-9-]{1,80}$/.test(slug)) {
     // 2. Known location slug — resolve to coordinates via internal locations API.
-    const loc = await fetchJson<Record<string, unknown> | Record<string, unknown>[]>(
-      `${INTERNAL_BASE}/api/py/locations?slug=${encodeURIComponent(slug)}`,
-    );
-    const doc = Array.isArray(loc) ? loc[0] : loc;
+    // `/api/py/locations?slug=` returns a `{ location: {…} }` WRAPPER (not the
+    // bare doc), so unwrap it — reading `loc.lat` directly yields undefined → NaN
+    // → a silent Harare fallback for every non-Harare embed.
+    const loc = await fetchJson<
+      | Record<string, unknown>
+      | Record<string, unknown>[]
+      | { location?: Record<string, unknown> }
+    >(`${INTERNAL_BASE}/api/py/locations?slug=${encodeURIComponent(slug)}`);
+    const doc = Array.isArray(loc)
+      ? loc[0]
+      : ((loc as { location?: Record<string, unknown> } | null)?.location ??
+        (loc as Record<string, unknown> | null) ??
+        undefined);
     const dLat = doc ? Number(doc.lat) : NaN;
     const dLon = doc ? Number(doc.lon) : NaN;
     if (doc && Number.isFinite(dLat) && Number.isFinite(dLon)) {

--- a/src/app/aviation/AviationPlanner.tsx
+++ b/src/app/aviation/AviationPlanner.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useDebounce } from "@/lib/use-debounce";
-import { getIcaoForSlug } from "@/lib/icao-codes";
+import { getIcaoForSlug, getAirportByIcao } from "@/lib/icao-codes";
 import { SearchIcon, MapPinIcon, NavigationIcon } from "@/lib/weather-icons";
 import type { AirportBriefing, BriefingData, MetarObs } from "./AviationBriefingPDF";
 
@@ -47,12 +47,14 @@ function AirportSearch({
   const [results, setResults] = useState<LocationResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const debounced = useDebounce(query, 300);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const search = useCallback(async (q: string) => {
     if (q.trim().length < 2) { setResults([]); return; }
     setLoading(true);
+    setSearchError(null);
     try {
       const res = await fetch(`/api/py/search?q=${encodeURIComponent(q)}&limit=8`);
       if (res.ok) {
@@ -60,7 +62,15 @@ function AirportSearch({
         setResults((data.locations ?? []).map((l: { slug: string; name: string; province: string; country?: string }) => ({
           slug: l.slug, name: l.name, province: l.province, country: l.country,
         })));
+      } else {
+        setResults([]);
+        setSearchError("Airport search failed. Please try again.");
       }
+    } catch {
+      // A network failure here previously escaped as an unhandled rejection and
+      // left the spinner stuck — surface it and clear the loading state instead.
+      setResults([]);
+      setSearchError("Airport search failed. Check your connection and try again.");
     } finally { setLoading(false); }
   }, []);
 
@@ -82,7 +92,7 @@ function AirportSearch({
     setResults([]);
   };
 
-  const clear = () => { onChange(null); setQuery(""); setResults([]); };
+  const clear = () => { onChange(null); setQuery(""); setResults([]); setSearchError(null); };
 
   return (
     <div ref={containerRef} className="relative">
@@ -105,6 +115,10 @@ function AirportSearch({
           <span className="absolute right-3 top-1/2 -translate-y-1/2 text-text-tertiary text-xs">…</span>
         )}
       </div>
+
+      {searchError && !value && (
+        <p className="mt-1.5 text-xs text-severity-moderate" role="alert">{searchError}</p>
+      )}
 
       {value && (
         <div className="mt-1.5 flamingo">
@@ -230,10 +244,16 @@ export function AviationPlanner() {
   const altIcao = alt ? getIcaoForSlug(alt.slug) : null;
   const canBrief = !!depIcao && !!destIcao;
 
-  const fetchAirport = async (slug: string, name: string, icao: string): Promise<AirportBriefing> => {
+  const fetchAirport = async (name: string, icao: string): Promise<AirportBriefing> => {
+    // `/api/py/weather` takes lat/lon ONLY — it ignores any `location`/`slug`
+    // param and defaults to Harare. Resolve the airport's own coordinates from
+    // the ICAO record so each airport gets its real weather (sunrise/sunset).
+    const airport = getAirportByIcao(icao);
     const [metarRes, wxRes] = await Promise.allSettled([
       fetch(`/api/py/metar?icao=${icao}`),
-      fetch(`/api/py/weather?location=${slug}`),
+      airport
+        ? fetch(`/api/py/weather?lat=${airport.lat}&lon=${airport.lon}`)
+        : Promise.reject(new Error(`No coordinates for ${icao}`)),
     ]);
 
     let metar: MetarObs[] = [];
@@ -248,7 +268,8 @@ export function AviationPlanner() {
     let sunset: string | undefined;
     if (wxRes.status === "fulfilled" && wxRes.value.ok) {
       const d = await wxRes.value.json();
-      const daily = d.weather?.daily;
+      // `/api/py/weather` returns `daily` at the TOP LEVEL (not under `weather`).
+      const daily = d.daily;
       if (daily?.sunrise?.[0]) {
         sunrise = new Date(daily.sunrise[0]).toLocaleTimeString("en-ZW", { hour: "2-digit", minute: "2-digit", hour12: false });
         sunset = new Date(daily.sunset[0]).toLocaleTimeString("en-ZW", { hour: "2-digit", minute: "2-digit", hour12: false });
@@ -265,9 +286,9 @@ export function AviationPlanner() {
     setBriefingData(null);
     try {
       const [departure, destination, alternate] = await Promise.all([
-        fetchAirport(dep.slug, dep.name, depIcao),
-        fetchAirport(dest.slug, dest.name, destIcao),
-        alt && altIcao ? fetchAirport(alt.slug, alt.name, altIcao) : Promise.resolve(undefined),
+        fetchAirport(dep.name, depIcao),
+        fetchAirport(dest.name, destIcao),
+        alt && altIcao ? fetchAirport(alt.name, altIcao) : Promise.resolve(undefined),
       ]);
       setBriefingData({
         departure,

--- a/src/app/aviation/aviation.test.ts
+++ b/src/app/aviation/aviation.test.ts
@@ -5,6 +5,8 @@ import { resolve } from "path";
 const plannerSrc = readFileSync(resolve(__dirname, "AviationPlanner.tsx"), "utf-8");
 const pdfSrc = readFileSync(resolve(__dirname, "AviationBriefingPDF.tsx"), "utf-8");
 const pageSrc = readFileSync(resolve(__dirname, "page.tsx"), "utf-8");
+const errorSrc = readFileSync(resolve(__dirname, "error.tsx"), "utf-8");
+const loadingSrc = readFileSync(resolve(__dirname, "loading.tsx"), "utf-8");
 
 describe("AviationPlanner", () => {
   it("is a client component", () => {
@@ -40,6 +42,52 @@ describe("AviationPlanner", () => {
   it("has alternate airport option", () => {
     expect(plannerSrc).toContain("Alternate Airport");
     expect(plannerSrc).toContain("alternate");
+  });
+});
+
+describe("AviationPlanner — Harare-bug fixes", () => {
+  it("resolves airport coordinates for the weather fetch (not a slug/location param)", () => {
+    expect(plannerSrc).toContain("getAirportByIcao");
+    // The weather endpoint takes lat/lon ONLY — a `location=` param is ignored
+    // and silently defaults to Harare, so it must never be used here.
+    expect(plannerSrc).toContain("/api/py/weather?lat=");
+    expect(plannerSrc).not.toContain("/api/py/weather?location=");
+  });
+
+  it("reads daily from the top level of the weather response, not d.weather.daily", () => {
+    expect(plannerSrc).toContain("const daily = d.daily");
+    expect(plannerSrc).not.toContain("d.weather?.daily");
+  });
+
+  it("catches airport-search failures so the spinner never sticks", () => {
+    expect(plannerSrc).toContain("catch");
+    expect(plannerSrc).toContain("searchError");
+    // The search callback must clear loading in finally after catching.
+    expect(plannerSrc).toContain("finally { setLoading(false); }");
+  });
+});
+
+describe("Aviation error boundary", () => {
+  it("is a client component", () => {
+    expect(errorSrc).toContain('"use client"');
+  });
+  it("exports a default error component with error + reset props", () => {
+    expect(errorSrc).toContain("export default function AviationError");
+    expect(errorSrc).toContain("reset");
+  });
+  it("reports to analytics and offers retry", () => {
+    expect(errorSrc).toContain("reportErrorToAnalytics");
+    expect(errorSrc).toContain("Try again");
+  });
+});
+
+describe("Aviation loading boundary", () => {
+  it("exports a default loading component", () => {
+    expect(loadingSrc).toContain("export default function AviationLoading");
+  });
+  it("renders the Header and an accessible loading status", () => {
+    expect(loadingSrc).toContain("Header");
+    expect(loadingSrc).toContain('role="status"');
   });
 });
 

--- a/src/app/aviation/error.tsx
+++ b/src/app/aviation/error.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { reportErrorToAnalytics, buildIssueUrl } from "@/lib/observability";
+import { getRetryCount, setRetryCount, clearRetryCount, MAX_RETRIES } from "@/lib/error-retry";
+
+export default function AviationError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const [exhausted, setExhausted] = useState(() => getRetryCount() >= MAX_RETRIES);
+
+  useEffect(() => {
+    console.error("Aviation page error:", error);
+    reportErrorToAnalytics(`aviation:${error.message}`, true);
+  }, [error]);
+
+  const handleRetry = () => {
+    const count = getRetryCount() + 1;
+    setRetryCount(count);
+
+    if (count >= MAX_RETRIES) {
+      setExhausted(true);
+      return;
+    }
+
+    reset();
+  };
+
+  const handleNavigate = () => {
+    clearRetryCount();
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+      <h1 className="font-heading text-4xl font-bold text-text-primary">
+        Briefing Unavailable
+      </h1>
+      <p className="mt-4 max-w-md text-center text-text-secondary">
+        {exhausted
+          ? "The aviation weather briefing is temporarily unavailable. Please try again later."
+          : "We couldn’t load the aviation weather briefing right now. This may be a temporary issue with METAR/TAF data."}
+      </p>
+      <div className="mt-8 flex flex-col items-center gap-3">
+        {!exhausted && (
+          <Button size="lg" onClick={handleRetry}>
+            Try again
+          </Button>
+        )}
+        <Button variant="outline" size="lg" asChild>
+          <Link href="/" onClick={handleNavigate}>
+            Go home
+          </Link>
+        </Button>
+        <a
+          href={buildIssueUrl({
+            title: "Aviation page error",
+            source: "aviation",
+            message: error.message,
+            page: "/aviation",
+            digest: error.digest,
+          })}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 text-base text-text-tertiary underline hover:text-text-secondary transition-colors"
+        >
+          Report this issue
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/app/aviation/loading.tsx
+++ b/src/app/aviation/loading.tsx
@@ -1,0 +1,32 @@
+import { Skeleton, CardSkeleton } from "@/components/ui/skeleton";
+import { Header } from "@/components/layout/Header";
+
+export default function AviationLoading() {
+  return (
+    <>
+      <Header />
+      <main
+        id="main-content"
+        aria-label="Loading aviation briefing"
+        className="mx-auto max-w-3xl px-4 py-6 pb-24 sm:px-6 sm:pb-8 md:px-8"
+      >
+        <div role="status" aria-label="Loading" aria-busy="true" className="space-y-6">
+          <span className="sr-only">Loading aviation weather briefing...</span>
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-72 max-w-full" />
+            <Skeleton className="h-4 w-full max-w-xl" />
+          </div>
+          {/* Route selection card */}
+          <div className="baobab p-5 space-y-4">
+            <Skeleton className="h-11 w-full" />
+            <Skeleton className="h-11 w-full" />
+            <Skeleton className="h-9 w-48" />
+          </div>
+          {/* Briefing result placeholders */}
+          <CardSkeleton />
+          <CardSkeleton />
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Two callers of the Python backend got the `/api/py/*` contract wrong and **silently returned Harare weather for every non-Harare location**. This fixes both, plus adds the missing aviation route error/loading boundaries.

### 1. Embed API — `src/app/api/embed/current/route.ts`
`/api/py/locations?slug=` returns a `{ location: {…} }` **wrapper**, but the route read `doc.lat` / `doc.lon` directly off the wrapper → `undefined` → `NaN` → fell back to `DEFAULT_LAT/LON` (Harare). Every non-Harare embed showed Harare.
**Fix:** unwrap `loc.location` before reading `lat`/`lon`/`name`/etc.

### 2. Aviation planner — `src/app/aviation/AviationPlanner.tsx`
- **(a)** Fetched `/api/py/weather?location=${slug}`, but the endpoint **ignores `location`** and defaults to Harare → every airport showed Harare weather. **Fix:** resolve the airport's own coordinates via `getAirportByIcao()` and call `/api/py/weather?lat=&lon=`.
- **(b)** Read sunrise/sunset from `d.weather?.daily`, but `/api/py/weather` returns `daily` at the **top level** → sun times never populated in the briefing or PDF. **Fix:** read `d.daily`.
- **(c)** The airport search used `try/finally` with **no `catch`** → unhandled rejection + stuck spinner on network failure. **Fix:** added a `catch` that surfaces an inline error state and clears the spinner.

### 3. Route boundaries — `src/app/aviation/error.tsx` + `loading.tsx`
The `/aviation` route was missing error/loading boundaries. Added them, mirroring `src/app/shamwari/` and `src/app/history/`.

## Tests
- Updated `src/app/api/embed/current/route.test.ts` (wrapper unwrap + lat/lon weather resolution).
- Updated `src/app/aviation/aviation.test.ts` (coord-based weather fetch, top-level `daily`, search `catch`, new error/loading boundaries).

## Verification
- `npm test` — 1841 passed
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)