### PR TITLE
fix(nav): redesign mobile bottom nav as a floating glass pill

### DIFF
--- a/src/components/layout/Header.test.ts
+++ b/src/components/layout/Header.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for Header — validates the mobile bottom navigation is a floating
+ * glass pill (detached, rounded, stays visible on scroll) while preserving
+ * the 5 nav items, accessibility, and touch-target sizing.
+ * Reads source file directly (no DOM renderer needed for structural checks).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const source = readFileSync(resolve(__dirname, "Header.tsx"), "utf-8");
+
+describe("Header — mobile nav floating pill", () => {
+  it("is a centered, detached floating pill (not an edge-pinned full-width bar)", () => {
+    // Floats above the safe-area, horizontally centered
+    expect(source).toContain(
+      "bottom-[calc(env(safe-area-inset-bottom,0px)+0.75rem)]",
+    );
+    expect(source).toContain("left-1/2");
+    expect(source).toContain("-translate-x-1/2");
+    // No longer full-width, edge-pinned
+    expect(source).not.toContain("bottom-0 left-0 right-0");
+  });
+
+  it("uses pill styling: rounded-full, glass, subtle border, shadow", () => {
+    expect(source).toContain("rounded-full");
+    expect(source).toContain("bg-surface-base/90");
+    expect(source).toContain("backdrop-blur-xl");
+    expect(source).toContain("border border-text-tertiary/10");
+    expect(source).toContain("shadow-lg");
+  });
+
+  it("drops the top border used by the old edge bar", () => {
+    expect(source).not.toContain("border-t border-text-tertiary/10");
+  });
+
+  it("stays fixed (visible on scroll) and above content via z-40", () => {
+    expect(source).toContain("fixed");
+    expect(source).toContain("z-40");
+  });
+
+  it("inner container is a compact horizontal row, not a full-height bar", () => {
+    expect(source).toContain("flex items-center gap-1 px-2 py-1.5");
+    expect(source).not.toContain("min-h-[5rem]");
+  });
+
+  it("keeps it visible only on mobile (sm:hidden)", () => {
+    expect(source).toContain("sm:hidden");
+  });
+});
+
+describe("Header — mobile nav preserved behaviour", () => {
+  it("keeps all 5 nav items and their labels", () => {
+    for (const label of [
+      "Weather",
+      "Explore",
+      "Shamwari",
+      "History",
+      "My Weather",
+    ]) {
+      expect(source).toContain(`>${label}</span>`);
+    }
+  });
+
+  it("preserves the active indicator dot and active text colour", () => {
+    expect(source).toContain("rounded-full bg-primary");
+    expect(source).toContain("text-primary");
+  });
+
+  it("preserves press feedback and aria-current on active items", () => {
+    expect(source).toContain("active:scale-95");
+    expect(source).toContain('aria-current');
+  });
+
+  it("preserves accessible touch targets via the design token", () => {
+    expect(source).toContain("min-w-[var(--touch-target-min)]");
+    expect(source).toContain("min-h-[var(--touch-target-min)]");
+  });
+
+  it("keeps the Mobile navigation aria-label landmark", () => {
+    expect(source).toContain('aria-label="Mobile navigation"');
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -149,14 +149,15 @@ export function Header() {
         </nav>
       </header>
 
-      {/* Mobile bottom navigation — 5 items with Shamwari center */}
-      {/* 56px min touch targets, 22px icons, 10px labels */}
+      {/* Mobile bottom navigation — floating glass pill, 5 items with Shamwari center */}
+      {/* Detached from the edges (floats above the safe-area) so mobile browser */}
+      {/* chrome never obscures it; stays put on scroll because it's fixed. */}
+      {/* 48px min touch targets, 22px icons, 10px labels */}
       <nav
         aria-label="Mobile navigation"
-        className="fixed bottom-0 left-0 right-0 z-40 border-t border-text-tertiary/10 bg-surface-base/95 backdrop-blur-xl sm:hidden"
-        style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+        className="fixed bottom-[calc(env(safe-area-inset-bottom,0px)+0.75rem)] left-1/2 z-40 -translate-x-1/2 rounded-full border border-text-tertiary/10 bg-surface-base/90 shadow-lg backdrop-blur-xl sm:hidden"
       >
-        <div className="mx-auto flex items-center justify-around px-1 min-h-[5rem]">
+        <div className="flex items-center gap-1 px-2 py-1.5">
           <Link
             href="/"
             className={`relative flex flex-col items-center justify-center gap-0.5 px-2 py-2 rounded-xl transition-all min-w-[var(--touch-target-min)] min-h-[var(--touch-target-min)] active:scale-95 ${


### PR DESCRIPTION
## What

Redesigns the mobile bottom navigation (`src/components/layout/Header.tsx`, `<nav aria-label="Mobile navigation">`, `sm:hidden`) from a full-width bar pinned to the bottom edge into a **floating glass pill** that stays visible on scroll.

The old bar (`fixed bottom-0 left-0 right-0 border-t ... min-h-[5rem]`) read as hidden/obscured by mobile browser chrome while scrolling. Detaching it from the edge and floating it above the safe-area fixes that perception.

## Changes

- **Wrapper → centered, detached floating pill:** `fixed bottom-[calc(env(safe-area-inset-bottom,0px)+0.75rem)] left-1/2 -translate-x-1/2 z-40 sm:hidden` with `rounded-full`, glass (`bg-surface-base/90 backdrop-blur-xl`), `border border-text-tertiary/10`, and `shadow-lg`. Removed the old `border-t` (no longer an edge bar).
- **Inner container → compact horizontal row:** `flex items-center gap-1 px-2 py-1.5` instead of `justify-around min-h-[5rem]`, so the pill fits its 5 items rather than spanning full width.
- **Stays visible on scroll:** still `fixed` at `z-40`; no hide-on-scroll behavior introduced.
- **Everything else preserved:** the 5 items (Weather / Explore / Shamwari / History / My Weather), icons, links, `active:scale-95`, active `text-primary` + indicator dot, `aria-current`, aria-labels, and ≥48px touch targets (`min-w/min-h-[var(--touch-target-min)]`).
- **Content clearance:** the pill is shorter than the old 80px bar, so existing mobile bottom padding (pages' `pb-24`, Footer `pb-24 sm:pb-0`, shamwari chat input `pb-[4.5rem]`) still clears it — no padding changes needed, and the shamwari full-viewport chat input is unaffected.
- Brand tokens / fauna classes only — no hardcoded hex or inline styles except the allowed `env(safe-area-inset-bottom)` dynamic value.

## Tests

Adds `src/components/layout/Header.test.ts` (source-reading structural assertions, matching the repo's existing component-test pattern) verifying the floating-pill classes and preserved behaviour.

## Verification

- `npm test` — 86 files, 1959 tests pass
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run build` — compiled successfully, 187/187 pages generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)