### PR TITLE
fix(map): harden weather overlay, clarify missing-key notice, move switcher right

### DIFF
--- a/src/app/[location]/map/MapDashboard.tsx
+++ b/src/app/[location]/map/MapDashboard.tsx
@@ -10,7 +10,10 @@ import { DEFAULT_LAYER } from "@/lib/map-layers";
 import type { WeatherLocation } from "@/lib/locations";
 
 const MapLibreMap = dynamic(
-  () => import("@/components/weather/map/MapLibreMap").then((m) => ({ default: m.MapLibreMap })),
+  () =>
+    import("@/components/weather/map/MapLibreMap").then((m) => ({
+      default: m.MapLibreMap,
+    })),
   { ssr: false, loading: () => <MapSkeleton fill className="rounded-none" /> },
 );
 
@@ -59,8 +62,10 @@ export function MapDashboard({ location }: MapDashboardProps) {
           </div>
         </div>
 
-        {/* Bottom-left overlay: weather layer panel */}
-        <div className="pointer-events-none absolute bottom-6 left-3 z-10 sm:bottom-4">
+        {/* Bottom-right overlay: weather layer panel. The map's attribution
+            control is pinned bottom-left (see MapLibreMap) so the two never
+            collide; the zoom control stays top-right. */}
+        <div className="pointer-events-none absolute bottom-6 right-3 z-10 sm:bottom-4">
           <WeatherLayerPanel
             activeLayer={activeLayer}
             onLayerChange={handleLayerChange}
@@ -69,7 +74,10 @@ export function MapDashboard({ location }: MapDashboardProps) {
         </div>
 
         {/* Mobile nav bottom padding — transparent spacer */}
-        <div className="absolute inset-x-0 bottom-0 h-16 sm:hidden" aria-hidden="true" />
+        <div
+          className="absolute inset-x-0 bottom-0 h-16 sm:hidden"
+          aria-hidden="true"
+        />
       </main>
     </div>
   );

--- a/src/components/weather/map/MapLibreMap.test.ts
+++ b/src/components/weather/map/MapLibreMap.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 
 // Mock the Zustand store so importing MapLibreMap doesn't pull in the RxDB
 // bridge / replication side effects. The pure helpers under test don't use it.
@@ -9,6 +11,9 @@ vi.mock("@/lib/store", () => ({
 
 import { getMapTilerStyle, classifyMapError } from "./MapLibreMap";
 import { WEATHER_OVERLAY_ID } from "@/lib/map-layers";
+
+// Node-env structural checks (no DOM renderer) — read the component source.
+const source = readFileSync(resolve(__dirname, "MapLibreMap.tsx"), "utf-8");
 
 describe("getMapTilerStyle", () => {
   it("returns the light MapTiler streets style URL by default", () => {
@@ -42,7 +47,10 @@ describe("classifyMapError", () => {
     // A failed style.json fetch (expired / over-quota key → 403/429) carries no
     // sourceId — it must surface the base-map notice, not the overlay one.
     expect(
-      classifyMapError({ error: new Error("403 Forbidden") }, WEATHER_OVERLAY_ID),
+      classifyMapError(
+        { error: new Error("403 Forbidden") },
+        WEATHER_OVERLAY_ID,
+      ),
     ).toBe("base");
   });
 
@@ -56,5 +64,38 @@ describe("classifyMapError", () => {
     expect(
       classifyMapError({} as { sourceId?: string }, WEATHER_OVERLAY_ID),
     ).toBe("base");
+  });
+});
+
+describe("missing-key notice (item 1 — empty NEXT_PUBLIC_MAPTILER_API_KEY)", () => {
+  it("skips map init and surfaces a clear base-map notice on an empty key", () => {
+    // The empty-key path must short-circuit before creating the map so it never
+    // falls through to a silent blank surface or only an overlay notice.
+    expect(source).toContain("baseMapMissingKey");
+    expect(source).toContain("if (baseMapMissingKey) return;");
+    expect(source).toContain("Base map unavailable — map key not configured");
+    expect(source).toContain("NEXT_PUBLIC_MAPTILER_API_KEY");
+  });
+});
+
+describe("overlay tile resilience (item 2 — decode errors non-fatal, non-spammy)", () => {
+  it("rate-limits overlay error logging with a once-per-selection guard", () => {
+    expect(source).toContain("overlayErrorLoggedRef");
+    // Log guard resets when the selected layer changes.
+    expect(source).toContain("overlayErrorLoggedRef.current = false");
+  });
+
+  it("logs overlay tile failures as a non-fatal warning, not an error", () => {
+    expect(source).toContain(
+      "[weather-map] weather overlay tile failed to load (non-fatal)",
+    );
+  });
+});
+
+describe("attribution placement (item 4 — clear the bottom-right for the switcher)", () => {
+  it("disables the default (bottom-right) attribution and re-adds it bottom-left", () => {
+    expect(source).toContain("attributionControl: false");
+    expect(source).toContain("AttributionControl");
+    expect(source).toContain('"bottom-left"');
   });
 });

--- a/src/components/weather/map/MapLibreMap.tsx
+++ b/src/components/weather/map/MapLibreMap.tsx
@@ -4,7 +4,10 @@ import { useEffect, useRef, useState } from "react";
 import type { Map as MapLibreGLMap, Marker } from "maplibre-gl";
 import { useAppStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import { WEATHER_OVERLAY_ID, buildWeatherOverlaySource } from "@/lib/map-layers";
+import {
+  WEATHER_OVERLAY_ID,
+  buildWeatherOverlaySource,
+} from "@/lib/map-layers";
 
 const MAPTILER_KEY = process.env.NEXT_PUBLIC_MAPTILER_API_KEY ?? "";
 
@@ -77,6 +80,11 @@ export function MapLibreMap({
   const weatherLayerRef = useRef<string | null>(weatherLayer);
   weatherLayerRef.current = weatherLayer;
   const [overlayError, setOverlayError] = useState(false);
+  // Dedupes overlay tile-load logging. A single map view fires one `error` event
+  // per failed raster tile (≈10 per pan/zoom), so without this guard a transient
+  // decode failure spams the console 10× and re-runs the handler needlessly. We
+  // log at most once per layer selection; reset when the layer changes below.
+  const overlayErrorLoggedRef = useRef(false);
   // Set when the base map style / base tiles fail to load at runtime (e.g. an
   // expired or over-quota MapTiler key returning 403/429). Without this the map
   // renders as a silent blank/partial surface with no feedback.
@@ -105,59 +113,83 @@ export function MapLibreMap({
     // never getting `.remove()`d by the cleanup below.
     let cancelled = false;
 
-    import("maplibre-gl").then(({ Map, Marker: MLMarker, NavigationControl }) => {
-      if (cancelled || !containerRef.current) return;
-      import("maplibre-gl/dist/maplibre-gl.css");
+    import("maplibre-gl").then(
+      ({ Map, Marker: MLMarker, NavigationControl, AttributionControl }) => {
+        if (cancelled || !containerRef.current) return;
+        import("maplibre-gl/dist/maplibre-gl.css");
 
-      const map: MapLibreGLMap = new Map({
-        container: containerRef.current,
-        style: getMapTilerStyle(isDark),
-        center: [lon, lat],
-        zoom,
-        interactive,
-        attributionControl: {
-          customAttribution: '© <a href="https://www.maptiler.com/">MapTiler</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-        },
-      });
+        const map: MapLibreGLMap = new Map({
+          container: containerRef.current,
+          style: getMapTilerStyle(isDark),
+          center: [lon, lat],
+          zoom,
+          interactive,
+          // The default attribution control sits bottom-right, which would collide
+          // with the bottom-right overlay layer switcher. Disable it here and re-add
+          // it explicitly at bottom-left below.
+          attributionControl: false,
+        });
 
-      // Unmounted while the Map was constructing — tear it down immediately.
-      if (cancelled) {
-        map.remove();
-        return;
-      }
-
-      mapRef.current = map;
-
-      if (interactive) {
-        map.addControl(new NavigationControl({ showCompass: false }), "top-right");
-      }
-
-      const restore = () => {
-        markerRef.current?.remove();
-        markerRef.current = new MLMarker({ color: "#0047AB" })
-          .setLngLat([lon, lat])
-          .addTo(map);
-        applyWeatherOverlay(map, weatherLayerRef.current);
-      };
-      restoreRef.current = restore;
-
-      map.on("load", restore);
-
-      // Surface tile/style failures (missing/expired API key → 403/503, rate
-      // limit → 429, upstream error) instead of showing a silent blank map.
-      // Overlay errors show the transient overlay notice; base-map/style errors
-      // show the "Base map unavailable" notice so a blank base map is never
-      // silent.
-      map.on("error", (e: { error?: Error; sourceId?: string }) => {
-        if (classifyMapError(e, WEATHER_OVERLAY_ID) === "overlay") {
-          setOverlayError(true);
-          console.error("[weather-map] overlay tile failed to load", e?.error);
-        } else {
-          setBaseMapError(true);
-          console.error("[weather-map] base map failed to load", e?.error);
+        // Unmounted while the Map was constructing — tear it down immediately.
+        if (cancelled) {
+          map.remove();
+          return;
         }
-      });
-    });
+
+        mapRef.current = map;
+
+        map.addControl(
+          new AttributionControl({
+            customAttribution:
+              '© <a href="https://www.maptiler.com/">MapTiler</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+          }),
+          "bottom-left",
+        );
+
+        if (interactive) {
+          map.addControl(
+            new NavigationControl({ showCompass: false }),
+            "top-right",
+          );
+        }
+
+        const restore = () => {
+          markerRef.current?.remove();
+          markerRef.current = new MLMarker({ color: "#0047AB" })
+            .setLngLat([lon, lat])
+            .addTo(map);
+          applyWeatherOverlay(map, weatherLayerRef.current);
+        };
+        restoreRef.current = restore;
+
+        map.on("load", restore);
+
+        // Surface tile/style failures (missing/expired API key → 403/503, rate
+        // limit → 429, upstream error) instead of showing a silent blank map.
+        // Overlay errors show the transient overlay notice; base-map/style errors
+        // show the "Base map unavailable" notice so a blank base map is never
+        // silent.
+        map.on("error", (e: { error?: Error; sourceId?: string }) => {
+          if (classifyMapError(e, WEATHER_OVERLAY_ID) === "overlay") {
+            // Overlay tile failures (e.g. a single raster tile that can't be
+            // decoded) are non-fatal — MapLibre keeps the rest of the layer, so we
+            // never blank it. Fire the notice once and log at most once per layer
+            // selection so a burst of ~10 per-tile errors doesn't spam the console.
+            setOverlayError(true);
+            if (!overlayErrorLoggedRef.current) {
+              overlayErrorLoggedRef.current = true;
+              console.warn(
+                "[weather-map] weather overlay tile failed to load (non-fatal)",
+                e?.error,
+              );
+            }
+          } else {
+            setBaseMapError(true);
+            console.error("[weather-map] base map failed to load", e?.error);
+          }
+        });
+      },
+    );
 
     return () => {
       cancelled = true;
@@ -186,6 +218,7 @@ export function MapLibreMap({
     const map = mapRef.current;
     if (!map) return;
     setOverlayError(false);
+    overlayErrorLoggedRef.current = false;
     if (!map.isStyleLoaded()) {
       const apply = () => applyWeatherOverlay(map, weatherLayer);
       map.once("idle", apply);
@@ -204,10 +237,12 @@ export function MapLibreMap({
           role="status"
           className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 bg-surface-base p-6 text-center"
         >
-          <p className="text-sm font-semibold text-text-primary">Map unavailable</p>
+          <p className="text-sm font-semibold text-text-primary">
+            Base map unavailable — map key not configured
+          </p>
           <p className="max-w-xs text-xs text-text-tertiary">
-            The base map key is not configured. Set NEXT_PUBLIC_MAPTILER_API_KEY to enable
-            the interactive weather map.
+            Set NEXT_PUBLIC_MAPTILER_API_KEY to enable the interactive weather
+            map.
           </p>
         </div>
       )}
@@ -216,10 +251,12 @@ export function MapLibreMap({
           role="status"
           className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 bg-surface-base p-6 text-center"
         >
-          <p className="text-sm font-semibold text-text-primary">Base map unavailable</p>
+          <p className="text-sm font-semibold text-text-primary">
+            Base map unavailable
+          </p>
           <p className="max-w-xs text-xs text-text-tertiary">
-            The base map could not be loaded. This is usually a temporary issue — please try
-            again later.
+            The base map could not be loaded. This is usually a temporary issue
+            — please try again later.
           </p>
         </div>
       )}

--- a/src/components/weather/map/WeatherLayerPanel.test.ts
+++ b/src/components/weather/map/WeatherLayerPanel.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for the compact overlay layer switcher (WeatherLayerPanel).
+ * Node-env structural checks (no DOM renderer) — read the component source and
+ * assert every configured layer resolves to a lucide icon, plus that the map
+ * route places the switcher bottom-RIGHT.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { MAP_LAYERS } from "@/lib/map-layers";
+
+const panelSource = readFileSync(
+  resolve(__dirname, "WeatherLayerPanel.tsx"),
+  "utf-8",
+);
+const dashboardSource = readFileSync(
+  resolve(__dirname, "../../../app/[location]/map/MapDashboard.tsx"),
+  "utf-8",
+);
+
+describe("WeatherLayerPanel — icon per layer (item 3)", () => {
+  it("imports and registers a lucide icon for EVERY configured layer", () => {
+    // The registry keys are the MapLayer.icon names; the icons are imported
+    // from lucide-react. If a layer's icon is missing here it would fall back
+    // silently, so assert every one is present in both the import and registry.
+    for (const layer of MAP_LAYERS) {
+      expect(panelSource).toContain(layer.icon);
+    }
+  });
+
+  it("includes the Cloud icon (the cloud layer was previously iconless)", () => {
+    expect(panelSource).toContain('from "lucide-react"');
+    expect(panelSource).toMatch(/LAYER_ICONS[\s\S]*Cloud/);
+    const cloud = MAP_LAYERS.find((l) => l.id === "cloudCover");
+    expect(cloud!.icon).toBe("Cloud");
+  });
+
+  it("renders an <Icon> for each layer button with a safe fallback", () => {
+    expect(panelSource).toContain(
+      "const Icon = LAYER_ICONS[layer.icon] ?? Cloud",
+    );
+    expect(panelSource).toContain("<Icon");
+  });
+});
+
+describe("MapDashboard — switcher placement (item 4)", () => {
+  it("positions the overlay switcher on the RIGHT, not the left", () => {
+    expect(dashboardSource).toContain("<WeatherLayerPanel");
+    expect(dashboardSource).toContain("right-3");
+    expect(dashboardSource).not.toContain("bottom-6 left-3");
+  });
+});

--- a/src/lib/map-layers.test.ts
+++ b/src/lib/map-layers.test.ts
@@ -37,7 +37,9 @@ describe("MAP_LAYERS", () => {
   });
 
   it("includes precipitationIntensity layer", () => {
-    expect(MAP_LAYERS.some((l) => l.id === "precipitationIntensity")).toBe(true);
+    expect(MAP_LAYERS.some((l) => l.id === "precipitationIntensity")).toBe(
+      true,
+    );
   });
 
   it("includes cloudCover layer", () => {
@@ -46,6 +48,19 @@ describe("MAP_LAYERS", () => {
 
   it("includes temperature layer", () => {
     expect(MAP_LAYERS.some((l) => l.id === "temperature")).toBe(true);
+  });
+
+  it("gives EVERY layer a non-empty icon name (switcher must never be iconless)", () => {
+    for (const layer of MAP_LAYERS) {
+      expect(typeof layer.icon).toBe("string");
+      expect(layer.icon.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("gives the cloud layer a Cloud icon (was previously missing in the switcher)", () => {
+    const cloud = MAP_LAYERS.find((l) => l.id === "cloudCover");
+    expect(cloud).toBeDefined();
+    expect(cloud!.icon).toBe("Cloud");
   });
 });
 


### PR DESCRIPTION
## Weather map UI + overlay resilience (`/[location]/map`)

MapLibre GL base map + proxied Tomorrow.io raster weather overlays. Four fixes, scoped to `src/components/weather/map/*`, `src/lib/map-layers.ts` tests, and the switcher-position wrapper in `MapDashboard.tsx`. The tile proxy (`api/py/_tiles.py`) is untouched.

### 1. Missing-key notice is now unmistakable
When `NEXT_PUBLIC_MAPTILER_API_KEY` is empty, `MapLibreMap` short-circuits map init (`if (baseMapMissingKey) return;`) so it can never fall through to only the overlay "Weather layer unavailable" banner. The centered notice now reads **"Base map unavailable — map key not configured"** with a `Set NEXT_PUBLIC_MAPTILER_API_KEY…` hint, using the existing notice UI/tokens. An invalid/over-quota key (403/429 on `style.json`, no `sourceId`) still routes to the separate "Base map unavailable" runtime notice via `classifyMapError`.

### 2. Cloud overlay decode errors — non-fatal + non-spammy
`InvalidStateError: source image could not be decoded` fired once per failed raster tile (~10 per view), spamming the console and re-running the handler. Overlay tile-load failures are now:
- **Non-fatal** — MapLibre keeps the rest of the layer; a bad tile never blanks the overlay.
- **Rate-limited** — logged at most once per layer selection via `overlayErrorLoggedRef` (reset when the layer changes), downgraded from `console.error` to a non-fatal `console.warn`.

The transient overlay notice still shows, but it no longer floods the console. No proxy changes.

### 3. Cloud layer icon
Confirmed every switcher layer resolves a lucide icon (`cloudCover → Cloud`, plus rain/temperature/wind/humidity) with a safe `?? Cloud` fallback in `WeatherLayerPanel`. Added icon-per-layer test coverage so an iconless layer regresses loudly.

### 4. Switcher moved to the RIGHT
The compact vertical layer switcher moved from bottom-left to **bottom-right**. To avoid colliding with MapLibre's default bottom-right attribution, the attribution control is now re-added explicitly at **bottom-left**; the zoom control stays top-right. Back-to-weather link stays top-left.

### Verification
- `npm test` — 1890 passed (81 files)
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- `npm run build` — compiled successfully, 185/185 pages

New/updated tests: `map-layers.test.ts` (icon-per-layer + cloud icon), `MapLibreMap.test.ts` (empty-key notice, attribution placement, rate-limited overlay logging), new `WeatherLayerPanel.test.ts` (icon-per-layer registry + bottom-right switcher position).

🤖 Generated with [Claude Code](https://claude.com/claude-code)