### PR TITLE
feat(embed): real copy-paste iframe widget + working /embed docs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -34,6 +34,15 @@ const nextConfig: NextConfig = {
         ],
       },
       {
+        // The iframe widget target must be embeddable on ANY third-party site.
+        // The app sets no X-Frame-Options (so framing is already allowed); this
+        // makes it explicit and future-proof via CSP frame-ancestors.
+        source: "/embed/widget",
+        headers: [
+          { key: "Content-Security-Policy", value: "frame-ancestors *" },
+        ],
+      },
+      {
         // API CORS headers
         source: "/api/:path*",
         headers: [

--- a/src/app/embed/page.tsx
+++ b/src/app/embed/page.tsx
@@ -1,15 +1,55 @@
 import type { Metadata } from "next";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
+import { MukokoWeatherEmbed } from "@/components/embed";
 
 export const metadata: Metadata = {
   title: "Embed Weather Widgets",
   description:
-    "Add mukoko weather widgets to your website. Four widget types — current condition, today card, 5-day and 7-day forecast cards — for any location worldwide, or the visitor's own location automatically.",
+    "Add mukoko weather widgets to any website in one line — copy-paste an <iframe>, or call the free public JSON API. Four widget types (current, today, 5-day, 7-day) for any location worldwide, or the visitor's own location automatically.",
   alternates: {
     canonical: "https://weather.mukoko.com/embed",
   },
 };
+
+const SITE = "https://weather.mukoko.com";
+
+// Copy-paste iframe snippets — the primary, works-anywhere embed method.
+const IFRAME_CURRENT = `<iframe
+  src="${SITE}/embed/widget?type=current&location=harare"
+  width="340" height="120" style="border:0" loading="lazy"
+  title="mukoko weather — current conditions"></iframe>`;
+
+const IFRAME_TODAY = `<iframe
+  src="${SITE}/embed/widget?type=today&location=bulawayo"
+  width="380" height="230" style="border:0" loading="lazy"
+  title="mukoko weather — today"></iframe>`;
+
+const IFRAME_5DAY = `<iframe
+  src="${SITE}/embed/widget?type=5day&location=victoria-falls"
+  width="460" height="300" style="border:0" loading="lazy"
+  title="mukoko weather — 5-day forecast"></iframe>`;
+
+const IFRAME_7DAY = `<iframe
+  src="${SITE}/embed/widget?type=7day&location=mutare"
+  width="460" height="380" style="border:0" loading="lazy"
+  title="mukoko weather — 7-day forecast"></iframe>`;
+
+const IFRAME_IP = `<!-- No location = the visitor's own weather (from their IP) -->
+<iframe
+  src="${SITE}/embed/widget?type=today"
+  width="380" height="230" style="border:0" loading="lazy"
+  title="mukoko weather — your location"></iframe>`;
+
+function CodeBlock({ children }: { children: string }) {
+  return (
+    <div className="mt-4 tortoise">
+      <pre className="overflow-x-auto text-base">
+        <code className="font-mono text-text-primary">{children}</code>
+      </pre>
+    </div>
+  );
+}
 
 export default function EmbedPage() {
   return (
@@ -20,94 +60,108 @@ export default function EmbedPage() {
           Embed Weather Widgets
         </h1>
         <p className="mt-4 text-text-secondary">
-          Add live weather to any React or Next.js site — all free, no API key
-          required. Four widget types are available. Omit the{" "}
+          Add live weather to any website — no build step, no API key, all free.
+          The fastest way is a copy-paste{" "}
+          <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+            &lt;iframe&gt;
+          </code>
+          . Four widget types are available. Omit the{" "}
           <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
             location
           </code>{" "}
-          prop and the widget automatically shows the visitor&apos;s local
+          parameter and the widget automatically shows the visitor&apos;s local
           weather (detected from their IP).
         </p>
 
-        {/* Install */}
+        {/* 1 · iframe quick start */}
         <section className="mt-10">
-          <h2 className="eagle">Install</h2>
-          <div className="mt-4 tortoise">
-            <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`import { MukokoWeatherEmbed } from "@mukoko/weather-embed";`}</code>
-            </pre>
-          </div>
-        </section>
-
-        {/* 1. Current condition */}
-        <section className="mt-10">
-          <h2 className="eagle">1 · Current condition</h2>
+          <h2 className="eagle">1 · Copy-paste iframe</h2>
           <p className="mt-2 text-base text-text-secondary">
-            A compact inline card — current temperature, condition, and an icon.
-            Great for navbars, headers, or sidebars.
+            Works on any site — WordPress, Squarespace, plain HTML, or any
+            framework. Paste the snippet where you want the widget to appear and
+            adjust <code className="font-mono">width</code> /{" "}
+            <code className="font-mono">height</code> to taste.
           </p>
-          <div className="mt-4 tortoise">
-            <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`{/* A specific location */}
-<MukokoWeatherEmbed type="current" location="harare" />
 
-{/* The visitor's own location (IP-based) */}
-<MukokoWeatherEmbed type="current" />`}</code>
-            </pre>
-          </div>
-        </section>
+          <h3 className="mt-6 giraffe">Current condition</h3>
+          <p className="mt-1 text-base text-text-secondary">
+            A compact inline card — current temperature, condition, and an icon.
+          </p>
+          <CodeBlock>{IFRAME_CURRENT}</CodeBlock>
 
-        {/* 2. Today card */}
-        <section className="mt-10">
-          <h2 className="eagle">2 · Today card</h2>
-          <p className="mt-2 text-base text-text-secondary">
+          <h3 className="mt-6 giraffe">Today card</h3>
+          <p className="mt-1 text-base text-text-secondary">
             A fuller current-day card — temperature, condition, feels-like, and
             today&apos;s high / low.
           </p>
-          <div className="mt-4 tortoise">
-            <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`<MukokoWeatherEmbed type="today" location="bulawayo" />`}</code>
-            </pre>
-          </div>
-        </section>
+          <CodeBlock>{IFRAME_TODAY}</CodeBlock>
 
-        {/* 3. 5-day card */}
-        <section className="mt-10">
-          <h2 className="eagle">3 · 5-day card</h2>
-          <p className="mt-2 text-base text-text-secondary">
+          <h3 className="mt-6 giraffe">5-day forecast</h3>
+          <p className="mt-1 text-base text-text-secondary">
             A five-day forecast strip — day, condition, and high / low per day.
           </p>
-          <div className="mt-4 tortoise">
-            <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`<MukokoWeatherEmbed type="5day" location="victoria-falls" />`}</code>
-            </pre>
-          </div>
-        </section>
+          <CodeBlock>{IFRAME_5DAY}</CodeBlock>
 
-        {/* 4. 7-day card */}
-        <section className="mt-10">
-          <h2 className="eagle">4 · 7-day card</h2>
-          <p className="mt-2 text-base text-text-secondary">
-            A seven-day forecast strip — same layout as the 5-day card, extended
-            to a full week.
+          <h3 className="mt-6 giraffe">7-day forecast</h3>
+          <p className="mt-1 text-base text-text-secondary">
+            The same layout as the 5-day card, extended to a full week.
           </p>
-          <div className="mt-4 tortoise">
-            <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`<MukokoWeatherEmbed type="7day" location="mutare" />`}</code>
-            </pre>
+          <CodeBlock>{IFRAME_7DAY}</CodeBlock>
+
+          <h3 className="mt-6 giraffe">Visitor&apos;s own location</h3>
+          <p className="mt-1 text-base text-text-secondary">
+            Drop the <code className="font-mono">location</code> parameter and
+            the widget resolves the visitor&apos;s weather from their IP.
+          </p>
+          <CodeBlock>{IFRAME_IP}</CodeBlock>
+        </section>
+
+        {/* 2 · Live preview — proves it works with real data */}
+        <section className="mt-10">
+          <h2 className="eagle">2 · Live preview</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            These are the real widgets, rendering live data from the public API
+            right now. What you see below is exactly what your visitors get.
+          </p>
+          <div className="mt-4 flex flex-wrap items-start gap-6">
+            <div>
+              <p className="mb-2 dove">type=current · location=harare</p>
+              <MukokoWeatherEmbed type="current" location="harare" />
+            </div>
+            <div>
+              <p className="mb-2 dove">type=today · location=harare</p>
+              <MukokoWeatherEmbed type="today" location="harare" />
+            </div>
+            <div>
+              <p className="mb-2 dove">type=5day · location=harare</p>
+              <MukokoWeatherEmbed type="5day" location="harare" />
+            </div>
           </div>
         </section>
 
