### PR TITLE
fix(location): kill React #418 hydration mismatch on the location page

### DIFF
--- a/src/components/weather/HourlyScrollCards.test.ts
+++ b/src/components/weather/HourlyScrollCards.test.ts
@@ -51,6 +51,24 @@ describe("HourlyScrollCards — hour slicing", () => {
   });
 });
 
+describe("HourlyScrollCards — deterministic render (no #418)", () => {
+  it("gates the wall-clock start index on useHydrated", () => {
+    expect(source).toContain("useHydrated");
+    // The current-hour slice must only apply once hydrated; SSR + first client
+    // render start at index 0 so the HTML matches and there is no text mismatch.
+    expect(source).toContain("hydrated");
+    expect(source).toContain("startIndex = hydrated");
+  });
+
+  it('only shows the "Now" label after hydration', () => {
+    expect(source).toContain('hydrated && i === 0 ? "Now"');
+  });
+
+  it("is a client component (uses the browser clock)", () => {
+    expect(source).toContain('"use client"');
+  });
+});
+
 describe("HourlyScrollCards — weather data", () => {
   it("displays temperature", () => {
     expect(source).toContain("temperature_2m");

--- a/src/components/weather/HourlyScrollCards.tsx
+++ b/src/components/weather/HourlyScrollCards.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import { WeatherIcon } from "@/lib/weather-icons";
 import { weatherCodeToInfo, type HourlyWeather } from "@/lib/weather";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { useHydrated } from "@/lib/use-hydrated";
 
 interface Props {
   hourly: HourlyWeather;
@@ -11,9 +14,18 @@ interface Props {
  * Renders eagerly above CurrentConditions on the location page.
  */
 export function HourlyScrollCards({ hourly }: Props) {
+  // The start of the strip is chosen from the client's wall clock
+  // (`new Date()`), which the server can't match at SSR time — computing it
+  // during hydration would slice a different set of hours and mismatch the
+  // server HTML (React error 418). Gate on `useHydrated()`: the server and the
+  // first client render both start at index 0 (identical HTML), then after
+  // hydration we advance to the current hour and label the first card "Now".
+  const hydrated = useHydrated();
   const now = new Date();
   const currentHour = now.getHours();
-  const startIndex = hourly.time.findIndex((t) => new Date(t).getHours() >= currentHour && new Date(t).getDate() === now.getDate());
+  const startIndex = hydrated
+    ? hourly.time.findIndex((t) => new Date(t).getHours() >= currentHour && new Date(t).getDate() === now.getDate())
+    : -1;
   const start = startIndex >= 0 ? startIndex : 0;
   const hours = hourly.time.slice(start, start + 24);
 
@@ -27,7 +39,7 @@ export function HourlyScrollCards({ hourly }: Props) {
             const info = weatherCodeToInfo(hourly.weather_code[idx]);
             const isDay = hourly.is_day[idx];
             const temp = Math.round(hourly.temperature_2m[idx]);
-            const timeLabel = i === 0 ? "Now" : date.toLocaleTimeString("en-ZW", { hour: "2-digit", minute: "2-digit", hour12: false });
+            const timeLabel = hydrated && i === 0 ? "Now" : date.toLocaleTimeString("en-ZW", { hour: "2-digit", minute: "2-digit", hour12: false });
             return (
               <div
                 key={time}

--- a/src/components/weather/LiveClock.test.ts
+++ b/src/components/weather/LiveClock.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for LiveClock — the location-page date/time line.
+ *
+ * Covers the pure `formatDateTime` helper (deterministic given a Date) and the
+ * deterministic-render contract that kills the hydration text mismatch that
+ * caused React error #418: the clock is gated behind `useHydrated()` so the
+ * server and first client render emit identical HTML, and it no longer relies
+ * on `suppressHydrationWarning` to paper over a real mismatch.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { formatDateTime } from "./LiveClock";
+
+const source = readFileSync(resolve(__dirname, "LiveClock.tsx"), "utf-8");
+
+describe("formatDateTime", () => {
+  // Dates are constructed with local-time components and formatted in the
+  // runtime's local timezone, so these assertions hold regardless of the CI
+  // machine's timezone.
+  it("formats as 'Weekday, D Month YYYY at HH:MM'", () => {
+    // 2026-07-03 08:33 local → the exact string observed on the live page.
+    expect(formatDateTime(new Date(2026, 6, 3, 8, 33))).toBe(
+      "Friday, 3 July 2026 at 08:33",
+    );
+  });
+
+  it("zero-pads the hour and minute to two digits", () => {
+    expect(formatDateTime(new Date(2026, 0, 5, 9, 5))).toBe(
+      "Monday, 5 January 2026 at 09:05",
+    );
+  });
+
+  it("uses 24-hour time (no am/pm)", () => {
+    const label = formatDateTime(new Date(2026, 6, 3, 20, 15));
+    expect(label).toContain("20:15");
+    expect(label.toLowerCase()).not.toContain("pm");
+  });
+});
+
+describe("LiveClock — deterministic render", () => {
+  it("exports the LiveClock component and the formatDateTime helper", () => {
+    expect(source).toContain("export function LiveClock");
+    expect(source).toContain("export function formatDateTime");
+  });
+
+  it("gates the clock on useHydrated so SSR + hydration render identical HTML", () => {
+    expect(source).toContain("useHydrated");
+    expect(source).toContain("if (!hydrated) return null");
+  });
+
+  it("does NOT rely on suppressHydrationWarning to hide a real mismatch", () => {
+    expect(source).not.toContain("suppressHydrationWarning");
+  });
+
+  it("still refreshes every minute via an interval", () => {
+    expect(source).toContain("setInterval");
+    expect(source).toContain("60_000");
+    expect(source).toContain("clearInterval");
+  });
+});

--- a/src/components/weather/LiveClock.tsx
+++ b/src/components/weather/LiveClock.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useHydrated } from "@/lib/use-hydrated";
 
-function formatDateTime(date: Date): string {
+/**
+ * Formats a Date as the human clock label, e.g. "Friday, 3 July 2026 at 08:33".
+ * Exported for testing — the output is deterministic for a given Date + runtime
+ * timezone. Kept pure (no `new Date()` inside) so both the caller and tests
+ * control the instant.
+ */
+export function formatDateTime(date: Date): string {
   return new Intl.DateTimeFormat("en-GB", {
     weekday: "long",
     day: "numeric",
@@ -15,9 +22,13 @@ function formatDateTime(date: Date): string {
 
 /** Displays the user's current browser date and time, updated every minute. */
 export function LiveClock() {
-  // Initialise with the current time so first paint is correct (avoids
-  // setState-in-effect). SSR may produce a different string than the client,
-  // so suppressHydrationWarning is applied to the rendered element below.
+  // The clock reflects the *client's* wall clock, which differs from the
+  // server's at SSR time — rendering it during hydration would cause a text
+  // mismatch (React hydration error 418). Gate on `useHydrated()`: the server and the
+  // first client render both return `null` (identical HTML → no mismatch), then
+  // the real time is revealed after hydration. `label` is seeded from the
+  // client clock and refreshed every minute by the interval below.
+  const hydrated = useHydrated();
   const [label, setLabel] = useState<string>(() => formatDateTime(new Date()));
 
   useEffect(() => {
@@ -25,12 +36,10 @@ export function LiveClock() {
     return () => clearInterval(id);
   }, []);
 
+  if (!hydrated) return null;
+
   return (
-    <p
-      className="text-sm text-text-tertiary"
-      aria-label={`Current time: ${label}`}
-      suppressHydrationWarning
-    >
+    <p className="text-sm text-text-tertiary" aria-label={`Current time: ${label}`}>
       {label}
     </p>
   );

--- a/src/lib/use-hydrated.test.ts
+++ b/src/lib/use-hydrated.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for the useHydrated deterministic-render helper — the snapshot
+ * functions that make `useSyncExternalStore` return a stable server value and
+ * a client value, so time-dependent UI can avoid hydration mismatches (#418).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import {
+  useHydrated,
+  getHydratedSnapshot,
+  getHydratedServerSnapshot,
+} from "./use-hydrated";
+
+const source = readFileSync(resolve(__dirname, "use-hydrated.ts"), "utf-8");
+
+describe("useHydrated — snapshot semantics", () => {
+  it("server snapshot is false (stable placeholder during SSR + hydration)", () => {
+    expect(getHydratedServerSnapshot()).toBe(false);
+  });
+
+  it("client snapshot is true (real content after hydration)", () => {
+    expect(getHydratedSnapshot()).toBe(true);
+  });
+
+  it("server and client snapshots differ so the reveal is a post-hydration render", () => {
+    expect(getHydratedServerSnapshot()).not.toBe(getHydratedSnapshot());
+  });
+
+  it("snapshots are pure — repeated calls are cached-stable (no #300 loop)", () => {
+    expect(getHydratedSnapshot()).toBe(getHydratedSnapshot());
+    expect(getHydratedServerSnapshot()).toBe(getHydratedServerSnapshot());
+  });
+});
+
+describe("useHydrated — structure", () => {
+  it("exports a useHydrated hook", () => {
+    expect(typeof useHydrated).toBe("function");
+  });
+
+  it("is built on useSyncExternalStore (no setState-in-effect)", () => {
+    expect(source).toContain("useSyncExternalStore");
+    expect(source).not.toContain("useEffect");
+  });
+
+  it("passes both a client and a server snapshot to the store", () => {
+    expect(source).toContain("getHydratedSnapshot");
+    expect(source).toContain("getHydratedServerSnapshot");
+  });
+});

--- a/src/lib/use-hydrated.ts
+++ b/src/lib/use-hydrated.ts
@@ -1,0 +1,37 @@
+import { useSyncExternalStore } from "react";
+
+// A store that never emits — it exists only so `useSyncExternalStore` can
+// return a different value for the server snapshot (`false`) than the client
+// snapshot (`true`). React uses `getServerSnapshot` for SSR and the initial
+// hydration render, then switches to `getSnapshot` in a post-hydration commit.
+// This lets a component render a stable, deterministic placeholder on the
+// server and first client render (identical HTML → no hydration mismatch /
+// React error 418), then reveal client-only content (live clocks, "now"-
+// relative slices) safely on the next render.
+function subscribe(): () => void {
+  return () => {};
+}
+
+/** Client snapshot — always `true` once running in the browser. */
+export function getHydratedSnapshot(): boolean {
+  return true;
+}
+
+/** Server snapshot — always `false` during SSR and the hydration render. */
+export function getHydratedServerSnapshot(): boolean {
+  return false;
+}
+
+/**
+ * Returns `false` during SSR and the first client (hydration) render, then
+ * `true` after hydration completes. Gate any value that differs between server
+ * and client — e.g. `new Date()` — behind this so both sides render identical
+ * HTML and no text-content hydration mismatch (React hydration error 418) occurs.
+ */
+export function useHydrated(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    getHydratedSnapshot,
+    getHydratedServerSnapshot,
+  );
+}


### PR DESCRIPTION
## Problem

Live `/harare` (and every location page) logged **`Minified React error #418`** — *"Text content does not match server-rendered HTML"* — on each visit. React recovered, but it's a real console error we want gone before a demo.

## Root cause

Two **eager, render-time `new Date()`** reads produced different output on the server (UTC) than on the client (local), so the SSR HTML and the hydration render disagreed:

1. **`LiveClock`** — the dated line (`"Friday, 3 July 2026 at 08:33"`). A prior lint fix (`react-hooks/set-state-in-effect`, #38) had changed it from the deterministic `useState(null)` + set-in-effect pattern to `useState(() => formatDateTime(new Date()))`, reintroducing the SSR/client divergence and papering it with `suppressHydrationWarning` — which also froze the visible value to the **server's** timezone.
2. **`HourlyScrollCards`** — `const now = new Date()` selected the start-of-strip index and the `"Now"` label from the wall clock, so server and client sliced a **different set of hours**. (The offset-less hourly time strings were already timezone-invariant for `getHours()`/`toLocaleTimeString`; only `now` diverged.)

## Fix

New shared hook **`src/lib/use-hydrated.ts`** — a `useSyncExternalStore`-based `useHydrated()` that returns `false` during SSR + the first client render and `true` afterwards, with **no setState-in-effect** (so it doesn't re-trip the lint rule that caused the regression).

- **`LiveClock`** now renders `null` on SSR + hydration (identical HTML → no mismatch), then reveals the correct **client-local** time after hydration, refreshed every minute. `suppressHydrationWarning` removed. `formatDateTime` exported for testing.
- **`HourlyScrollCards`** gates the current-hour slice and `"Now"` label behind `useHydrated()` — both sides start at index 0 until hydrated, then advance to the current hour.

Displayed values stay correct; no hardcoded styles; explicit `git add`.

## Other #418 sources checked
Swept the eagerly-rendered tree (`CurrentConditions`, `AtmosphericSummary`, `SeasonBadge`, `Header`, breadcrumbs, `SeasonBadge`, theme script). Season/breadcrumbs are server-computed props (deterministic). The `<html data-theme>` theme FOUC path is already covered by `suppressHydrationWarning` on `<html>` and the localStorage key the anti-FOUC script reads matches the Zustand persist key — no mismatch. `Footer`'s `new Date().getFullYear()` is the same value on both sides. LiveClock + HourlyScrollCards were the only two real sources.

## Verification
- `npm test` — **1909 passed**
- `npx tsc --noEmit` — clean
- `npm run lint` — **0 errors**
- `npm run build` — compiled successfully, 185/185 pages

Added tests: `use-hydrated.test.ts` (snapshot semantics), `LiveClock.test.ts` (`formatDateTime` + deterministic-render contract), and extended `HourlyScrollCards.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)