### PR TITLE
fix(resilience): stop /status quota burn + guard history/suntimes/footer/usermenu

### DIFF
--- a/api/py/_status.py
+++ b/api/py/_status.py
@@ -17,6 +17,22 @@ from ._db import get_db, get_api_key
 
 router = APIRouter()
 
+# Model the app actually runs (Haiku). Kept in sync with api/py/_ai.py.
+ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
+
+# Server-side cache for the assembled status payload. The dashboard polls this
+# endpoint (and multiple tabs multiply that), so without a short TTL every poll
+# fans out to live MongoDB / Tomorrow.io / Open-Meteo checks — which burns the
+# shared Tomorrow.io free-tier quota (25/hr) and can 429 real weather serving.
+_STATUS_CACHE_TTL_S = 60.0
+_status_cache: dict = {"data": None, "ts": 0.0}
+
+
+def _reset_status_cache() -> None:
+    """Clear the cached status payload (used by tests)."""
+    _status_cache["data"] = None
+    _status_cache["ts"] = 0.0
+
 
 def _check_mongodb() -> dict:
     start = time.time()
@@ -137,9 +153,16 @@ def _check_open_meteo() -> dict:
 
 
 def _check_anthropic() -> dict:
-    start = time.time()
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    """Check Anthropic availability WITHOUT spending tokens.
 
+    A live /v1/messages ping bills a request every time the status page is
+    polled (and anonymous users could burn credits at will). Instead we verify
+    the key is present and report the model the app is actually configured to
+    run — a key-presence + model-config check that costs nothing.
+    """
+    start = time.time()
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         try:
             api_key = get_api_key("anthropic")
@@ -154,59 +177,12 @@ def _check_anthropic() -> dict:
             "message": "API key not configured — basic summary fallback active",
         }
 
-    try:
-        with httpx.Client(timeout=15.0) as client:
-            resp = client.post(
-                "https://api.anthropic.com/v1/messages",
-                headers={
-                    "x-api-key": api_key,
-                    "anthropic-version": "2023-06-01",
-                    "content-type": "application/json",
-                },
-                json={
-                    "model": "claude-sonnet-4-20250514",
-                    "max_tokens": 1,
-                    "messages": [{"role": "user", "content": "ping"}],
-                },
-            )
-
-        if resp.status_code == 401:
-            return {
-                "name": "Anthropic AI (Shamwari)",
-                "status": "down",
-                "latencyMs": round((time.time() - start) * 1000),
-                "message": "Invalid API key",
-            }
-
-        if resp.status_code == 429:
-            return {
-                "name": "Anthropic AI (Shamwari)",
-                "status": "degraded",
-                "latencyMs": round((time.time() - start) * 1000),
-                "message": "Rate limited — AI summaries may be delayed",
-            }
-
-        if 200 <= resp.status_code < 300:
-            return {
-                "name": "Anthropic AI (Shamwari)",
-                "status": "operational",
-                "latencyMs": round((time.time() - start) * 1000),
-                "message": "Responding normally",
-            }
-
-        return {
-            "name": "Anthropic AI (Shamwari)",
-            "status": "degraded",
-            "latencyMs": round((time.time() - start) * 1000),
-            "message": f"HTTP {resp.status_code}",
-        }
-    except Exception as e:
-        return {
-            "name": "Anthropic AI (Shamwari)",
-            "status": "down",
-            "latencyMs": round((time.time() - start) * 1000),
-            "message": str(e)[:200],
-        }
+    return {
+        "name": "Anthropic AI (Shamwari)",
+        "status": "operational",
+        "latencyMs": round((time.time() - start) * 1000),
+        "message": f"API key configured (model: {ANTHROPIC_MODEL})",
+    }
 
 
 def _check_weather_cache() -> dict:
@@ -263,7 +239,16 @@ def _check_ai_cache() -> dict:
 
 @router.get("/api/py/status")
 async def system_status():
