### PR TITLE
fix(explore): derive country provinces so all 67 countries resolve

### DIFF
--- a/src/app/explore/[tag]/page.tsx
+++ b/src/app/explore/[tag]/page.tsx
@@ -104,7 +104,7 @@ export default async function ExploreTagPage({ params }: Props) {
 
         {locations.length === 0 && (
           <div className="mt-8 rounded-[var(--radius-card)] bg-surface-card p-6 text-center text-text-tertiary">
-            <p>No locations found. Please run database initialisation.</p>
+            <p>No locations available here yet.</p>
           </div>
         )}
 

--- a/src/app/explore/country/[code]/[province]/page.tsx
+++ b/src/app/explore/country/[code]/[province]/page.tsx
@@ -6,7 +6,6 @@ import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { getCountryByCode, getLocationsByProvince, getProvinceBySlug } from "@/lib/db";
 import { getFlagEmoji, PROVINCES } from "@/lib/countries";
-import { logError } from "@/lib/observability";
 
 export const revalidate = 3600;
 
@@ -55,35 +54,18 @@ export default async function ProvinceDetailPage({ params }: Props) {
 
   if (!/^[A-Z]{2}$/.test(upperCode)) notFound();
 
-  let locations: Awaited<ReturnType<typeof getLocationsByProvince>> = [];
-  let countryName = upperCode;
-  let provinceName = provinceSlug;
+  // These are pure static-array reads (LOCATIONS / COUNTRIES / PROVINCES) — they
+  // never throw, so no try/catch is needed.
+  const [locations, country, province] = await Promise.all([
+    getLocationsByProvince(provinceSlug),
+    loadCountry(upperCode),
+    loadProvince(provinceSlug),
+  ]);
+  const countryName = country?.name ?? upperCode;
+  // Use the stored province name rather than reconstructing from the slug.
+  const provinceName = province?.name ?? provinceSlug;
 
-  try {
-    const [locs, country, province] = await Promise.all([
-      getLocationsByProvince(provinceSlug),
-      loadCountry(upperCode),
-      loadProvince(provinceSlug),
-    ]);
-    locations = locs;
-    countryName = country?.name ?? upperCode;
-    // Use the stored province name rather than reconstructing from the slug
-    provinceName = province?.name ?? provinceSlug;
-  } catch (err) {
-    logError({
-      source: "mongodb",
-      severity: "high",
-      message: "Failed to load province detail page",
-      error: err,
-      meta: { code: upperCode, provinceSlug },
-    });
-    // Re-throw at request time so Next.js routes to error.tsx instead of a silent 404.
-    // During build-time static generation (MONGODB_URI absent), fall through to notFound()
-    // so the build succeeds and ISR handles the route on first real request.
-    if (process.env.MONGODB_URI) throw err;
-  }
-
-  // DB succeeded but the province has no locations — genuine 404.
+  // The province has no locations — genuine 404.
   if (locations.length === 0) notFound();
 
   const flag = getFlagEmoji(upperCode);

--- a/src/app/explore/country/[code]/page.tsx
+++ b/src/app/explore/country/[code]/page.tsx
@@ -6,7 +6,6 @@ import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import { getCountryWithStats, getProvincesWithLocationCounts } from "@/lib/db";
 import { getFlagEmoji, COUNTRIES } from "@/lib/countries";
-import { logError } from "@/lib/observability";
 
 export const revalidate = 3600;
 
@@ -45,29 +44,14 @@ export default async function CountryDetailPage({ params }: Props) {
   // Reject obviously invalid codes early — valid ISO 3166-1 alpha-2 are exactly 2 letters
   if (!/^[A-Z]{2}$/.test(upperCode)) notFound();
 
-  let country: Awaited<ReturnType<typeof getCountryWithStats>> = null;
-  let provinces: Awaited<ReturnType<typeof getProvincesWithLocationCounts>> = [];
+  // These are pure static-array reads (LOCATIONS / COUNTRIES / PROVINCES) — they
+  // never throw, so no try/catch is needed.
+  const [country, provinces] = await Promise.all([
+    loadCountry(upperCode),
+    getProvincesWithLocationCounts(upperCode),
+  ]);
 
-  try {
-    [country, provinces] = await Promise.all([
-      loadCountry(upperCode),
-      getProvincesWithLocationCounts(upperCode),
-    ]);
-  } catch (err) {
-    logError({
-      source: "mongodb",
-      severity: "high",
-      message: "Failed to load country detail page",
-      error: err,
-      meta: { code: upperCode },
-    });
-    // Re-throw at request time so Next.js routes to error.tsx instead of a silent 404.
-    // During build-time static generation (MONGODB_URI absent), fall through to notFound()
-    // so the build succeeds and ISR handles the route on first real request.
-    if (process.env.MONGODB_URI) throw err;
-  }
-
-  // DB succeeded but the country doesn't exist — genuine 404.
+  // The country doesn't exist — genuine 404.
   if (!country) notFound();
 
   const flag = getFlagEmoji(upperCode);
@@ -114,7 +98,7 @@ export default async function CountryDetailPage({ params }: Props) {
 
         {provinces.filter((p) => p.locationCount > 0).length === 0 ? (
           <div className="mt-8 rounded-[var(--radius-card)] bg-surface-card p-6 text-center text-text-tertiary">
-            <p>No provinces found. Run database initialisation to populate data.</p>
+            <p>No locations available here yet.</p>
           </div>
         ) : (
           <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -116,7 +116,7 @@ export default async function ExplorePage() {
 
           {tagCounts.length === 0 && (
             <div className="mt-6 rounded-[var(--radius-card)] bg-surface-card p-6 text-center text-text-tertiary">
-              <p>Location data is loading. Please run database initialisation first.</p>
+              <p>No locations available here yet.</p>
             </div>
           )}
 

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -38,6 +38,8 @@ import {
 import { REGIONS } from "./seed-regions";
 import { TAGS } from "./seed-tags";
 import { SEASONS } from "./seed-seasons";
+import { LOCATIONS } from "./locations";
+import { PROVINCES, generateProvinceSlug } from "./countries";
 
 describe("getTtlForLocation", () => {
   it("returns tier 1 (1800s) for locations with city tag", () => {
@@ -176,6 +178,86 @@ describe("new DB helper function exports", () => {
 
     expect(fnBody).toContain("LOCATIONS.length");
     expect(fnBody).not.toContain("estimatedDocumentCount");
+  });
+});
+
+describe("province readers derive from LOCATIONS (union with static PROVINCES)", () => {
+  const slugForLoc = (l: (typeof LOCATIONS)[number]) =>
+    l.provinceSlug ?? generateProvinceSlug(l.province, l.country ?? "");
+
+  // Pick a country that has seed LOCATIONS but NO static PROVINCES rows, so its
+  // provinces MUST be derived. Singapore (SG) is the canonical example.
+  const derivedOnlyCode = "SG";
+
+  it("derives provinces for a country with no static PROVINCES rows", async () => {
+    const sgLocations = LOCATIONS.filter(
+      (l) => (l.country ?? "").toUpperCase() === derivedOnlyCode,
+    );
+    expect(sgLocations.length).toBeGreaterThan(0);
+    // Precondition for the test: SG genuinely has no static province rows.
+    expect(PROVINCES.some((p) => p.countryCode.toUpperCase() === derivedOnlyCode)).toBe(false);
+
+    const provinces = await getProvincesWithLocationCounts(derivedOnlyCode);
+
+    // Every SG location's province slug is represented exactly once.
+    const expectedSlugs = new Set(sgLocations.map(slugForLoc));
+    const returnedSlugs = provinces.map((p) => p.slug);
+    expect(new Set(returnedSlugs).size).toBe(returnedSlugs.length); // no dupes
+    for (const slug of expectedSlugs) {
+      expect(returnedSlugs).toContain(slug);
+    }
+
+    // Counts are correct: sum of derived counts equals SG's location total.
+    const total = provinces.reduce((sum, p) => sum + p.locationCount, 0);
+    expect(total).toBe(sgLocations.length);
+    // Each derived province carries its human province name, not the slug.
+    for (const p of provinces) {
+      expect(p.name.length).toBeGreaterThan(0);
+      expect(p.name).not.toBe(p.slug);
+    }
+  });
+
+  it("getProvinceBySlug resolves a derived (non-static) province", async () => {
+    const sgLoc = LOCATIONS.find((l) => (l.country ?? "").toUpperCase() === derivedOnlyCode);
+    expect(sgLoc).toBeTruthy();
+    const slug = slugForLoc(sgLoc!);
+
+    // Not present in the static catalog — must be derived.
+    expect(PROVINCES.some((p) => p.slug === slug)).toBe(false);
+
+    const province = await getProvinceBySlug(slug);
+    expect(province).not.toBeNull();
+    expect(province!.slug).toBe(slug);
+    expect(province!.name).toBe(sgLoc!.province);
+    expect(province!.countryCode).toBe(derivedOnlyCode);
+  });
+
+  it("every seed location is reachable via exactly one province card (all countries)", async () => {
+    const codes = new Set(
+      LOCATIONS.map((l) => (l.country ?? "").toUpperCase()).filter(Boolean),
+    );
+    for (const code of codes) {
+      const countryLocs = LOCATIONS.filter((l) => (l.country ?? "").toUpperCase() === code);
+      const provinces = await getProvincesWithLocationCounts(code);
+      const bySlug = new Map(provinces.map((p) => [p.slug, p.locationCount]));
+      // Each location's province slug exists in the returned catalog.
+      for (const loc of countryLocs) {
+        expect(bySlug.has(slugForLoc(loc))).toBe(true);
+      }
+      // Total counted equals the number of seed locations in the country.
+      const total = provinces.reduce((sum, p) => sum + p.locationCount, 0);
+      expect(total).toBe(countryLocs.length);
+    }
+  });
+
+  it("getAllProvinces includes derived provinces for sitemap coverage", async () => {
+    const all = await getAllProvinces();
+    const allSlugs = new Set(all.map((p) => p.slug));
+    // Every province slug that any seed location maps to is present.
+    for (const loc of LOCATIONS) {
+      if (!(loc.country ?? "")) continue;
+      expect(allSlugs.has(slugForLoc(loc))).toBe(true);
+    }
   });
 });
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1390,18 +1390,60 @@ export async function getLocationsByProvince(provinceSlug: string): Promise<Loca
     .map((loc) => ({ ...loc, updatedAt: now })) as LocationDoc[];
 }
 
-/** Get a single province by its slug (from the static PROVINCES catalog) */
-export async function getProvinceBySlug(slug: string): Promise<ProvinceDoc | null> {
-  const province = PROVINCES.find((p) => p.slug === slug);
-  return province ? { ...province, updatedAt: new Date() } : null;
+/**
+ * Compute the province slug for a seed location: prefer its explicit
+ * `provinceSlug`, otherwise derive it from the province name + country code.
+ */
+function provinceSlugForLocation(loc: WeatherLocation): string {
+  return loc.provinceSlug ?? generateProvinceSlug(loc.province, loc.country ?? "");
 }
 
-/** Get all provinces (for sitemap generation) from the static PROVINCES catalog */
+/**
+ * Get a single province by its slug. Prefers the static PROVINCES catalog (for
+ * curated name/metadata) and falls back to DERIVING the province from the seed
+ * LOCATIONS — so provinces that have seed locations but no static row (e.g.
+ * Singapore's "Central Region") still resolve instead of dead-ending in a 404.
+ */
+export async function getProvinceBySlug(slug: string): Promise<ProvinceDoc | null> {
+  const now = new Date();
+  const province = PROVINCES.find((p) => p.slug === slug);
+  if (province) return { ...province, updatedAt: now };
+
+  const loc = LOCATIONS.find((l) => provinceSlugForLocation(l) === slug);
+  if (!loc) return null;
+  return {
+    slug,
+    name: loc.province,
+    countryCode: (loc.country ?? "").toUpperCase(),
+    updatedAt: now,
+  };
+}
+
+/**
+ * Get all provinces (for sitemap generation). UNIONs the static PROVINCES
+ * catalog with provinces DERIVED from the seed LOCATIONS (static row wins on
+ * name/metadata), so every province that has at least one location — including
+ * countries with no static PROVINCES rows — is present in the sitemap.
+ */
 export async function getAllProvinces(): Promise<ProvinceDoc[]> {
   const now = new Date();
-  return [...PROVINCES]
-    .sort((a, b) => a.countryCode.localeCompare(b.countryCode) || a.name.localeCompare(b.name))
-    .map((p) => ({ ...p, updatedAt: now }));
+  const bySlug = new Map<string, ProvinceDoc>();
+
+  for (const p of PROVINCES) {
+    bySlug.set(p.slug, { ...p, updatedAt: now });
+  }
+  for (const loc of LOCATIONS) {
+    const countryCode = (loc.country ?? "").toUpperCase();
+    if (!countryCode) continue;
+    const slug = provinceSlugForLocation(loc);
+    if (!bySlug.has(slug)) {
+      bySlug.set(slug, { slug, name: loc.province, countryCode, updatedAt: now });
+    }
+  }
+
+  return [...bySlug.values()].sort(
+    (a, b) => a.countryCode.localeCompare(b.countryCode) || a.name.localeCompare(b.name),
+  );
 }
 
 /**
@@ -1424,7 +1466,16 @@ export async function getAllLocationSlugsForSitemap(): Promise<{ slug: string; t
 
 /**
  * Get provinces for a country with their seed-location counts.
- * Phase 0F: counts come from the static seed catalog.
+ *
+ * Provinces are DERIVED from the actual seed LOCATIONS (grouped by
+ * `provinceSlug ?? generateProvinceSlug(province, country)`) and UNIONed with
+ * any static PROVINCES rows for the country. The static row wins for
+ * name/metadata; derived groups fill the gaps for the ~41 countries that have
+ * seed locations but no static PROVINCES entry (SG, DZ, MG, LY, SZ, …) and for
+ * orphaned locations whose province slug has no matching static row. This
+ * guarantees every location is reachable via exactly one province card with a
+ * correct count. Static provinces with no seed locations are retained (count 0)
+ * to preserve the previous browse behaviour.
  */
 export async function getProvincesWithLocationCounts(
   countryCode: string,
@@ -1432,18 +1483,33 @@ export async function getProvincesWithLocationCounts(
   const upper = countryCode.toUpperCase();
   const now = new Date();
 
-  const provinces = PROVINCES.filter((p) => p.countryCode.toUpperCase() === upper)
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map((p) => ({ ...p, updatedAt: now }));
+  const bySlug = new Map<string, ProvinceDoc & { locationCount: number }>();
 
-  const countMap = new Map<string, number>();
-  for (const loc of LOCATIONS) {
-    if ((loc.country ?? "").toUpperCase() !== upper) continue;
-    const slug = loc.provinceSlug ?? generateProvinceSlug(loc.province, loc.country ?? "");
-    countMap.set(slug, (countMap.get(slug) ?? 0) + 1);
+  // Seed static rows first so their curated name/metadata win.
+  for (const p of PROVINCES) {
+    if (p.countryCode.toUpperCase() !== upper) continue;
+    bySlug.set(p.slug, { ...p, updatedAt: now, locationCount: 0 });
   }
 
-  return provinces.map((p) => ({ ...p, locationCount: countMap.get(p.slug) ?? 0 }));
+  // Derive from actual locations: fill gaps and count every location.
+  for (const loc of LOCATIONS) {
+    if ((loc.country ?? "").toUpperCase() !== upper) continue;
+    const slug = provinceSlugForLocation(loc);
+    const existing = bySlug.get(slug);
+    if (existing) {
+      existing.locationCount += 1;
+    } else {
+      bySlug.set(slug, {
+        slug,
+        name: loc.province,
+        countryCode: upper,
+        updatedAt: now,
+        locationCount: 1,
+      });
+    }
+  }
+
+  return [...bySlug.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`/explore/country/[code]` dead-ended on **"No provinces found. Run database initialisation…"** for 40 of 67 countries. `getProvincesWithLocationCounts` built its province list by filtering the **static** `PROVINCES` array (`src/lib/countries.ts`), which only defines provinces for 27 countries. Countries with seed `LOCATIONS` but no `PROVINCES` rows (SG, DZ, MG, LY, SZ, MM, SD, LS, MU, KH, LA, …) showed the empty state even though they have locations. Additionally, locations in otherwise-working countries whose `provinceSlug` had no matching `PROVINCES` row (e.g. `ibadan-ng`→`oyo-state-ng`, `pattaya-th`→`chonburi-province-th`) were orphaned/unreachable.

## Fix

Province readers now **derive** provinces from the actual `LOCATIONS` for a country — grouping by `location.provinceSlug ?? generateProvinceSlug(location.province, country)` — and **union** them with any static `PROVINCES` rows (static row wins for name/metadata; derived fills the gaps). Return shapes are unchanged, so the explore pages need no structural changes.

- **`getProvincesWithLocationCounts`** — derive + union; every location reachable via exactly one province card with a correct count. Static provinces with no locations are retained (count 0) to preserve prior browse behaviour.
- **`getProvinceBySlug`** — falls back to deriving from `LOCATIONS` so derived province pages resolve instead of 404ing.
- **`getAllProvinces`** — unions derived provinces for full sitemap coverage.
- **Explore pages** — reworded the stale *"run database initialisation"* empty-state copy to *"No locations available here yet."* (these read static arrays now; DB init cannot change the state), and removed the now-unreachable `if (process.env.MONGODB_URI) throw` blocks in the country and province pages (pure static-array reads never throw).

## Impact

- **67 / 67** countries with seed locations now resolve their province browse (previously **27**).
- **40** countries that used to dead-end now show derived province cards.
- Orphaned locations within the 27 already-working countries are now reachable too.

## Tests

Added a `db.test.ts` suite covering a country with **no** static `PROVINCES` rows (Singapore): asserts provinces are derived, counts are correct, `getProvinceBySlug` resolves the derived province, `getAllProvinces` includes it, and — across **all** countries — every seed location maps to exactly one returned province with the totals matching.

Verified: `npm test` (1835 passed), `npx tsc --noEmit` (0 errors), `npm run lint` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)