### PR TITLE
feat(developers): public API docs page at /developers

### DIFF
--- a/src/app/developers/developers.test.ts
+++ b/src/app/developers/developers.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for the /developers page — validates metadata, canonical URL,
+ * JSON-LD, documented public endpoints, and site-style layout by reading
+ * the source file (Vitest runs in Node).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const pageSource = readFileSync(resolve(__dirname, "page.tsx"), "utf-8");
+
+describe("developers page — metadata", () => {
+  it("exports a Developers-focused title", () => {
+    expect(pageSource).toContain("Developers & Public API");
+  });
+
+  it("sets the canonical URL to /developers", () => {
+    expect(pageSource).toContain("https://weather.mukoko.com/developers");
+    expect(pageSource).toContain("canonical:");
+  });
+});
+
+describe("developers page — structure", () => {
+  it("is a server component (no use client directive)", () => {
+    expect(pageSource).not.toContain('"use client"');
+  });
+
+  it("is an async server component that reads auth state", () => {
+    expect(pageSource).toContain("export default async function");
+    expect(pageSource).toContain("getCurrentUser");
+    expect(pageSource).toContain("@/lib/auth");
+  });
+
+  it("renders the shared Header and Footer", () => {
+    expect(pageSource).toContain("Header");
+    expect(pageSource).toContain("Footer");
+  });
+
+  it("includes JSON-LD structured data (TechArticle)", () => {
+    expect(pageSource).toContain("application/ld+json");
+    expect(pageSource).toContain("TechArticle");
+  });
+
+  it("uses the fauna section-heading class (eagle)", () => {
+    expect(pageSource).toContain("eagle");
+  });
+
+  it("uses the fauna code-block surface class (tortoise)", () => {
+    expect(pageSource).toContain("tortoise");
+  });
+
+  it("links to the embed page for the widget", () => {
+    expect(pageSource).toContain('href="/embed"');
+  });
+});
+
+describe("developers page — documented public endpoints", () => {
+  const endpoints = [
+    "/api/embed/current",
+    "/api/py/weather?lat=",
+    "/api/py/geo?lat=",
+    "/api/py/locations?slug=",
+    "/api/py/search?q=",
+    "/api/py/airquality?lat=",
+    "/api/py/airports/nearest?lat=",
+  ];
+
+  it.each(endpoints)("documents %s", (endpoint) => {
+    expect(pageSource).toContain(endpoint);
+  });
+
+  it("notes the open CORS policy", () => {
+    expect(pageSource).toContain("Access-Control-Allow-Origin: *");
+  });
+
+  it("mentions the weather provider response headers", () => {
+    expect(pageSource).toContain("X-Weather-Provider");
+    expect(pageSource).toContain("X-Current-Source");
+  });
+
+  it("links to Shamwari for the AI endpoints", () => {
+    expect(pageSource).toContain('href="/shamwari"');
+  });
+
+  it("includes a terms / fair use note", () => {
+    expect(pageSource).toContain("fair use");
+  });
+});
+
+describe("developers page — optional API keys", () => {
+  it("leads with the free-and-open, no-key-needed message", () => {
+    expect(pageSource).toContain(
+      "The API is free and open — call it directly, no key needed.",
+    );
+  });
+
+  it("has an optional API keys section", () => {
+    expect(pageSource).toContain("API keys (optional)");
+  });
+
+  it("shows a Manage API keys CTA for signed-in users", () => {
+    expect(pageSource).toContain("Manage API keys");
+    expect(pageSource).toContain('href="/developers/keys"');
+  });
+
+  it("shows a sign-in CTA (with returnTo) for anonymous users", () => {
+    expect(pageSource).toContain("Sign in to create an API key");
+    expect(pageSource).toContain(
+      'href="/auth/signin?returnTo=/developers/keys"',
+    );
+  });
+});

