### PR TITLE
fix(auth): land on the requested gated page after sign-in (returnTo)

### DIFF
--- a/src/app/auth/signin/route.test.ts
+++ b/src/app/auth/signin/route.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for the /auth/signin sanitizeReturnPath open-redirect guard.
+ *
+ * The sign-in route echoes a `returnTo` query param into the WorkOS sign-in
+ * state so gated pages can send the user back where they started. That value
+ * is attacker-controllable, so it must never resolve to an off-origin URL.
+ */
+import { describe, it, expect } from "vitest";
+import { sanitizeReturnPath } from "./sanitize";
+
+describe("sanitizeReturnPath", () => {
+  it("accepts a plain in-app path", () => {
+    expect(sanitizeReturnPath("/aviation")).toBe("/aviation");
+  });
+
+  it("accepts a path with a query string", () => {
+    expect(sanitizeReturnPath("/history?days=30")).toBe("/history?days=30");
+  });
+
+  it("returns undefined for null / empty input", () => {
+    expect(sanitizeReturnPath(null)).toBeUndefined();
+    expect(sanitizeReturnPath("")).toBeUndefined();
+  });
+
+  it("rejects absolute URLs (scheme present)", () => {
+    expect(sanitizeReturnPath("https://evil.com")).toBeUndefined();
+    expect(sanitizeReturnPath("http://evil.com/aviation")).toBeUndefined();
+  });
+
+  it("rejects protocol-relative URLs (leading //)", () => {
+    expect(sanitizeReturnPath("//evil.com")).toBeUndefined();
+    expect(sanitizeReturnPath("//evil.com/path")).toBeUndefined();
+  });
+
+  it("rejects backslash protocol-relative bypass (/\\evil.com)", () => {
+    // Browsers normalise the backslash to a forward slash, turning this into
+    // //evil.com — a protocol-relative external redirect.
+    expect(sanitizeReturnPath("/\\evil.com")).toBeUndefined();
+    expect(sanitizeReturnPath("/\\/evil.com")).toBeUndefined();
+  });
+
+  it("rejects values that do not start with a slash", () => {
+    expect(sanitizeReturnPath("evil.com")).toBeUndefined();
+    expect(sanitizeReturnPath("javascript:alert(1)")).toBeUndefined();
+  });
+});

--- a/src/app/auth/signin/route.ts
+++ b/src/app/auth/signin/route.ts
@@ -10,20 +10,7 @@
 import { redirect } from "next/navigation";
 import type { NextRequest } from "next/server";
 import { getSignInUrl } from "@workos-inc/authkit-nextjs";
