### PR TITLE
fix(home,location): harden onboarding geo path + escape JSON-LD (XSS)

### DIFF
--- a/src/app/HomeLanding.test.ts
+++ b/src/app/HomeLanding.test.ts
@@ -194,6 +194,29 @@ describe("page.tsx — server component", () => {
     expect(pageSource).toContain("/harare");
     expect(pageSource).toContain("canonical");
   });
+
+  it("uses autoCreate=false on the server IP-geo path (find-only, no junk locations)", () => {
+    expect(pageSource).toContain("autoCreate=false");
+    expect(pageSource).not.toContain("autoCreate=true");
+  });
+
+  it("bounds the self-fetch with an AbortController timeout", () => {
+    expect(pageSource).toContain("AbortController");
+    expect(pageSource).toContain("controller.abort()");
+    expect(pageSource).toContain("signal: controller.signal");
+    expect(pageSource).toContain("GEO_FETCH_TIMEOUT_MS");
+  });
+
+  it("uses a stable base URL for the self-fetch (not VERCEL_URL)", () => {
+    expect(pageSource).not.toContain("VERCEL_URL");
+    expect(pageSource).toContain('process.env.NODE_ENV === "production"');
+  });
+
+  it("only redirects on a lastLocation cookie that actually resolves", () => {
+    expect(pageSource).toContain("getLocationFromDb(lastLocation)");
+    // The resolution check must gate the redirect, breaking the stale-cookie loop.
+    expect(pageSource).toContain("if (resolved)");
+  });
 });
 
 describe("middleware — edge routing", () => {

--- a/src/app/[location]/page.tsx
+++ b/src/app/[location]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { checkFrostRisk, createFallbackWeather, weatherCodeToInfo } from "@/lib/weather";
 import { getWeatherForLocation, getLocationFromDb, getCountryByCode, getSeasonForDate } from "@/lib/db";
 import { getCurrentUser } from "@/lib/auth";
+import { safeJsonLd } from "@/lib/json-ld";
 import { WeatherDashboard } from "./WeatherDashboard";
 
 // Deduplicate DB calls between generateMetadata and the page component.
@@ -134,6 +135,12 @@ export default async function LocationPage({
   const usingFallback = weatherSource === "fallback";
   const frostAlert = usingFallback ? null : checkFrostRisk(weather.hourly);
   const conditionInfo = weatherCodeToInfo(weather.current.weather_code);
+  // Guard against empty daily arrays — Math.max(...[]) is -Infinity and
+  // Math.min(...[]) is Infinity, which would render as garbage in the FAQ schema.
+  const dailyHighs = weather.daily.temperature_2m_max;
+  const dailyLows = weather.daily.temperature_2m_min;
+  const weekHigh = dailyHighs.length ? Math.round(Math.max(...dailyHighs)) : null;
+  const weekLow = dailyLows.length ? Math.round(Math.min(...dailyLows)) : null;
   const countryCode = (location.country ?? "").toUpperCase();
   const [countryDoc, season, currentUser] = await Promise.all([
     countryCode ? loadCountry(countryCode) : Promise.resolve(null),
@@ -234,7 +241,10 @@ export default async function LocationPage({
         name: `What is the 7-day forecast for ${location.name}, ${countryName}?`,
         acceptedAnswer: {
           "@type": "Answer",
-          text: `The 7-day forecast for ${location.name} shows highs of ${Math.round(Math.max(...weather.daily.temperature_2m_max))}\u00b0C and lows of ${Math.round(Math.min(...weather.daily.temperature_2m_min))}\u00b0C. Check mukoko weather for detailed daily and hourly forecasts.`,
+          text:
+            weekHigh !== null && weekLow !== null
+              ? `The 7-day forecast for ${location.name} shows highs of ${weekHigh}\u00b0C and lows of ${weekLow}\u00b0C. Check mukoko weather for detailed daily and hourly forecasts.`
+              : `Check mukoko weather for the detailed daily and hourly forecast for ${location.name}.`,
         },
       },
       {
@@ -253,7 +263,7 @@ export default async function LocationPage({
       {/* SEO schemas — server rendered only */}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(
           usingFallback ? [breadcrumbSchema] : [pageSchema, breadcrumbSchema, faqSchema]
         ) }}
       />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,12 +2,23 @@ import type { Metadata } from "next";
 import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { HomeLanding } from "./HomeLanding";
+import { getLocationFromDb } from "@/lib/db";
 import type { WeatherLocation } from "@/lib/locations";
 
 const BASE_URL = "https://weather.mukoko.com";
+// Stable base for the server-to-self geo lookup. The per-deployment Vercel
+// hostname env var points at a protected preview origin that 401s the self-fetch
+// (Deployment Protection) — the failure is swallowed and onboarding silently
+// degrades. Prefer the production hostname (like the embed route's fixed base) so
+// the lookup targets a stable, publicly reachable origin; fall back to localhost
+// only in development.
 const APP_URL =
   process.env.NEXT_PUBLIC_APP_URL ??
-  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
+  (process.env.NODE_ENV === "production" ? BASE_URL : "http://localhost:3000");
+
+// Bound the server-to-self geo fetch so a hung or protected upstream can't stall
+// the home render — the onboarding chooser is a fine fallback.
+const GEO_FETCH_TIMEOUT_MS = 2500;
 
 const SLUG_RE = /^[a-z0-9-]{1,80}$/;
 
@@ -34,11 +45,19 @@ export const metadata: Metadata = {
  *    or a "Where are you?" chooser when detection is unavailable.
  */
 export default async function Home() {
-  // Belt-and-suspenders redirect for returning users (middleware handles this too)
+  // Belt-and-suspenders redirect for returning users (middleware handles this too).
+  // Only redirect when the cookie slug both looks valid AND actually resolves to a
+  // real location. A stale cookie pointing at a deleted/never-existent slug would
+  // otherwise ping-pong: / → /<deadslug> → not-found → "go home" → / → … . Verifying
+  // resolution first breaks that loop and lets us fall through to fresh detection.
   const cookieStore = await cookies();
   const lastLocation = cookieStore.get("lastLocation")?.value;
   if (lastLocation && SLUG_RE.test(lastLocation)) {
-    redirect(`/${lastLocation}`);
+    const resolved = await getLocationFromDb(lastLocation).catch(() => null);
+    if (resolved) {
+      redirect(`/${lastLocation}`);
+    }
+    // Unresolvable cookie — ignore it and continue to IP-geo detection below.
   }
 
   // Read Vercel's automatic IP geolocation headers
@@ -49,15 +68,17 @@ export default async function Home() {
   let detectedLocation: WeatherLocation | null = null;
 
   if (lat && lon) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), GEO_FETCH_TIMEOUT_MS);
     try {
-      // autoCreate=true: create-on-demand from the IP-derived position so a
-      // first-time visitor from a city we haven't seen still lands on a real,
-      // resolvable location instead of the "not found" page. Dedup in
-      // upsert_placesgeo_city (5 km + normalised-name) prevents duplicates, so
-      // repeat visits from the same city resolve the existing entry.
+      // autoCreate=false: IP geolocation is FIND-ONLY. Vercel's IP headers give a
+      // coarse ISP/datacentre-centroid position, so creating a location from them
+      // would seed inaccurate, fine-grained entries. Auto-creation only happens on
+      // explicit user GPS (HomeLanding's detectUserLocation({ autoCreate: true })).
+      // Here we just resolve the nearest existing location for the countdown card.
       const res = await fetch(
-        `${APP_URL}/api/py/geo?lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}&autoCreate=true`,
-        { cache: "no-store" },
+        `${APP_URL}/api/py/geo?lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}&autoCreate=false`,
+        { cache: "no-store", signal: controller.signal },
       );
       if (res.ok) {
         const data = await res.json();
@@ -66,7 +87,9 @@ export default async function Home() {
         }
       }
     } catch {
-      // Geo lookup unavailable — HomeLanding will show the city-chooser fallback
+      // Geo lookup unavailable or timed out — HomeLanding shows the city-chooser fallback
+    } finally {
+      clearTimeout(timeout);
     }
   }
 

--- a/src/components/weather/CurrentConditions.tsx
+++ b/src/components/weather/CurrentConditions.tsx
@@ -16,8 +16,14 @@ interface Props {
 
 export function CurrentConditions({ current, locationName, daily, slug }: Props) {
   const info = weatherCodeToInfo(current.weather_code);
-  const todayHigh = daily ? Math.round(daily.temperature_2m_max[0]) : null;
-  const todayLow = daily ? Math.round(daily.temperature_2m_min[0]) : null;
+  // Guard empty daily arrays — daily.temperature_2m_max[0] would be undefined and
+  // Math.round(undefined) is NaN, rendering as "High NaN°".
+  const todayHigh = daily?.temperature_2m_max?.length
+    ? Math.round(daily.temperature_2m_max[0])
+    : null;
+  const todayLow = daily?.temperature_2m_min?.length
+    ? Math.round(daily.temperature_2m_min[0])
+    : null;
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
 

--- a/src/lib/json-ld.test.ts
+++ b/src/lib/json-ld.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { safeJsonLd } from "./json-ld";
+
+describe("safeJsonLd", () => {
+  it("produces JSON that parses back to the original value", () => {
+    const data = { name: "Harare", province: "Harare Metropolitan", tags: ["city"] };
+    expect(JSON.parse(safeJsonLd(data))).toEqual(data);
+  });
+
+  it("escapes < and > so a </script> payload cannot break out of the tag", () => {
+    const malicious = { name: "</script><script>alert(1)</script>" };
+    const out = safeJsonLd(malicious);
+    // The raw closing tag must not appear verbatim in the serialized output.
+    expect(out).not.toContain("</script>");
+    expect(out).not.toContain("<script>");
+    expect(out).toContain("\\u003c");
+    expect(out).toContain("\\u003e");
+    // ...but it still round-trips to the exact original string.
+    expect(JSON.parse(out).name).toBe("</script><script>alert(1)</script>");
+  });
+
+  it("escapes ampersands", () => {
+    const out = safeJsonLd({ name: "Dar & Salaam" });
+    expect(out).not.toContain(" & ");
+    expect(out).toContain("\\u0026");
+    expect(JSON.parse(out).name).toBe("Dar & Salaam");
+  });
+
+  it("escapes U+2028 and U+2029 line separators", () => {
+    const raw = "line1\u2028line2\u2029line3";
+    const out = safeJsonLd({ name: raw });
+    expect(out).not.toContain("\u2028");
+    expect(out).not.toContain("\u2029");
+    expect(out).toContain("\\u2028");
+    expect(out).toContain("\\u2029");
+    expect(JSON.parse(out).name).toBe(raw);
+  });
+
+  it("handles arrays of schema objects (as used on the location page)", () => {
+    const schemas = [{ "@type": "WebPage" }, { "@type": "BreadcrumbList" }];
+    expect(JSON.parse(safeJsonLd(schemas))).toEqual(schemas);
+  });
+});

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,0 +1,22 @@
+/**
+ * Safe serialization for JSON-LD injected into a
+ * `<script type="application/ld+json">` tag via `dangerouslySetInnerHTML`.
+ *
+ * Location names, provinces and country names in mukoko weather are
+ * Nominatim-derived and therefore attacker-influenceable. A raw `JSON.stringify`
+ * leaves `<`, `>` and `&` intact, so a value containing `</script>` would break
+ * out of the script element and execute — a stored XSS. Escaping those characters
+ * to their `\uXXXX` forms keeps the JSON byte-for-byte semantically identical
+ * (JSON parsers decode the escapes) while making script-tag breakout impossible.
+ *
+ * U+2028 / U+2029 are also escaped: they are valid inside JSON strings but are
+ * line terminators in HTML/JS and can corrupt the surrounding document.
+ */
+export function safeJsonLd(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}


### PR DESCRIPTION
## Summary

Fixes five issues on the home page and location page onboarding/SEO paths.

### Home page — `src/app/page.tsx`
1. **Stops creating junk locations from IP geo.** The server IP-geo lookup now calls `/api/py/geo?...&autoCreate=false`. Vercel's IP headers are a coarse ISP/datacentre-centroid position; auto-creating from them seeded inaccurate fine-grained locations. Per the Python contract, IP-geo must be find-only — auto-create stays on the explicit user-GPS path (`HomeLanding`'s `detectUserLocation({ autoCreate: true })`, unchanged).
2. **Non-degrading server self-fetch.** The `no-store` server-to-self fetch is now bounded by a 2.5s `AbortController` timeout and targets a stable base URL (production hostname, else localhost) instead of the per-deployment Vercel hostname. That hostname 401s on protected preview deployments (Deployment Protection), and the swallowed failure silently degraded onboarding.
3. **Breaks the stale-cookie redirect loop.** The `lastLocation` cookie redirect now verifies the slug actually resolves (`getLocationFromDb`) before redirecting, instead of only checking slug format. A stale cookie pointing at a dead slug previously ping-ponged `/` → `/<deadslug>` → not-found → "go home" → `/` → … .

### Location page — `src/app/[location]/page.tsx`
4. **JSON-LD XSS fixed.** The `<script type="application/ld+json">` block is now serialized via a new `safeJsonLd()` helper (`src/lib/json-ld.ts`) that escapes `<`, `>`, `&`, and U+2028/U+2029. A Nominatim-derived `name`/`province`/`countryName` containing `</script>` could previously break out of the script element (stored XSS). There is one JSON-LD block on this page; it is now escaped.
5. **Empty-array guards.** Guards empty `daily` arrays so `Math.max(...[])`/`Math.min(...[])` can't emit `-Infinity`/`Infinity` into the FAQ schema.

### CurrentConditions — `src/components/weather/CurrentConditions.tsx`
5. Guards empty `daily` arrays so today's high/low can't render as `NaN`.

## Tests
- New `src/lib/json-ld.test.ts` — behavioral escaping test (verifies a `</script>` payload cannot break out and still round-trips).
- Extended `src/app/HomeLanding.test.ts` — asserts `autoCreate=false`, the AbortController timeout, the stable base URL (no Vercel per-deployment hostname env var), and cookie-resolution gating.

## Verification
- `npm test` — 1840 passed
- `python3 -m pytest tests/py/` — 908 passed
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm run build` — compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)