-        {/* Props */}
+        {/* 3 · Widget URL parameters */}
         <section className="mt-10">
-          <h2 className="eagle">Props</h2>
+          <h2 className="eagle">3 · Widget URL parameters</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            Configure the widget via query parameters on{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              {SITE}/embed/widget
+            </code>
+            .
+          </p>
           <div className="mt-4 overflow-x-auto">
             <table className="w-full text-base">
               <thead>
                 <tr className="border-b border-text-tertiary/10 text-left">
-                  <th className="pb-2 pr-4 font-semibold text-text-primary">Prop</th>
-                  <th className="pb-2 pr-4 font-semibold text-text-primary">Values</th>
-                  <th className="pb-2 font-semibold text-text-primary">Description</th>
+                  <th className="pb-2 pr-4 font-semibold text-text-primary">
+                    Parameter
+                  </th>
+                  <th className="pb-2 pr-4 font-semibold text-text-primary">
+                    Values
+                  </th>
+                  <th className="pb-2 font-semibold text-text-primary">
+                    Description
+                  </th>
                 </tr>
               </thead>
               <tbody className="text-text-secondary">
@@ -119,35 +173,35 @@ export default function EmbedPage() {
                 <tr className="border-b border-text-tertiary/10">
                   <td className="py-2 pr-4 font-mono text-base">location</td>
                   <td className="py-2 pr-4">harare, bulawayo, ...</td>
-                  <td className="py-2">Location slug. Omit for the visitor&apos;s IP location</td>
+                  <td className="py-2">
+                    Location slug. Omit for the visitor&apos;s IP location
+                  </td>
                 </tr>
                 <tr className="border-b border-text-tertiary/10">
                   <td className="py-2 pr-4 font-mono text-base">lat / lon</td>
                   <td className="py-2 pr-4">numbers</td>
-                  <td className="py-2">Explicit coordinates (override slug + IP)</td>
+                  <td className="py-2">
+                    Explicit coordinates (override slug + IP)
+                  </td>
                 </tr>
                 <tr className="border-b border-text-tertiary/10">
                   <td className="py-2 pr-4 font-mono text-base">theme</td>
-                  <td className="py-2 pr-4">light, dark, auto</td>
+                  <td className="py-2 pr-4">auto, light, dark</td>
                   <td className="py-2">Theme (default: auto)</td>
-                </tr>
-                <tr className="border-b border-text-tertiary/10">
-                  <td className="py-2 pr-4 font-mono text-base">apiUrl</td>
-                  <td className="py-2 pr-4">URL</td>
-                  <td className="py-2">API origin (default: weather.mukoko.com)</td>
                 </tr>
               </tbody>
             </table>
           </div>
         </section>
 
-        {/* Public API */}
-        <section className="mt-10 mb-10">
-          <h2 className="eagle">Public API</h2>
+        {/* 4 · Public API */}
+        <section className="mt-10">
+          <h2 className="eagle">4 · Direct JSON API</h2>
           <p className="mt-2 text-base text-text-secondary">
-            The widget is powered by a public JSON endpoint you can call directly
-            from any site. With no parameters it returns weather for the
-            visitor&apos;s location (derived from their IP); pass{" "}
+            Prefer to build your own UI? The widget is powered by a public JSON
+            endpoint you can call directly from any site or server. With no
+            parameters it returns weather for the visitor&apos;s location
+            (derived from their IP); pass{" "}
             <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
               slug
             </code>{" "}
@@ -161,22 +215,16 @@ export default function EmbedPage() {
             </code>{" "}
             to pin a location. CORS is open to all origins.
           </p>
-          <div className="mt-4 tortoise">
-            <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`# Visitor's local weather (IP-based)
-GET https://weather.mukoko.com/api/embed/current
+          <CodeBlock>{`# Visitor's local weather (IP-based)
+curl ${SITE}/api/embed/current
 
 # A specific location
-GET https://weather.mukoko.com/api/embed/current?slug=harare
+curl "${SITE}/api/embed/current?slug=harare"
 
 # Explicit coordinates
-GET https://weather.mukoko.com/api/embed/current?lat=-17.83&lon=31.05`}</code>
-            </pre>
-          </div>
+curl "${SITE}/api/embed/current?lat=-17.83&lon=31.05"`}</CodeBlock>
           <p className="mt-4 text-base text-text-secondary">Response shape:</p>
-          <div className="mt-4 tortoise">
-            <pre className="overflow-x-auto text-base">
-              <code className="font-mono text-text-primary">{`{
+          <CodeBlock>{`{
   "location": { "name": "Harare", "province": "Harare",
                 "slug": "harare", "country": "ZW" },
   "current":  { "temp": 24, "feelsLike": 23, "code": 2,
@@ -188,10 +236,26 @@ GET https://weather.mukoko.com/api/embed/current?lat=-17.83&lon=31.05`}</code>
                "precipitationProbability": 0 } /* up to 7 */ ],
   "source": "ip",
   "attribution": { "name": "mukoko weather",
-                   "url": "https://weather.mukoko.com/harare" }
-}`}</code>
-            </pre>
-          </div>
+                   "url": "${SITE}/harare" }
+}`}</CodeBlock>
+        </section>
+
+        {/* npm package — clearly marked as not yet available */}
+        <section className="mt-10 mb-10">
+          <h2 className="eagle">React / npm package</h2>
+          <p className="mt-2 text-base text-text-secondary">
+            A published{" "}
+            <code className="rounded bg-surface-base px-1.5 py-0.5 font-mono text-base">
+              @mukoko/weather-embed
+            </code>{" "}
+            React package is{" "}
+            <strong className="text-text-primary">
+              not yet available — coming soon
+            </strong>
+            . Until it ships, use the copy-paste{" "}
+            <code className="font-mono">&lt;iframe&gt;</code> above (works in React
+            and every other framework) or call the JSON API directly.
+          </p>
         </section>
       </main>
       <Footer />