-
-/**
- * Honour a `returnTo` query param so deep-links (the AI summary sign-in
- * CTA, page-level gates) can send the user back to where they started
- * after a successful sign-in. Only same-origin paths are accepted —
- * anything starting with `//` or containing a scheme is dropped to
- * prevent open-redirect abuse.
- */
-function sanitizeReturnPath(raw: string | null): string | undefined {
-  if (!raw) return undefined;
-  if (!raw.startsWith("/")) return undefined;
-  if (raw.startsWith("//")) return undefined; // protocol-relative URL
-  return raw;
-}
+import { sanitizeReturnPath } from "./sanitize";
 
 export const GET = async (request: NextRequest) => {
   const returnTo = sanitizeReturnPath(request.nextUrl.searchParams.get("returnTo"));

--- a/src/app/auth/signin/sanitize.ts
+++ b/src/app/auth/signin/sanitize.ts
@@ -1,0 +1,22 @@
+/**
+ * Open-redirect guard for the `/auth/signin` `returnTo` param.
+ *
+ * Lives in its own module (not `route.ts`) because Next.js route files may
+ * only export route handlers + a fixed set of config fields — exporting a
+ * helper from `route.ts` fails the build type check.
+ *
+ * Honour a `returnTo` query param so deep-links (the AI summary sign-in CTA,
+ * page-level gates) can send the user back to where they started after a
+ * successful sign-in. Only same-origin paths are accepted — anything that can
+ * resolve to an off-origin URL is dropped to prevent open-redirect abuse.
+ */
+export function sanitizeReturnPath(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+  if (!raw.startsWith("/")) return undefined;
+  if (raw.startsWith("//")) return undefined; // protocol-relative URL
+  // `/\evil.com` — a backslash after the leading slash. Browsers normalise
+  // backslashes to forward slashes, turning this into a protocol-relative
+  // `//evil.com` external redirect. Reject it.
+  if (raw.startsWith("/\\")) return undefined;
+  return raw;
+}

--- a/src/app/aviation/aviation.test.ts
+++ b/src/app/aviation/aviation.test.ts
@@ -99,7 +99,7 @@ describe("Aviation page — auth gating (Phase 1D)", () => {
     expect(pageSrc).toContain("@/lib/auth");
   });
 
-  it("awaits requireUser() inside the page export", () => {
-    expect(pageSrc).toContain("await requireUser()");
+  it("awaits requireUser() inside the page export, passing its own path as returnTo", () => {
+    expect(pageSrc).toContain('await requireUser("/aviation")');
   });
 });

--- a/src/app/aviation/page.tsx
+++ b/src/app/aviation/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 };
 
 export default async function AviationPage() {
-  await requireUser(); // redirects to AuthKit sign-in if not signed in
+  await requireUser("/aviation"); // redirects anon users to sign-in, returns here after
   return (
     <>
       <Header />

--- a/src/app/history/HistoryDashboard.test.ts
+++ b/src/app/history/HistoryDashboard.test.ts
@@ -395,10 +395,10 @@ describe("history page — auth gating (Phase 1D)", () => {
     expect(pageSrc).toContain("@/lib/auth");
   });
 
-  it("awaits requireUser() inside the page default export", async () => {
+  it("awaits requireUser() inside the page default export, passing its own path as returnTo", async () => {
     const fs = await import("fs");
     const pageSrc = fs.readFileSync("src/app/history/page.tsx", "utf-8");
-    expect(pageSrc).toContain("await requireUser()");
+    expect(pageSrc).toContain('await requireUser("/history")');
     expect(pageSrc).toContain("export default async function HistoryPage");
   });
 

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
 };
 
 export default async function HistoryPage() {
-  await requireUser(); // redirects to AuthKit sign-in if not signed in
+  await requireUser("/history"); // redirects anon users to sign-in, returns here after
   return (
     <>
       <Header />

--- a/src/app/shamwari/page.tsx
+++ b/src/app/shamwari/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ShamwariPage() {
-  await requireUser(); // redirects to AuthKit sign-in if not signed in
+  await requireUser("/shamwari"); // redirects anon users to sign-in, returns here after
   return (
     <>
       <Header />

--- a/src/app/shamwari/shamwari.test.ts
+++ b/src/app/shamwari/shamwari.test.ts
@@ -35,8 +35,8 @@ describe("shamwari page — auth gating (Phase 1D)", () => {
     expect(pageSource).toContain("@/lib/auth");
   });
 
-  it("invokes requireUser() inside the default export so anonymous users are redirected to sign-in", () => {
-    expect(pageSource).toContain("await requireUser()");
+  it("invokes requireUser() inside the default export, passing its own path as returnTo so anonymous users return here after sign-in", () => {
+    expect(pageSource).toContain('await requireUser("/shamwari")');
   });
 
   it("is an async server component (requireUser is awaited)", () => {

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -30,15 +30,26 @@ vi.mock("./db", async () => {
   };
 });
 
+const mockWithAuth = vi.hoisted(() => vi.fn());
+
 // AuthKit is server-only and imports Next.js internals — stub it so importing
 // auth.ts in a unit test environment doesn't blow up.
 vi.mock("@workos-inc/authkit-nextjs", () => ({
-  withAuth: vi.fn(),
+  withAuth: mockWithAuth,
   getSignInUrl: vi.fn(),
   signOut: vi.fn(),
 }));
 
-import { upsertPlatformPerson, type WorkOSUser } from "./auth";
+// `redirect()` throws a control-flow signal in Next.js. Emulate that so tests
+// can assert the target and confirm requireUser never returns for anon users.
+const mockRedirect = vi.hoisted(() =>
+  vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+);
+vi.mock("next/navigation", () => ({ redirect: mockRedirect }));
+
+import { upsertPlatformPerson, requireUser, type WorkOSUser } from "./auth";
 
 const sampleUser: WorkOSUser = {
   id: "user_01HZX",
@@ -251,5 +262,47 @@ describe("upsertPlatformPerson", () => {
     await expect(
       upsertPlatformPerson({ id: "", email: "x@y.com" } as WorkOSUser),
     ).rejects.toThrow(/workosUser\.id is required/);
+  });
+});
+
+describe("requireUser", () => {
+  beforeEach(() => {
+    mockWithAuth.mockReset();
+    mockRedirect.mockClear();
+  });
+
+  it("returns the signed-in user without redirecting", async () => {
+    mockWithAuth.mockResolvedValue({ user: sampleUser });
+
+    const user = await requireUser("/aviation");
+
+    expect(user).toEqual(sampleUser);
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("redirects anonymous users through /auth/signin with an encoded returnTo", async () => {
+    mockWithAuth.mockResolvedValue({ user: null });
+
+    await expect(requireUser("/aviation")).rejects.toThrow(
+      "NEXT_REDIRECT:/auth/signin?returnTo=%2Faviation",
+    );
+    expect(mockRedirect).toHaveBeenCalledWith(
+      "/auth/signin?returnTo=%2Faviation",
+    );
+  });
+
+  it("preserves query strings in the returnTo path (encoded)", async () => {
+    mockWithAuth.mockResolvedValue({ user: null });
+
+    await expect(requireUser("/history?days=30")).rejects.toThrow(
+      "NEXT_REDIRECT:/auth/signin?returnTo=%2Fhistory%3Fdays%3D30",
+    );
+  });
+
+  it("falls back to bare /auth/signin when no returnTo is given", async () => {
+    mockWithAuth.mockResolvedValue({ user: null });
+
+    await expect(requireUser()).rejects.toThrow("NEXT_REDIRECT:/auth/signin");
+    expect(mockRedirect).toHaveBeenCalledWith("/auth/signin");
   });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,6 +17,7 @@
  * See docs/mongodb-schema-map.md → `identity` for the full schema.
  */
 
+import { redirect } from "next/navigation";
 import {
   withAuth,
   getSignInUrl,
@@ -92,13 +93,30 @@ export async function getCurrentUser(): Promise<WorkOSUser | null> {
 }
 
 /**
- * Require a signed-in user; redirects to the WorkOS sign-in flow if not.
+ * Require a signed-in user; redirects anonymous users to sign-in.
  * Returns the WorkOS user object — guaranteed non-null on a successful return.
+ *
+ * Anonymous users are routed through our own `/auth/signin?returnTo=<path>`
+ * handler rather than AuthKit's `ensureSignedIn` middleware redirect. That
+ * handler seals `returnTo` into the PKCE state via `getSignInUrl({ returnTo })`
+ * in a plain route-handler response (whose Set-Cookie survives), so after the
+ * WorkOS exchange the callback lands the user back on the page they requested.
+ * The `ensureSignedIn` path sets its PKCE cookie from inside a React Server
+ * Component, where our custom `proxy.ts` middleware drops it — losing the
+ * intended path and bouncing the user to their lastLocation instead.
+ *
+ * @param returnTo Absolute in-app path (e.g. `/aviation`) to return to after
+ *   sign-in. When omitted, sign-in falls back to its own default landing.
  */
-export async function requireUser(): Promise<WorkOSUser> {
-  const { user } = await withAuth({ ensureSignedIn: true });
-  // `ensureSignedIn: true` either returns a user or throws/redirects.
-  return user as WorkOSUser;
+export async function requireUser(returnTo?: string): Promise<WorkOSUser> {
+  const user = await getCurrentUser();
+  if (!user) {
+    const target = returnTo
+      ? `/auth/signin?returnTo=${encodeURIComponent(returnTo)}`
+      : "/auth/signin";
+    redirect(target); // throws — never returns
+  }
+  return user;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem (demo-blocking)

Anonymous users who visit an auth-gated page (`/aviation`, `/shamwari`, `/history`), then sign in, land on their **lastLocation** weather page instead of the page they requested. The gated pages are effectively unreachable.

## Root cause (traced)

These pages gate with `requireUser()` → `withAuth({ ensureSignedIn: true })`. AuthKit's internal `redirectToSignIn()` seals the intended `returnPathname` into a PKCE **state cookie** — but it does so from inside a React Server Component. The custom middleware `src/proxy.ts` calls `authkit(request)` + `handleAuthkitProxy(...)` **without** middlewareAuth/redirectUri configured, so that `Set-Cookie` is dropped. The sealed `returnPathname` is lost, the callback's `returnPathname: "/"` fallback fires, and `proxy.ts` then rewrites `/` → `lastLocation`.

## Fix (lowest-risk mechanism)

Route anonymous users through the **already-working** `/auth/signin?returnTo=<path>` handler, which seals `returnTo` via `getSignInUrl({ returnTo })` in a plain route-handler response — whose `Set-Cookie` survives (this is the same path the `AISummary` sign-in CTA already uses successfully).

- `requireUser(returnTo?)` now reads `getCurrentUser()` and, for anon users, `redirect()`s to `/auth/signin?returnTo=<encoded path>` instead of `ensureSignedIn`.
- `/aviation`, `/shamwari`, `/history` each pass their own path.
- **No callback change needed:** `handleAuth` already prefers the state returnTo over the option (`returnPathname = returnPathnameState ?? returnPathnameOption`), so `returnPathname: "/"` stays a harmless fallback and the `/` → lastLocation rewrite never clobbers the sealed target.
- **Open-redirect hardening:** `sanitizeReturnPath` now also rejects values starting with `/\` (backslash normalises to a protocol-relative `//evil.com` external redirect). Extracted to `sanitize.ts` because Next.js route files may only export route handlers.

## Acceptance test (reasoning)

Anonymous → `/aviation` → `requireUser("/aviation")` sees no user → `redirect("/auth/signin?returnTo=%2Faviation")` → route seals `returnTo` via `getSignInUrl` (cookie survives) → WorkOS sign-in → `/callback` → `handleAuth` reads `returnPathnameState = "/aviation"` and redirects there → `proxy.ts` only rewrites `/` (not `/aviation`), and `aviation` is a KNOWN_ROUTE so no lastLocation cookie is set → `/aviation` renders. Same for `/shamwari` and `/history`.

## Verification

- `npm test` — 78 files, 1842 tests pass
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors (16 pre-existing warnings, none in changed files)
- `npm run build` — compiles, all routes generated

New/updated tests: `requireUser` returnTo redirect target + URL encoding + bare fallback; `sanitizeReturnPath` rejects `/\`, `//`, and absolute URLs; gated pages pass their own path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