--- a/src/app/developers/page.tsx
+++ b/src/app/developers/page.tsx
@@ -1,0 +1,399 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { getCurrentUser } from "@/lib/auth";
+
+export const metadata: Metadata = {
+  title: "Developers & Public API",
+  description:
+    "Free, no-auth public weather API for developers. Current conditions, full forecasts, geo lookup, location search, air quality, and nearest airports — CORS-open and browser-callable, with real curl examples and response shapes.",
+  alternates: {
+    canonical: "https://weather.mukoko.com/developers",
+  },
+};
+
+const BASE_URL = "https://weather.mukoko.com";
+
+export default async function DevelopersPage() {
+  const user = await getCurrentUser();
+  const signedIn = user !== null;
+
+  const articleSchema = {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: "mukoko weather Public API",
+    description:
+      "Free, no-auth public weather API — current conditions, forecasts, geo lookup, location search, air quality, and nearest airports. CORS-open and browser-callable.",
+    inLanguage: "en",
+    isPartOf: {
+      "@type": "WebSite",
+      name: "mukoko weather",
+      url: BASE_URL,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Mukoko Africa",
+      url: BASE_URL,
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `${BASE_URL}/developers`,
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <Header />
+      <main
+        id="main-content"
+        className="mx-auto max-w-3xl px-4 py-10 pb-24 sm:pb-10 sm:px-6 md:px-8"
+      >
+        <h1 className="font-display text-3xl font-bold text-text-primary sm:text-4xl">
+          Developers &amp; Public API
+        </h1>
+        <p className="mt-4 text-text-secondary leading-relaxed">
+          <strong className="text-text-primary">
+            The API is free and open — call it directly, no key needed.
+          </strong>{" "}
+          mukoko weather runs on a set of public JSON endpoints with no account
+          and no auth. They&apos;re served with{" "}
+          <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+            Access-Control-Allow-Origin: *
+          </code>
+          , so you can call them straight from the browser, cross-origin, from
+          any site or app. All coordinates are WGS 84 decimal degrees; all
+          timestamps are ISO 8601. Want a drop-in widget instead of raw JSON?
+          See the{" "}
+          <Link
+            href="/embed"
+            prefetch={false}
+            className="text-primary underline hover:text-primary/80 transition-colors"
+          >
+            embed page
+          </Link>
+          .
+        </p>
+
+        {/* Base URL */}
+        <section className="mt-10">
+          <h2 className="eagle">Base URL</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            All endpoints are relative to the production origin:
+          </p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`https://weather.mukoko.com`}</code>
+            </pre>
+          </div>
+        </section>
+
+        {/* Embed current */}
+        <section className="mt-10">
+          <h2 className="eagle">Current weather (embed)</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              GET /api/embed/current
+            </code>{" "}
+            — a compact current-conditions payload built for widgets. Pass a{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              slug
+            </code>{" "}
+            or{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              lat
+            </code>{" "}
+            &amp;{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              lon
+            </code>
+            . With no parameters it returns weather for the visitor&apos;s own
+            location, derived from their IP.
+          </p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`# Visitor's local weather (IP-based)
+curl "https://weather.mukoko.com/api/embed/current"
+
+# A specific location by slug
+curl "https://weather.mukoko.com/api/embed/current?slug=harare"
+
+# Explicit coordinates
+curl "https://weather.mukoko.com/api/embed/current?lat=-17.83&lon=31.05"`}</code>
+            </pre>
+          </div>
+          <p className="mt-4 text-base text-text-secondary">Response shape:</p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`{
+  "location": { "name": "Harare", "province": "Harare",
+                "slug": "harare", "country": "ZW" },
+  "current":  { "temp": 24, "feelsLike": 23, "code": 2,
+                "condition": "Partly cloudy", "high": 27, "low": 14,
+                "humidity": 55, "windSpeed": 9, "windDirection": "SE",
+                "isDay": true },
+  "daily": [ { "date": "2026-06-30", "day": "Today", "code": 2,
+               "condition": "Partly cloudy", "high": 27, "low": 14,
+               "precipitationProbability": 0 } /* up to 7 */ ],
+  "source": "ip",
+  "attribution": { "name": "mukoko weather",
+                   "url": "https://weather.mukoko.com/harare" }
+}`}</code>
+            </pre>
+          </div>
+        </section>
+
+        {/* Full forecast */}
+        <section className="mt-10">
+          <h2 className="eagle">Full forecast</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              GET /api/py/weather?lat=&amp;lon=
+            </code>{" "}
+            — the complete forecast: current conditions plus 24-hour hourly and
+            7-day daily arrays. Add{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              &amp;models=
+            </code>{" "}
+            (a comma list of{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              gfs_seamless,ecmwf_ifs04,icon_seamless,meteofrance_seamless
+            </code>
+            ) for a Windy-style multi-model comparison. A next-hour
+            precipitation nowcast (
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              minutely
+            </code>
+            , four 15-minute steps) is attached automatically when available.
+          </p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`# Full forecast for Harare
+curl "https://weather.mukoko.com/api/py/weather?lat=-17.83&lon=31.05"
+
+# With a multi-model comparison
+curl "https://weather.mukoko.com/api/py/weather?lat=-17.83&lon=31.05&models=gfs_seamless,ecmwf_ifs04"`}</code>
+            </pre>
+          </div>
+          <p className="mt-4 text-base text-text-secondary">
+            The response carries headers that tell you which provider served
+            what:{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              X-Weather-Provider
+            </code>{" "}
+            (origin of the hourly/daily forecast —{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              tomorrow
+            </code>{" "}
+            /{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              open-meteo
+            </code>{" "}
+            /{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              fallback
+            </code>
+            ) and{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              X-Current-Source
+            </code>{" "}
+            (origin of the{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              current
+            </code>{" "}
+            block, which may be{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              stationkit
+            </code>{" "}
+            when a nearby weather station is in range).
+          </p>
+        </section>
+
+        {/* Geo lookup */}
+        <section className="mt-10">
+          <h2 className="eagle">Nearest location (geo lookup)</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              GET /api/py/geo?lat=&amp;lon=
+            </code>{" "}
+            — resolves coordinates to the nearest known location (name, slug,
+            province, country). Handy for turning a device GPS fix into a place.
+          </p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`curl "https://weather.mukoko.com/api/py/geo?lat=-17.83&lon=31.05"`}</code>
+            </pre>
+          </div>
+        </section>
+
+        {/* Locations & search */}
+        <section className="mt-10">
+          <h2 className="eagle">Location lookup &amp; search</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              GET /api/py/locations?slug=
+            </code>{" "}
+            fetches a single location by slug.{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              GET /api/py/search?q=
+            </code>{" "}
+            runs a text search across supported locations.
+          </p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`# Look up a location by slug
+curl "https://weather.mukoko.com/api/py/locations?slug=harare"
+
+# Search locations by name
+curl "https://weather.mukoko.com/api/py/search?q=nairobi"`}</code>
+            </pre>
+          </div>
+        </section>
+
+        {/* Air quality */}
+        <section className="mt-10">
+          <h2 className="eagle">Air quality</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              GET /api/py/airquality?lat=&amp;lon=
+            </code>{" "}
+            — the EPA-standard Air Quality Index (0–500) plus a seven-pollutant
+            breakdown (PM2.5, PM10, O₃, NO₂, SO₂, CO, NH₃).
+          </p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`curl "https://weather.mukoko.com/api/py/airquality?lat=-17.83&lon=31.05"`}</code>
+            </pre>
+          </div>
+        </section>
+
+        {/* Nearest airports */}
+        <section className="mt-10">
+          <h2 className="eagle">Nearest airports</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              GET /api/py/airports/nearest?lat=&amp;lon=&amp;count=
+            </code>{" "}
+            — the N nearest ICAO airports, each with its code, name, and
+            distance in kilometres, sorted closest-first.{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              count
+            </code>{" "}
+            defaults to 5 (max 20).
+          </p>
+          <div className="mt-4 tortoise">
+            <pre className="overflow-x-auto text-base">
+              <code className="font-mono text-text-primary">{`curl "https://weather.mukoko.com/api/py/airports/nearest?lat=-17.83&lon=31.05&count=3"`}</code>
+            </pre>
+          </div>
+        </section>
+
+        {/* AI endpoints */}
+        <section className="mt-10">
+          <h2 className="eagle">AI endpoints</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            mukoko also runs AI-powered weather summaries and the Shamwari
+            chatbot. These are rate-limited and evolve quickly, so we don&apos;t
+            document their internals here — try them live at{" "}
+            <Link
+              href="/shamwari"
+              prefetch={false}
+              className="text-primary underline hover:text-primary/80 transition-colors"
+            >
+              Shamwari
+            </Link>
+            .
+          </p>
+        </section>
+
+        {/* API keys (optional) */}
+        <section className="mt-10">
+          <h2 className="eagle">API keys (optional)</h2>
+          <p className="mt-2 text-base text-text-secondary leading-relaxed">
+            You never need a key for the public endpoints above. API keys are an
+            optional extra for registered developers who want{" "}
+            <strong className="text-text-primary">higher rate limits</strong>{" "}
+            and <strong className="text-text-primary">named attribution</strong>{" "}
+            for their traffic. Creating a key requires signing in.
+          </p>
+          <div className="mt-4 baobab">
+            {signedIn ? (
+              <>
+                <p className="text-base text-text-secondary">
+                  You&apos;re signed in{user?.email ? ` as ${user.email}` : ""}{" "}
+                  — manage your developer keys below.
+                </p>
+                <Link
+                  href="/developers/keys"
+                  prefetch={false}
+                  className="kudu press-scale mt-4 inline-flex"
+                >
+                  Manage API keys
+                </Link>
+              </>
+            ) : (
+              <>
+                <p className="text-base text-text-secondary">
+                  Sign in to create and manage API keys. It&apos;s free — keys
+                  just unlock higher limits for registered developers.
+                </p>
+                <Link
+                  href="/auth/signin?returnTo=/developers/keys"
+                  prefetch={false}
+                  className="kudu press-scale mt-4 inline-flex"
+                >
+                  Sign in to create an API key
+                </Link>
+              </>
+            )}
+          </div>
+        </section>
+
+        {/* Terms / fair use */}
+        <section className="mt-10 mb-10">
+          <h2 className="eagle">Terms &amp; fair use</h2>
+          <p className="mt-2 text-base text-text-secondary leading-relaxed">
+            These endpoints are free to use — weather is a public good. They are
+            rate-limited per IP to keep the service healthy for everyone, so
+            cache responses where you can and avoid hammering them in tight
+            loops. Please keep the{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              attribution
+            </code>{" "}
+            back to mukoko weather when you display our data. Weather data is
+            sourced from{" "}
+            <a
+              href="https://www.tomorrow.io"
+              className="text-primary underline hover:text-primary/80 transition-colors"
+              rel="noopener noreferrer"
+            >
+              Tomorrow.io
+            </a>{" "}
+            and{" "}
+            <a
+              href="https://open-meteo.com"
+              className="text-primary underline hover:text-primary/80 transition-colors"
+              rel="noopener noreferrer"
+            >
+              Open-Meteo
+            </a>
+            . For a ready-made UI, use the{" "}
+            <Link
+              href="/embed"
+              prefetch={false}
+              className="text-primary underline hover:text-primary/80 transition-colors"
+            >
+              embeddable widget
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/seo.test.ts
+++ b/src/app/seo.test.ts
@@ -42,7 +42,9 @@ describe("sitemap.ts", () => {
   // static pages + explore tag pages (locations array will be empty).
   it("includes the homepage", async () => {
     const result = await sitemap();
-    const home = result.find((entry) => entry.url === "https://weather.mukoko.com");
+    const home = result.find(
+      (entry) => entry.url === "https://weather.mukoko.com",
+    );
     expect(home).toBeDefined();
     expect(home!.priority).toBe(1.0);
     expect(home!.changeFrequency).toBe("hourly");
@@ -51,37 +53,60 @@ describe("sitemap.ts", () => {
   it("includes static pages (about, help, history, privacy, terms)", async () => {
     const result = await sitemap();
 
-    const aboutEntry = result.find((e) => e.url === "https://weather.mukoko.com/about");
+    const aboutEntry = result.find(
+      (e) => e.url === "https://weather.mukoko.com/about",
+    );
     expect(aboutEntry).toBeDefined();
     expect(aboutEntry!.changeFrequency).toBe("monthly");
 
-    const helpEntry = result.find((e) => e.url === "https://weather.mukoko.com/help");
+    const helpEntry = result.find(
+      (e) => e.url === "https://weather.mukoko.com/help",
+    );
     expect(helpEntry).toBeDefined();
     expect(helpEntry!.changeFrequency).toBe("monthly");
 
-    const historyEntry = result.find((e) => e.url === "https://weather.mukoko.com/history");
+    const historyEntry = result.find(
+      (e) => e.url === "https://weather.mukoko.com/history",
+    );
     expect(historyEntry).toBeDefined();
     expect(historyEntry!.changeFrequency).toBe("daily");
     expect(historyEntry!.priority).toBe(0.8);
 
-    const privacyEntry = result.find((e) => e.url === "https://weather.mukoko.com/privacy");
+    const privacyEntry = result.find(
+      (e) => e.url === "https://weather.mukoko.com/privacy",
+    );
     expect(privacyEntry).toBeDefined();
     expect(privacyEntry!.changeFrequency).toBe("yearly");
 
-    const termsEntry = result.find((e) => e.url === "https://weather.mukoko.com/terms");
+    const termsEntry = result.find(
+      (e) => e.url === "https://weather.mukoko.com/terms",
+    );
     expect(termsEntry).toBeDefined();
     expect(termsEntry!.changeFrequency).toBe("yearly");
   });
 
   it("includes explore page and tag pages", async () => {
     const result = await sitemap();
-    const explore = result.find((e) => e.url === "https://weather.mukoko.com/explore");
+    const explore = result.find(
+      (e) => e.url === "https://weather.mukoko.com/explore",
+    );
     expect(explore).toBeDefined();
     expect(explore!.priority).toBe(0.8);
 
-    const exploreTags = ["city", "farming", "mining", "tourism", "national-park", "education", "border", "travel"];
+    const exploreTags = [
+      "city",
+      "farming",
+      "mining",
+      "tourism",
+      "national-park",
+      "education",
+      "border",
+      "travel",
+    ];
     for (const tag of exploreTags) {
-      const entry = result.find((e) => e.url === `https://weather.mukoko.com/explore/${tag}`);
+      const entry = result.find(
+        (e) => e.url === `https://weather.mukoko.com/explore/${tag}`,
+      );
       expect(entry).toBeDefined();
       expect(entry!.priority).toBe(0.7);
     }
@@ -89,15 +114,21 @@ describe("sitemap.ts", () => {
 
   it("includes boosted city entries (harare, bulawayo, victoria-falls)", async () => {
     const result = await sitemap();
-    const harare = result.find((e) => e.url === "https://weather.mukoko.com/harare");
+    const harare = result.find(
+      (e) => e.url === "https://weather.mukoko.com/harare",
+    );
     expect(harare).toBeDefined();
     expect(harare!.priority).toBe(0.9);
 
-    const bulawayo = result.find((e) => e.url === "https://weather.mukoko.com/bulawayo");
+    const bulawayo = result.find(
+      (e) => e.url === "https://weather.mukoko.com/bulawayo",
+    );
     expect(bulawayo).toBeDefined();
     expect(bulawayo!.priority).toBe(0.9);
 
-    const vicfalls = result.find((e) => e.url === "https://weather.mukoko.com/victoria-falls");
+    const vicfalls = result.find(
+      (e) => e.url === "https://weather.mukoko.com/victoria-falls",
+    );
     expect(vicfalls).toBeDefined();
     expect(vicfalls!.priority).toBe(0.9);
   });
@@ -139,8 +170,8 @@ describe("canonical URLs — every page sets its own canonical", () => {
 
   // Pages that MUST have their own canonical to avoid GSC errors
   const pagesWithCanonicals: [string, string][] = [
-    ["page.tsx", "/harare"],               // home → points to /harare
-    ["[location]/page.tsx", "loc.slug"],   // dynamic locations
+    ["page.tsx", "/harare"], // home → points to /harare
+    ["[location]/page.tsx", "loc.slug"], // dynamic locations
     ["explore/page.tsx", "/explore"],
     ["shamwari/page.tsx", "/shamwari"],
     ["history/page.tsx", "/history"],
@@ -150,6 +181,7 @@ describe("canonical URLs — every page sets its own canonical", () => {
     ["terms/page.tsx", "/terms"],
     ["status/page.tsx", "/status"],
     ["embed/page.tsx", "/embed"],
+    ["developers/page.tsx", "/developers"],
   ];
 
   for (const [file, expectedFragment] of pagesWithCanonicals) {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,10 @@
 import type { MetadataRoute } from "next";
-import { getAllLocationSlugsForSitemap, getAllCountryCodes, getAllProvinces, getFeaturedTagsFromDb } from "@/lib/db";
+import {
+  getAllLocationSlugsForSitemap,
+  getAllCountryCodes,
+  getAllProvinces,
+  getFeaturedTagsFromDb,
+} from "@/lib/db";
 import { TAGS } from "@/lib/seed-tags";
 import { logError } from "@/lib/observability";
 
@@ -89,6 +94,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.5,
     },
     {
+      url: `${baseUrl}/developers`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
       url: `${baseUrl}/privacy`,
       lastModified: now,
       changeFrequency: "yearly",
@@ -118,7 +129,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     countryCodes = codes;
     provinces = provs;
     // Fall back to seed tags if DB returns nothing (e.g. cold start / test environment)
-    featuredTagSlugs = tags.length > 0 ? tags.map((t) => t.slug) : TAGS.filter((t) => t.featured).map((t) => t.slug);
+    featuredTagSlugs =
+      tags.length > 0
+        ? tags.map((t) => t.slug)
+        : TAGS.filter((t) => t.featured).map((t) => t.slug);
   } catch (err) {
     logError({
       source: "mongodb",
@@ -195,5 +209,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.5,
   }));
 
-  return [...staticPages, ...explorePages, ...countryPages, ...provincePages, ...locationPages, ...subRoutePages];
+  return [
+    ...staticPages,
+    ...explorePages,
+    ...countryPages,
+    ...provincePages,
+    ...locationPages,
+    ...subRoutePages,
+  ];
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -7,32 +7,80 @@ export function Footer() {
   const year = new Date().getFullYear();
 
   const col = "flex flex-col gap-1";
-  const heading = "mb-2 text-xs font-semibold uppercase tracking-widest text-text-tertiary";
-  const link = "text-base text-text-secondary transition-colors hover:text-text-primary";
+  const heading =
+    "mb-2 text-xs font-semibold uppercase tracking-widest text-text-tertiary";
+  const link =
+    "text-base text-text-secondary transition-colors hover:text-text-primary";
 
   return (
-    <footer className="border-t border-text-tertiary/10 bg-surface-base pb-24 sm:pb-0" role="contentinfo">
+    <footer
+      className="border-t border-text-tertiary/10 bg-surface-base pb-24 sm:pb-0"
+      role="contentinfo"
+    >
       <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 md:px-8">
-
         {/* ── Main columns ── */}
         <div className="grid grid-cols-2 gap-x-8 gap-y-12 sm:grid-cols-4">
-
           {/* Brand */}
           <div className={`${col} col-span-2 sm:col-span-1`}>
-            <Link href="/" className="flex items-center gap-2" aria-label="mukoko weather home">
-              <Image src="/logo-light.svg" alt="mukoko mark" width={28} height={28} className="h-7 w-7 dark:hidden" />
-              <Image src="/logo-dark.svg" alt="mukoko mark" width={28} height={28} className="h-7 w-7 hidden dark:block" />
-              <span className="font-heading font-bold text-text-primary">weather</span>
+            <Link
+              href="/"
+              className="flex items-center gap-2"
+              aria-label="mukoko weather home"
+            >
+              <Image
+                src="/logo-light.svg"
+                alt="mukoko mark"
+                width={28}
+                height={28}
+                className="h-7 w-7 dark:hidden"
+              />
+              <Image
+                src="/logo-dark.svg"
+                alt="mukoko mark"
+                width={28}
+                height={28}
+                className="h-7 w-7 hidden dark:block"
+              />
+              <span className="font-heading font-bold text-text-primary">
+                weather
+              </span>
             </Link>
             <p className="text-base text-text-secondary leading-relaxed max-w-[220px]">
-              AI-powered weather intelligence for Africa and beyond. Weather as a public good.
+              AI-powered weather intelligence for Africa and beyond. Weather as
+              a public good.
             </p>
             <div className="flex items-center gap-3 pt-1">
-              <a href="https://twitter.com/mukokoafrica" target="_blank" rel="noopener noreferrer" aria-label="Twitter" className="text-text-tertiary hover:text-text-primary transition-colors">
-                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.745l7.73-8.835L1.254 2.25H8.08l4.259 5.632zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+              <a
+                href="https://twitter.com/mukokoafrica"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Twitter"
+                className="text-text-tertiary hover:text-text-primary transition-colors"
+              >
+                <svg
+                  className="h-4 w-4"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.745l7.73-8.835L1.254 2.25H8.08l4.259 5.632zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                </svg>
               </a>
-              <a href="https://github.com/nyuchitech/mukoko-weather" target="_blank" rel="noopener noreferrer" aria-label="GitHub" className="text-text-tertiary hover:text-text-primary transition-colors">
-                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+              <a
+                href="https://github.com/nyuchitech/mukoko-weather"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="GitHub"
+                className="text-text-tertiary hover:text-text-primary transition-colors"
+              >
+                <svg
+                  className="h-4 w-4"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+                </svg>
               </a>
             </div>
           </div>
@@ -40,32 +88,92 @@ export function Footer() {
           {/* Weather */}
           <div className={col}>
             <p className={heading}>Weather</p>
-            <Link href="/explore" prefetch={false} className={link}>Explore</Link>
-            <Link href="/history" prefetch={false} className={link}>Historical data</Link>
-            <Link href="/shamwari" prefetch={false} className={link}>Shamwari AI</Link>
-            <Link href="/aviation" prefetch={false} className={link}>Aviation</Link>
-            <Link href="/embed" prefetch={false} className={link}>Embed widget</Link>
-            <Link href="/status" prefetch={false} className={link}>System status</Link>
+            <Link href="/explore" prefetch={false} className={link}>
+              Explore
+            </Link>
+            <Link href="/history" prefetch={false} className={link}>
+              Historical data
+            </Link>
+            <Link href="/shamwari" prefetch={false} className={link}>
+              Shamwari AI
+            </Link>
+            <Link href="/aviation" prefetch={false} className={link}>
+              Aviation
+            </Link>
+            <Link href="/embed" prefetch={false} className={link}>
+              Embed widget
+            </Link>
+            <Link href="/developers" prefetch={false} className={link}>
+              Developers &amp; API
+            </Link>
+            <Link href="/status" prefetch={false} className={link}>
+              System status
+            </Link>
           </div>
 
           {/* Company */}
           <div className={col}>
             <p className={heading}>Company</p>
-            <Link href="/about" prefetch={false} className={link}>About</Link>
-            <Link href="/help" prefetch={false} className={link}>Help</Link>
-            <Link href="/privacy" prefetch={false} className={link}>Privacy</Link>
-            <Link href="/terms" prefetch={false} className={link}>Terms</Link>
-            <a href="mailto:support@mukoko.com" className={link}>Contact</a>
-            <a href="https://github.com/nyuchitech/mukoko-weather/issues/new/choose" target="_blank" rel="noopener noreferrer" className={link}>Report an issue</a>
+            <Link href="/about" prefetch={false} className={link}>
+              About
+            </Link>
+            <Link href="/help" prefetch={false} className={link}>
+              Help
+            </Link>
+            <Link href="/privacy" prefetch={false} className={link}>
+              Privacy
+            </Link>
+            <Link href="/terms" prefetch={false} className={link}>
+              Terms
+            </Link>
+            <a href="mailto:support@mukoko.com" className={link}>
+              Contact
+            </a>
+            <a
+              href="https://github.com/nyuchitech/mukoko-weather/issues/new/choose"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={link}
+            >
+              Report an issue
+            </a>
           </div>
 
           {/* Ecosystem */}
           <div className={col}>
             <p className={heading}>Ecosystem</p>
-            <a href="https://nyuchi.com" target="_blank" rel="noopener noreferrer" className={link}>Nyuchi Africa</a>
-            <a href="https://mukoko.com" target="_blank" rel="noopener noreferrer" className={link}>Mukoko.com</a>
-            <a href="https://barstool.mukoko.com" target="_blank" rel="noopener noreferrer" className={link}>Barstool</a>
-            <a href="https://travel.mukoko.com" target="_blank" rel="noopener noreferrer" className={link}>Travel</a>
+            <a
+              href="https://nyuchi.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={link}
+            >
+              Nyuchi Africa
+            </a>
+            <a
+              href="https://mukoko.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={link}
+            >
+              Mukoko.com
+            </a>
+            <a
+              href="https://barstool.mukoko.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={link}
+            >
+              Barstool
+            </a>
+            <a
+              href="https://travel.mukoko.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={link}
+            >
+              Travel
+            </a>
           </div>
         </div>
 
@@ -73,16 +181,32 @@ export function Footer() {
         <div className="mt-14 flex flex-col gap-4 border-t border-text-tertiary/10 pt-8 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-base text-text-tertiary">
             &copy; {year} Mukoko Africa — a division of{" "}
-            <a href="https://nyuchi.com" className="transition-colors hover:text-text-secondary" rel="noopener">
+            <a
+              href="https://nyuchi.com"
+              className="transition-colors hover:text-text-secondary"
+              rel="noopener"
+            >
               Nyuchi Africa (PVT) Ltd
             </a>
             . <span className="italic">Ndiri nekuti tiri.</span>
           </p>
           <p className="text-sm text-text-tertiary">
             Weather data:{" "}
-            <a href="https://www.tomorrow.io" className="hover:text-text-secondary transition-colors" rel="noopener noreferrer">Tomorrow.io</a>
+            <a
+              href="https://www.tomorrow.io"
+              className="hover:text-text-secondary transition-colors"
+              rel="noopener noreferrer"
+            >
+              Tomorrow.io
+            </a>
             {" & "}
-            <a href="https://open-meteo.com" className="hover:text-text-secondary transition-colors" rel="noopener noreferrer">Open-Meteo</a>
+            <a
+              href="https://open-meteo.com"
+              className="hover:text-text-secondary transition-colors"
+              rel="noopener noreferrer"
+            >
+              Open-Meteo
+            </a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adds a live public API documentation page at **`/developers`** — there was previously no page documenting mukoko's public, no-auth weather endpoints.

The page is a server component that mirrors the existing `/embed` and `/help` page style (Header/Footer, `eagle` section headings, `tortoise` code blocks, brand tokens only — no hardcoded styles). It sets its own canonical (`https://weather.mukoko.com/developers`) and emits `TechArticle` JSON-LD consistent with the site's structured-data pattern.

### Documented public endpoints (free, no key, CORS-open, with real curl examples + response shapes)
- `GET /api/embed/current` — compact current weather (`?slug=`, `?lat=&lon=`, or IP-based); full JSON response shape (location/current/daily/source/attribution)
- `GET /api/py/weather?lat=&lon=` — full forecast; notes `?models=` multi-model + `minutely` nowcast and the `X-Weather-Provider` / `X-Current-Source` headers
- `GET /api/py/geo?lat=&lon=` — nearest location lookup
- `GET /api/py/locations?slug=` / `GET /api/py/search?q=` — location lookup / search
- `GET /api/py/airquality?lat=&lon=` — AQI
- `GET /api/py/airports/nearest?lat=&lon=&count=` — nearest ICAO airports
- Notes the open CORS policy (browser-callable cross-origin), a **Terms / fair use** note (free, rate-limited per IP, attribution), and links to `/embed` for the widget and `/shamwari` for the AI surface (internals not documented).

### API keys (optional) — auth-aware
Leads with "**The API is free and open — call it directly, no key needed.**" Adds an optional **API keys** section explaining keys are for registered developers (higher limits / attribution) and require sign-in. Auth-aware CTA via `getCurrentUser()`:
- Signed in → **Manage API keys** → `/developers/keys`
- Anonymous → **Sign in to create an API key** → `/auth/signin?returnTo=/developers/keys`

The key backend and the `/developers/keys` page are owned by a separate workstream — this PR only links to them.

### Also
- Footer: added **Developers & API** link under the Weather column
- Sitemap: added `/developers` (priority 0.6, monthly)
- Tests: co-located `developers.test.ts` (metadata, canonical, JSON-LD, documented endpoints, CORS/header notes, auth-aware key CTAs) + `/developers` added to `seo.test.ts` canonical coverage

## Verification
- `npm test` — 84 files, 1934 tests passing
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — compiles; `/developers` generates (dynamic route, since it reads auth state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)