### PR TITLE
fix(map): surface base-map load failures + fix async leak, layer toggle, layout shift

### DIFF
--- a/src/app/[location]/map/MapDashboard.tsx
+++ b/src/app/[location]/map/MapDashboard.tsx
@@ -11,7 +11,7 @@ import type { WeatherLocation } from "@/lib/locations";
 
 const MapLibreMap = dynamic(
   () => import("@/components/weather/map/MapLibreMap").then((m) => ({ default: m.MapLibreMap })),
-  { ssr: false, loading: () => <MapSkeleton className="h-full rounded-none" /> },
+  { ssr: false, loading: () => <MapSkeleton fill className="rounded-none" /> },
 );
 
 interface MapDashboardProps {

--- a/src/components/weather/map/MapLibreMap.test.ts
+++ b/src/components/weather/map/MapLibreMap.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock the Zustand store so importing MapLibreMap doesn't pull in the RxDB
+// bridge / replication side effects. The pure helpers under test don't use it.
+vi.mock("@/lib/store", () => ({
+  useAppStore: (selector: (s: { theme: string }) => unknown) =>
+    selector({ theme: "light" }),
+}));
+
+import { getMapTilerStyle, classifyMapError } from "./MapLibreMap";
+import { WEATHER_OVERLAY_ID } from "@/lib/map-layers";
+
+describe("getMapTilerStyle", () => {
+  it("returns the light MapTiler streets style URL by default", () => {
+    const url = getMapTilerStyle(false);
+    expect(url).toContain("maptiler.com/maps/streets-v2/style.json");
+    expect(url).not.toContain("streets-v2-dark");
+  });
+
+  it("returns the dark MapTiler streets style URL when isDark", () => {
+    const url = getMapTilerStyle(true);
+    expect(url).toContain("maptiler.com/maps/streets-v2-dark/style.json");
+  });
+
+  it("always targets MapTiler, never Mapbox", () => {
+    for (const dark of [true, false]) {
+      const url = getMapTilerStyle(dark);
+      expect(url).toContain("maptiler.com");
+      expect(url).not.toContain("mapbox.com");
+    }
+  });
+});
+
+describe("classifyMapError", () => {
+  it("classifies weather-overlay source errors as 'overlay'", () => {
+    expect(
+      classifyMapError({ sourceId: WEATHER_OVERLAY_ID }, WEATHER_OVERLAY_ID),
+    ).toBe("overlay");
+  });
+
+  it("classifies a style-load error with no sourceId as 'base'", () => {
+    // A failed style.json fetch (expired / over-quota key → 403/429) carries no
+    // sourceId — it must surface the base-map notice, not the overlay one.
+    expect(
+      classifyMapError({ error: new Error("403 Forbidden") }, WEATHER_OVERLAY_ID),
+    ).toBe("base");
+  });
+
+  it("classifies base-tile source errors as 'base'", () => {
+    expect(
+      classifyMapError({ sourceId: "openmaptiles" }, WEATHER_OVERLAY_ID),
+    ).toBe("base");
+  });
+
+  it("handles a null/empty event defensively as 'base'", () => {
+    expect(
+      classifyMapError({} as { sourceId?: string }, WEATHER_OVERLAY_ID),
+    ).toBe("base");
+  });
+});

--- a/src/components/weather/map/MapLibreMap.tsx
+++ b/src/components/weather/map/MapLibreMap.tsx
@@ -14,6 +14,21 @@ export function getMapTilerStyle(isDark: boolean): string {
 }
 
 /**
+ * Classifies a MapLibre `error` event as either a weather-overlay failure or a
+ * base-map failure (style/base-tile/source load error). The weather overlay is
+ * the only source we register under `overlayId`, so any error not tied to it —
+ * including a failed style.json fetch (expired/over-quota MapTiler key → 403/429)
+ * which carries no `sourceId` — is treated as a base-map failure. Exported for
+ * testing.
+ */
+export function classifyMapError(
+  e: { error?: Error; sourceId?: string },
+  overlayId: string,
+): "overlay" | "base" {
+  return e?.sourceId === overlayId ? "overlay" : "base";
+}
+
+/**
  * Adds (or replaces) the Tomorrow.io weather overlay on a loaded map.
  * Idempotent — removes any existing overlay first, then re-adds it for the
  * given layer. A null/empty layer just clears the overlay. Safe to call after
@@ -62,6 +77,10 @@ export function MapLibreMap({
   const weatherLayerRef = useRef<string | null>(weatherLayer);
   weatherLayerRef.current = weatherLayer;
   const [overlayError, setOverlayError] = useState(false);
+  // Set when the base map style / base tiles fail to load at runtime (e.g. an
+  // expired or over-quota MapTiler key returning 403/429). Without this the map
+  // renders as a silent blank/partial surface with no feedback.
+  const [baseMapError, setBaseMapError] = useState(false);
   // The MapTiler base tiles load client-side directly from the CDN using
   // NEXT_PUBLIC_MAPTILER_API_KEY. When the key is missing the style request
   // fails and the map renders as a blank surface — surface that explicitly
@@ -81,13 +100,17 @@ export function MapLibreMap({
     // notice below rather than letting MapLibre repeatedly fail on a broken URL.
     if (baseMapMissingKey) return;
 
-    let map: MapLibreGLMap;
+    // Guard against the async import resolving after unmount (doubled under
+    // React StrictMode) — a Map created past unmount would otherwise leak,
+    // never getting `.remove()`d by the cleanup below.
+    let cancelled = false;
 
     import("maplibre-gl").then(({ Map, Marker: MLMarker, NavigationControl }) => {
+      if (cancelled || !containerRef.current) return;
       import("maplibre-gl/dist/maplibre-gl.css");
 
-      map = new Map({
-        container: containerRef.current!,
+      const map: MapLibreGLMap = new Map({
+        container: containerRef.current,
         style: getMapTilerStyle(isDark),
         center: [lon, lat],
         zoom,
@@ -96,6 +119,12 @@ export function MapLibreMap({
           customAttribution: '© <a href="https://www.maptiler.com/">MapTiler</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
         },
       });
+
+      // Unmounted while the Map was constructing — tear it down immediately.
+      if (cancelled) {
+        map.remove();
+        return;
+      }
 
       mapRef.current = map;
 
@@ -114,18 +143,24 @@ export function MapLibreMap({
 
       map.on("load", restore);
 
-      // Surface tile failures (missing/expired API key → 503, rate limit → 429,
-      // upstream error) instead of showing a silent blank overlay.
+      // Surface tile/style failures (missing/expired API key → 403/503, rate
+      // limit → 429, upstream error) instead of showing a silent blank map.
+      // Overlay errors show the transient overlay notice; base-map/style errors
+      // show the "Base map unavailable" notice so a blank base map is never
+      // silent.
       map.on("error", (e: { error?: Error; sourceId?: string }) => {
-        if (e?.sourceId === WEATHER_OVERLAY_ID) {
+        if (classifyMapError(e, WEATHER_OVERLAY_ID) === "overlay") {
           setOverlayError(true);
-          // eslint-disable-next-line no-console
           console.error("[weather-map] overlay tile failed to load", e?.error);
+        } else {
+          setBaseMapError(true);
+          console.error("[weather-map] base map failed to load", e?.error);
         }
       });
     });
 
     return () => {
+      cancelled = true;
       markerRef.current?.remove();
       mapRef.current?.remove();
       mapRef.current = null;
@@ -144,11 +179,20 @@ export function MapLibreMap({
     map.once("idle", () => restoreRef.current?.());
   }, [isDark]);
 
-  // Switch weather overlay when the selected layer changes.
+  // Switch weather overlay when the selected layer changes. If the style isn't
+  // loaded yet (e.g. user toggles a layer before the base style finishes), defer
+  // until the map goes idle and apply then — otherwise the switch silently no-ops.
   useEffect(() => {
     const map = mapRef.current;
-    if (!map || !map.isStyleLoaded()) return;
+    if (!map) return;
     setOverlayError(false);
+    if (!map.isStyleLoaded()) {
+      const apply = () => applyWeatherOverlay(map, weatherLayer);
+      map.once("idle", apply);
+      return () => {
+        map.off("idle", apply);
+      };
+    }
     applyWeatherOverlay(map, weatherLayer);
   }, [weatherLayer]);
 
@@ -167,7 +211,19 @@ export function MapLibreMap({
           </p>
         </div>
       )}
-      {overlayError && !baseMapMissingKey && (
+      {baseMapError && !baseMapMissingKey && (
+        <div
+          role="status"
+          className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 bg-surface-base p-6 text-center"
+        >
+          <p className="text-sm font-semibold text-text-primary">Base map unavailable</p>
+          <p className="max-w-xs text-xs text-text-tertiary">
+            The base map could not be loaded. This is usually a temporary issue — please try
+            again later.
+          </p>
+        </div>
+      )}
+      {overlayError && !baseMapMissingKey && !baseMapError && (
         <div
           role="status"
           className="pointer-events-none absolute left-1/2 top-3 z-10 -translate-x-1/2 rounded-[var(--radius-button)] border border-severity-high/30 bg-surface-card/95 px-3 py-1.5 text-xs font-medium text-severity-high shadow-lg backdrop-blur-sm"

--- a/src/components/weather/map/MapSkeleton.tsx
+++ b/src/components/weather/map/MapSkeleton.tsx
@@ -1,9 +1,21 @@
 "use client";
 
-export function MapSkeleton({ className }: { className?: string }) {
+/**
+ * Map loading placeholder. Defaults to a 16:9 card (matches the compact
+ * MapPreview). Pass `fill` for full-height contexts (the full-viewport map
+ * dashboard) so the skeleton box matches the final map and there's no layout
+ * shift when the real map mounts.
+ */
+export function MapSkeleton({
+  className,
+  fill = false,
+}: {
+  className?: string;
+  fill?: boolean;
+}) {
   return (
     <div
-      className={`relative aspect-[16/9] w-full animate-pulse rounded-[var(--radius-card)] bg-surface-card overflow-hidden ${className ?? ""}`}
+      className={`relative ${fill ? "h-full w-full" : "aspect-[16/9] w-full"} animate-pulse rounded-[var(--radius-card)] bg-surface-card overflow-hidden ${className ?? ""}`}
       role="status"
       aria-label="Loading map"
     >


### PR DESCRIPTION
## Problem

The MapLibre weather map (`src/components/weather/map/MapLibreMap.tsx`) could silently blank with no user feedback, and it leaked `Map` instances. Four related issues, all fixed here.

## Fixes

1. **Invisible base-map failure** — the `map.on("error")` handler only reacted when the error was tied to the weather overlay source, and the "map unavailable" notice only rendered for a literally-empty `NEXT_PUBLIC_MAPTILER_API_KEY`. So an **expired / over-quota MapTiler key (403/429)** or any style/base-tile load error produced a silent blank or partial base map — a classic pitch-day blank map. Added `classifyMapError()` which routes any non-overlay error to a visible **"Base map unavailable"** notice (reuses the existing notice UI + design tokens, no hardcoded styles).

2. **Async-mount leak** — the dynamic `import("maplibre-gl")` had no cancellation guard, so unmount-before-resolve orphaned a `Map` that was never `.remove()`d (doubled under React StrictMode). Added a `cancelled` flag / cleanup that removes a `Map` constructed after unmount.

3. **Layer toggle dropped mid-load** — switching the overlay before the style finished loading early-returned and never retried, so the change silently no-op'd. Now defers via `map.once("idle", …)` and applies the selected layer then (with listener cleanup).

4. **Layout shift** — the full-viewport dashboard loading fallback (`src/app/[location]/map/MapDashboard.tsx`) used `h-full` while `MapSkeleton` was hardcoded `aspect-[16/9]`, causing a jump when the real map mounted. Added a `fill` mode to `MapSkeleton` so the skeleton box matches the final map.

## Tests

- New `src/components/weather/map/MapLibreMap.test.ts` — covers `getMapTilerStyle` (light/dark, MapTiler-not-Mapbox) and the new `classifyMapError` (overlay vs base, no-`sourceId` style-load error → base, defensive empty event).

## Verification

- `npm test` — 78 files, 1838 passed
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors
- `npm run build` — succeeds

Scope: only the MapLibre map component + dashboard wrapper + its skeleton. The Tomorrow.io tile proxy and the layer switcher panel are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)