--- a/src/app/embed/widget/page.tsx
+++ b/src/app/embed/widget/page.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+import { MukokoWeatherEmbed, type EmbedType } from "@/components/embed";
+import "./widget.css";
+
+/**
+ * Standalone iframe target for the weather widget.
+ *
+ * This is the URL people put in an <iframe src>. It renders ONLY the widget —
+ * no Header, Footer, or nav — so it drops cleanly into any third-party page.
+ *
+ *   /embed/widget?type=current|today|5day|7day
+ *                &location=<slug>            (or)
+ *                &lat=<n>&lon=<n>            (or)
+ *                (none — visitor's IP location)
+ *                &theme=auto|light|dark
+ *
+ * The underlying MukokoWeatherEmbed component fetches the public embed API
+ * (`/api/embed/current`) client-side, so this page needs no data fetching.
+ */
+
+export const metadata: Metadata = {
+  title: "Weather widget",
+  description: "Embeddable mukoko weather widget.",
+  // Embed targets are meant to live inside other pages, not to be indexed.
+  robots: { index: false, follow: false },
+};
+
+const VALID_TYPES: EmbedType[] = ["current", "today", "5day", "7day"];
+
+function first(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parseType(value: string | undefined): EmbedType {
+  return VALID_TYPES.includes(value as EmbedType)
+    ? (value as EmbedType)
+    : "current";
+}
+
+function parseTheme(value: string | undefined): "light" | "dark" | "auto" {
+  return value === "light" || value === "dark" ? value : "auto";
+}
+
+function parseNum(value: string | undefined): number | undefined {
+  if (value === undefined || value === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export default async function EmbedWidgetPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+
+  const type = parseType(first(sp.type));
+  // Accept both `location` (documented) and `slug` (API param name) for the slug.
+  const location = first(sp.location) ?? first(sp.slug);
+  const lat = parseNum(first(sp.lat));
+  const lon = parseNum(first(sp.lon));
+  const theme = parseTheme(first(sp.theme));
+
+  return (
+    <main className="mkw-embed-host" aria-label="mukoko weather widget">
+      <MukokoWeatherEmbed
+        type={type}
+        location={location}
+        lat={lat}
+        lon={lon}
+        theme={theme}
+      />
+    </main>
+  );
+}

--- a/src/app/embed/widget/widget.css
+++ b/src/app/embed/widget/widget.css
@@ -1,0 +1,35 @@
+/* Standalone iframe target for the weather widget.
+ *
+ * This is a PLAIN (non-module) global stylesheet, imported only by the widget
+ * route's page.tsx — so it is included solely on /embed/widget, never elsewhere.
+ * A CSS Module can't be used here: this file's whole job is to override the
+ * root layout's GLOBAL brand chrome (mineral stripe, body background, left
+ * gutter), and the project's css-loader runs in pure mode, which rejects
+ * global-only module selectors.
+ *
+ * All class names are namespaced with `mkw-embed-` to avoid collisions. */
+
+.mkw-embed-host {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  min-height: 100dvh;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+}
+
+/* Hide the root-layout decorative mineral stripe so the iframe shows only the widget. */
+.minerals-stripe {
+  display: none !important;
+}
+
+/* Let the host page's background show through the iframe (transparent embed). */
+body {
+  background: transparent !important;
+}
+
+/* Remove the root layout's left gutter so the widget sits flush at 0,0. */
+body > div {
+  padding-left: 0 !important;
+}

--- a/src/app/embed/widget/widget.test.ts
+++ b/src/app/embed/widget/widget.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Tests for the standalone iframe widget route (/embed/widget).
+ *
+ * This is the URL users put in an <iframe src>. It must render ONLY the widget
+ * (no Header/Footer/nav), validate its query params, and strip the app's global
+ * brand chrome so the embed is self-contained.
+ */
+
+const pagePath = resolve(__dirname, "./page.tsx");
+const pageContent = readFileSync(pagePath, "utf-8");
+
+const cssPath = resolve(__dirname, "./widget.css");
+const cssContent = readFileSync(cssPath, "utf-8");
+
+describe("embed widget route — page", () => {
+  it("renders the shared MukokoWeatherEmbed component", () => {
+    expect(pageContent).toContain("MukokoWeatherEmbed");
+    expect(pageContent).toContain('from "@/components/embed"');
+    expect(pageContent).toContain("<MukokoWeatherEmbed");
+  });
+
+  it("reads query params via the Next 16 async searchParams API", () => {
+    expect(pageContent).toContain("searchParams: Promise<");
+    expect(pageContent).toContain("await searchParams");
+  });
+
+  it("passes all documented params through to the widget", () => {
+    for (const prop of ["type=", "location=", "lat=", "lon=", "theme="]) {
+      expect(pageContent).toContain(prop);
+    }
+  });
+
+  it("validates type against exactly the four supported variants", () => {
+    expect(pageContent).toContain('"current"');
+    expect(pageContent).toContain('"today"');
+    expect(pageContent).toContain('"5day"');
+    expect(pageContent).toContain('"7day"');
+    // Falls back to "current" for anything unexpected.
+    expect(pageContent).toMatch(/\?\s*\([\s\S]*?\)\s*:\s*"current"/);
+  });
+
+  it("accepts both location and slug for the location slug", () => {
+    expect(pageContent).toContain("sp.location");
+    expect(pageContent).toContain("sp.slug");
+  });
+
+  it("only accepts explicit light/dark, otherwise auto", () => {
+    expect(pageContent).toContain('value === "light" || value === "dark"');
+    expect(pageContent).toContain('"auto"');
+  });
+
+  it("marks the embed target as noindex (not a public landing page)", () => {
+    expect(pageContent).toContain("robots:");
+    expect(pageContent).toContain("index: false");
+  });
+
+  it("does not render app chrome (no Header/Footer imports)", () => {
+    expect(pageContent).not.toContain("components/layout/Header");
+    expect(pageContent).not.toContain("components/layout/Footer");
+  });
+
+  it("does not use inline style objects", () => {
+    expect(pageContent).not.toMatch(/style=\{\{/);
+  });
+});
+
+describe("embed widget route — standalone CSS", () => {
+  it("hides the global mineral stripe chrome for the embed", () => {
+    expect(cssContent).toContain(".minerals-stripe");
+    expect(cssContent).toContain("display: none");
+  });
+
+  it("uses a transparent background so the host page shows through", () => {
+    expect(cssContent).toContain("background: transparent");
+  });
+});

--- a/src/components/embed/MukokoWeatherEmbed.test.ts
+++ b/src/components/embed/MukokoWeatherEmbed.test.ts
@@ -99,4 +99,37 @@ describe("MukokoWeatherEmbed component", () => {
     expect(componentContent).toContain("styles.todayCard");
     expect(componentContent).toContain("styles.forecastCard");
   });
+
+  it("is re-exported from the embed barrel for external consumers", () => {
+    const indexContent = readFileSync(resolve(__dirname, "./index.ts"), "utf-8");
+    expect(indexContent).toContain(
+      'export { MukokoWeatherEmbed } from "./MukokoWeatherEmbed"',
+    );
+    expect(indexContent).toContain('export type { EmbedType }');
+  });
+});
+
+describe("MukokoWeatherEmbed consumers", () => {
+  it("is rendered by the standalone iframe widget route", () => {
+    const widgetPage = readFileSync(
+      resolve(__dirname, "../../app/embed/widget/page.tsx"),
+      "utf-8",
+    );
+    expect(widgetPage).toContain('from "@/components/embed"');
+    expect(widgetPage).toContain("<MukokoWeatherEmbed");
+  });
+
+  it("powers the live preview on the /embed docs page", () => {
+    const docsPage = readFileSync(
+      resolve(__dirname, "../../app/embed/page.tsx"),
+      "utf-8",
+    );
+    expect(docsPage).toContain("MukokoWeatherEmbed");
+    // The docs page leads with a copy-paste iframe pointing at the widget route.
+    expect(docsPage).toContain("/embed/widget?type=");
+    // The broken npm import must NOT be presented as usable.
+    expect(docsPage).not.toContain(
+      'import { MukokoWeatherEmbed } from "@mukoko/weather-embed"',
+    );
+  });
 });


### PR DESCRIPTION
## Problem

The `/embed` page documented `import { MukokoWeatherEmbed } from "@mukoko/weather-embed"` — **a package that does not exist**. Nobody could actually embed the widget, even though the public JSON API (`GET /api/embed/current`) worked fine.

## What this does

Ships genuinely usable, copy-paste embedding.

### New iframe widget route — `/embed/widget`
- Renders **only** the `MukokoWeatherEmbed` widget — no Header / Footer / nav.
- Query params: `type=current|today|5day|7day`, `location=<slug>`, `lat`/`lon`, `theme=auto|light|dark`. Accepts `slug` as an alias for `location`.
- A route-scoped plain global stylesheet (`widget.css`, loaded only on this route) hides the root layout's brand chrome (mineral stripe, left gutter) and makes the body transparent so the embed blends into the host page. A CSS Module can't do this — the project's css-loader is in pure mode and rejects global-only module selectors.
- `noindex` metadata (it's an embed target, not a landing page).
- Public / not auth-gated (`/embed/*` is on the anonymous allowlist).

### next.config.ts
- Explicit `Content-Security-Policy: frame-ancestors *` on `/embed/widget` so it's always embeddable on third-party sites (the app already sets no `X-Frame-Options`).

### `/embed` docs rewrite
1. **Copy-paste `<iframe>`** snippets for all four types + the IP-based (no-location) default.
2. **Live preview** — renders the real `MukokoWeatherEmbed` (current / today / 5-day) with live data, proving it works.
3. **Widget URL parameter** table.
4. **Direct JSON API** section with `curl` examples + response shape (unchanged, still correct).
5. The `@mukoko/weather-embed` npm reference is **relabeled "not yet available — coming soon"** so nobody copies a broken import.

### Tests
- New `src/app/embed/widget/widget.test.ts` (route + standalone CSS).
- `MukokoWeatherEmbed.test.ts` updated: barrel export + both consumers (widget route, docs live preview), and asserts the broken import is gone.

## Verification
- `npm test` — 84 files, 1923 tests pass
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — compiles; `/embed` and `/embed/widget` both build

## Paste-this snippet
```html
<iframe
  src="https://weather.mukoko.com/embed/widget?type=current&location=harare"
  width="340" height="120" style="border:0" loading="lazy"
  title="mukoko weather"></iframe>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)