-    """GET /api/py/status — Live system health checks."""
+    """GET /api/py/status — Live system health checks.
+
+    Result is cached server-side for ~60s so rapid/multi-tab polling doesn't
+    multiply upstream calls (protects the shared Tomorrow.io free-tier quota).
+    """
+    now = time.time()
+    cached = _status_cache["data"]
+    if cached is not None and (now - _status_cache["ts"]) < _STATUS_CACHE_TTL_S:
+        return cached
+
     start = time.time()
 
     checks = [
@@ -281,9 +266,13 @@ async def system_status():
     elif any(c["status"] == "degraded" for c in checks):
         overall = "degraded"
 
-    return {
+    result = {
         "status": overall,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "totalLatencyMs": round((time.time() - start) * 1000),
         "checks": checks,
     }
+
+    _status_cache["data"] = result
+    _status_cache["ts"] = time.time()
+    return result

--- a/src/app/history/HistoryDashboard.test.ts
+++ b/src/app/history/HistoryDashboard.test.ts
@@ -196,6 +196,23 @@ describe("transformHistory", () => {
     expect(result[0].tempHigh).toBe(28); // current.temperature_2m
     expect(result[0].precipitation).toBe(0); // current.precipitation
   });
+
+  it("skips docs missing the current block without throwing", () => {
+    const good = makeDoc("2026-01-02");
+    const broken = makeDoc("2026-01-01");
+    // Simulate a persisted doc that never got a `current` block.
+    delete (broken as Partial<WeatherHistoryDoc>).current;
+    const result = transformHistory([good, broken]);
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toBe("2026-01-02");
+  });
+
+  it("returns empty array when all docs lack current (no crash)", () => {
+    const broken = makeDoc("2026-01-01");
+    delete (broken as Partial<WeatherHistoryDoc>).current;
+    expect(() => transformHistory([broken])).not.toThrow();
+    expect(transformHistory([broken])).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/app/history/HistoryDashboard.tsx
+++ b/src/app/history/HistoryDashboard.tsx
@@ -98,6 +98,9 @@ function formatSunTime(iso: string): string {
 
 export function transformHistory(docs: WeatherHistoryDoc[]): HistoryRecord[] {
   return docs
+    // A persisted doc missing `current` would throw on the unguarded
+    // `current.*` reads below and blank the whole dashboard. Skip such docs.
+    .filter((doc) => doc.current != null)
     .map((doc) => {
       const daily = doc.daily;
       const current = doc.current;

--- a/src/app/status/StatusDashboard.tsx
+++ b/src/app/status/StatusDashboard.tsx
@@ -71,8 +71,10 @@ export function StatusDashboard() {
   useEffect(() => {
     fetchStatus();
 
-    // Auto-refresh every 60 seconds
-    const interval = setInterval(fetchStatus, 60000);
+    // Auto-refresh every 5 minutes. The server caches the payload for ~60s, so
+    // spacing client polls well beyond that avoids piling requests on top of a
+    // still-fresh cache while keeping the dashboard reasonably live.
+    const interval = setInterval(fetchStatus, 5 * 60 * 1000);
     return () => clearInterval(interval);
   }, [fetchStatus]);
 
@@ -98,7 +100,7 @@ export function StatusDashboard() {
         <p className="mt-1 text-base text-text-secondary">{error}</p>
         <button
           onClick={fetchStatus}
-          className="mt-4 rounded-md bg-primary px-4 py-2 text-base font-medium text-primary-fg transition-colors hover:bg-primary/90"
+          className="mt-4 rounded-md bg-primary px-4 py-2 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
           Retry
         </button>
@@ -171,7 +173,7 @@ export function StatusDashboard() {
           </li>
         </ul>
         <p className="mt-3 text-text-tertiary">
-          Status auto-refreshes every 60 seconds. All checks run in parallel for minimum latency.
+          Status auto-refreshes every 5 minutes and is cached server-side for ~60 seconds. All checks run in parallel for minimum latency.
         </p>
       </div>
     </div>

--- a/src/components/auth/UserMenu.tsx
+++ b/src/components/auth/UserMenu.tsx
@@ -75,8 +75,8 @@ export function UserMenu({ user: userProp, compact = true }: UserMenuProps) {
   // ── Signed in ─────────────────────────────────────────────────────────
   const initials = initialsFor(user);
   const displayName =
-    user.email ??
-    [user.firstName, user.lastName].filter(Boolean).join(" ") ??
+    user.email ||
+    [user.firstName, user.lastName].filter(Boolean).join(" ") ||
     "Signed in";
   const hasPicture = Boolean(user.profilePictureUrl);
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,20 +2,9 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 
 export function Footer() {
   const year = new Date().getFullYear();
-  const [stars, setStars] = useState(0);
-
-  useEffect(() => {
-    fetch("https://api.github.com/repos/nyuchitech/mukoko-weather", {
-      headers: { Accept: "application/vnd.github.v3+json" },
-    })
-      .then((r) => r.ok ? r.json() : null)
-      .then((d) => { if (typeof d?.stargazers_count === "number") setStars(d.stargazers_count); })
-      .catch(() => {});
-  }, []);
 
   const col = "flex flex-col gap-1";
   const heading = "mb-2 text-xs font-semibold uppercase tracking-widest text-text-tertiary";
@@ -45,9 +34,6 @@ export function Footer() {
               <a href="https://github.com/nyuchitech/mukoko-weather" target="_blank" rel="noopener noreferrer" aria-label="GitHub" className="text-text-tertiary hover:text-text-primary transition-colors">
                 <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
               </a>
-              {stars > 0 && (
-                <span className="text-xs text-text-tertiary tabular-nums">★ {stars}</span>
-              )}
             </div>
           </div>
 

--- a/src/components/weather/SunTimes.tsx
+++ b/src/components/weather/SunTimes.tsx
@@ -6,14 +6,25 @@ interface Props {
 }
 
 export function SunTimes({ daily }: Props) {
-  const sunrise = new Date(daily.sunrise[0]);
-  const sunset = new Date(daily.sunset[0]);
-  const fmt = (d: Date) =>
-    d.toLocaleTimeString("en-ZW", { hour: "2-digit", minute: "2-digit", hour12: false });
+  const sunriseRaw = daily.sunrise?.[0];
+  const sunsetRaw = daily.sunset?.[0];
+  const sunrise = sunriseRaw != null ? new Date(sunriseRaw) : null;
+  const sunset = sunsetRaw != null ? new Date(sunsetRaw) : null;
 
-  const daylightMs = sunset.getTime() - sunrise.getTime();
-  const daylightHours = Math.floor(daylightMs / (1000 * 60 * 60));
-  const daylightMinutes = Math.round((daylightMs % (1000 * 60 * 60)) / (1000 * 60));
+  const isValid = (d: Date | null): d is Date => d != null && !Number.isNaN(d.getTime());
+
+  const fmt = (d: Date | null) =>
+    isValid(d)
+      ? d.toLocaleTimeString("en-ZW", { hour: "2-digit", minute: "2-digit", hour12: false })
+      : "--:--";
+
+  const hasDaylight = isValid(sunrise) && isValid(sunset);
+  const daylightMs = hasDaylight ? sunset.getTime() - sunrise.getTime() : 0;
+  const daylightHours = hasDaylight ? Math.floor(daylightMs / (1000 * 60 * 60)) : 0;
+  const daylightMinutes = hasDaylight
+    ? Math.round((daylightMs % (1000 * 60 * 60)) / (1000 * 60))
+    : 0;
+  const daylightLabel = hasDaylight ? `${daylightHours}h ${daylightMinutes}m` : "--";
 
   return (
     <section aria-labelledby="sun-times-heading">
@@ -38,7 +49,7 @@ export function SunTimes({ daily }: Props) {
             <SunIcon size={20} className="text-warmth" aria-hidden="true" />
             <div>
               <p className="text-base text-text-tertiary">Daylight</p>
-              <p className="text-base font-semibold text-text-primary" aria-label={`${daylightHours} hours and ${daylightMinutes} minutes of daylight`}>{daylightHours}h {daylightMinutes}m</p>
+              <p className="text-base font-semibold text-text-primary" aria-label={hasDaylight ? `${daylightHours} hours and ${daylightMinutes} minutes of daylight` : "Daylight unavailable"}>{daylightLabel}</p>
             </div>
           </div>
         </div>

--- a/tests/py/test_status.py
+++ b/tests/py/test_status.py
@@ -7,14 +7,24 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from py._status import (
+    ANTHROPIC_MODEL,
     _check_mongodb,
     _check_tomorrow_io,
     _check_open_meteo,
     _check_anthropic,
     _check_weather_cache,
     _check_ai_cache,
+    _reset_status_cache,
     system_status,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_status_cache():
+    """Ensure the server-side status cache never leaks between tests."""
+    _reset_status_cache()
+    yield
+    _reset_status_cache()
 
 
 # ---------------------------------------------------------------------------
@@ -170,18 +180,16 @@ class TestCheckOpenMeteo:
 
 
 class TestCheckAnthropic:
-    @patch("py._status.httpx.Client")
-    def test_operational_on_2xx(self, mock_client_cls):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_client_cls.return_value.__enter__ = MagicMock(return_value=MagicMock())
-        mock_client_cls.return_value.__enter__.return_value.post.return_value = mock_resp
-        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+    """The check is now key/model-presence only — it must NOT spend tokens."""
 
+    def test_operational_with_env_key(self):
         with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
             result = _check_anthropic()
         assert result["status"] == "operational"
-        assert "Responding normally" in result["message"]
+        assert result["name"] == "Anthropic AI (Shamwari)"
+        # Reports the model the app actually runs (Haiku), not Sonnet.
+        assert ANTHROPIC_MODEL in result["message"]
+        assert "claude-haiku-4-5-20251001" in result["message"]
 
     def test_degraded_on_no_key(self):
         with patch.dict("os.environ", {}, clear=True):
@@ -190,64 +198,31 @@ class TestCheckAnthropic:
         assert result["status"] == "degraded"
         assert "not configured" in result["message"]
 
-    @patch("py._status.httpx.Client")
-    def test_degraded_on_429(self, mock_client_cls):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 429
-        mock_client_cls.return_value.__enter__ = MagicMock(return_value=MagicMock())
-        mock_client_cls.return_value.__enter__.return_value.post.return_value = mock_resp
-        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
-
-        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
-            result = _check_anthropic()
-        assert result["status"] == "degraded"
-        assert "Rate limited" in result["message"]
-
-    @patch("py._status.httpx.Client")
-    def test_down_on_401(self, mock_client_cls):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 401
-        mock_client_cls.return_value.__enter__ = MagicMock(return_value=MagicMock())
-        mock_client_cls.return_value.__enter__.return_value.post.return_value = mock_resp
-        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
-
-        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-invalid"}):
-            result = _check_anthropic()
-        assert result["status"] == "down"
-        assert "Invalid API key" in result["message"]
-
-    def test_down_on_exception(self):
-        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
-            with patch("py._status.httpx.Client", side_effect=Exception("Connection error")):
-                result = _check_anthropic()
-        assert result["status"] == "down"
-        assert "Connection error" in result["message"]
-
-    @patch("py._status.httpx.Client")
-    def test_uses_db_key_when_env_absent(self, mock_client_cls):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_client_cls.return_value.__enter__ = MagicMock(return_value=MagicMock())
-        mock_client_cls.return_value.__enter__.return_value.post.return_value = mock_resp
-        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
-
+    def test_uses_db_key_when_env_absent(self):
         with patch.dict("os.environ", {}, clear=True):
             with patch("py._status.get_api_key", return_value="sk-from-db"):
                 result = _check_anthropic()
         assert result["status"] == "operational"
+        assert ANTHROPIC_MODEL in result["message"]
 
-    @patch("py._status.httpx.Client")
-    def test_degraded_on_other_status(self, mock_client_cls):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 503
-        mock_client_cls.return_value.__enter__ = MagicMock(return_value=MagicMock())
-        mock_client_cls.return_value.__enter__.return_value.post.return_value = mock_resp
-        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
-
-        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
-            result = _check_anthropic()
+    def test_degraded_when_db_key_lookup_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with patch("py._status.get_api_key", side_effect=Exception("DB down")):
+                result = _check_anthropic()
         assert result["status"] == "degraded"
-        assert "503" in result["message"]
+        assert "not configured" in result["message"]
+
+    def test_does_not_spend_tokens(self):
+        """No live Anthropic request should ever be made (no token spend)."""
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
+            with patch("py._status.httpx.Client") as mock_client_cls:
+                result = _check_anthropic()
+        mock_client_cls.assert_not_called()
+        assert result["status"] == "operational"
+
+    def test_model_matches_configured_model(self):
+        # Guards against the Sonnet/Haiku mismatch regressing.
+        assert ANTHROPIC_MODEL == "claude-haiku-4-5-20251001"
 
 
 # ---------------------------------------------------------------------------
@@ -385,3 +360,25 @@ class TestSystemStatus:
 
         result = await system_status()
         assert result["status"] == "degraded"
+
+    @patch("py._status._check_ai_cache")
+    @patch("py._status._check_weather_cache")
+    @patch("py._status._check_anthropic")
+    @patch("py._status._check_open_meteo")
+    @patch("py._status._check_tomorrow_io")
+    @patch("py._status._check_mongodb")
+    @pytest.mark.asyncio
+    async def test_result_is_cached_between_calls(
+        self, mock_mongo, mock_tomorrow, mock_meteo, mock_anthro, mock_weather, mock_ai
+    ):
+        for m in [mock_mongo, mock_tomorrow, mock_meteo, mock_anthro, mock_weather, mock_ai]:
+            m.return_value = {"name": "test", "status": "operational", "latencyMs": 1, "message": "ok"}
+
+        first = await system_status()
+        # A rapid second poll must be served from cache — no extra upstream calls.
+        second = await system_status()
+
+        assert second is first
+        # Each check ran exactly once despite two endpoint calls.
+        for m in [mock_mongo, mock_tomorrow, mock_meteo, mock_anthro, mock_weather, mock_ai]:
+            assert m.call_count == 1


### PR DESCRIPTION
Fixes a cluster of small, disjoint resilience issues found in an audit. Each fix touches a separate file.

## What & why

1. **/status burned billed API quota.** `api/py/_status.py` made live billed Anthropic + Tomorrow.io + Open-Meteo calls on every request, and `StatusDashboard.tsx` auto-refreshed every 60s unauthenticated + unthrottled — one open tab ≈ 60 Tomorrow.io calls/hr (free tier is 25/hr), 429-ing the shared key and degrading real weather serving; anons could also burn Anthropic credits.
   - **(a)** The status payload is now cached server-side (~60s TTL), so rapid/multi-tab polls don't multiply upstream calls.
   - **(b)** The Anthropic check is now a key-presence + model-config check (no token spend) instead of a billed `/v1/messages` ping.
   - **(c)** Client auto-refresh raised to 5 min (server cache is ~60s).
2. **Status Anthropic model mismatch.** The ping used `claude-sonnet-4-20250514` while the app runs Haiku `claude-haiku-4-5-20251001` → false "degraded". The check now reports the configured Haiku model.
3. **History crash on partial data.** `HistoryDashboard.transformHistory` dereferenced `current.*` unguarded; one persisted doc missing `current` threw inside `.map` and blanked the dashboard. Now filters `d => d.current != null` first.
4. **SunTimes garbage on empty arrays.** `new Date(daily.sunrise[0])` produced "Invalid Date" / "NaNh NaNm" on empty arrays. Now guards `sunrise?.[0]`/`sunset?.[0]` and validates `getTime()`, rendering `--:--` / `--`.
5. **Footer per-mount GitHub call.** Removed the unauthenticated `api.github.com` fetch fired on every page mount (60/hr anon limit).
6. **UserMenu empty name.** `[given, family].join(" ") ?? "Signed in"` never fell back (join returns `""`). Now uses `||`.
7. **Status retry button token.** `text-primary-fg` → `text-primary-foreground` (real token).

## Semantics preserved
The dashboard keeps its operational/degraded/down semantics. No hardcoded hex/inline styles introduced.

## Tests / verification
- `tests/py/test_status.py` updated: no-token Anthropic check (asserts no `httpx.Client` call, reports Haiku model) + server-cache behaviour; autouse fixture resets the cache between tests.
- `HistoryDashboard.test.ts` updated: missing-`current` filter (skips broken docs, no throw).
- `npm test` — 1833 passed. `python3 -m pytest tests/py/` — 916 passed. `npx tsc --noEmit` — clean. `npm run lint` — 0 errors. `npm run build` — compiles successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)