### PR TITLE
fix(location): nearby POI names must not override the current-location road/address

### DIFF
--- a/api/py/_locations.py
+++ b/api/py/_locations.py
@@ -636,12 +636,15 @@ def _match_nearby_poi(lat: float, lon: float) -> dict | None:
     Returns ``{"name": str, "poiType": str | None}`` when a *named* POI exists
     within ``POI_MATCH_RADIUS_KM`` (≤250 m) of (lat, lon), else ``None``.
 
-    A very close named POI (a school, hospital, market, park) gives a richer,
-    more consistent location name than a raw reverse-geocode. This is
-    intentionally tight — it is NOT a coarse distance-snap to far-away places.
-    Wrapped so a POI-lookup failure never breaks location resolution: any
-    error, missing index, or empty result falls through to ``None`` and the
-    caller keeps its reverse-geocoded name.
+    Callers use only ``poiType`` (school/hospital/market/park) as
+    supplementary context for the location page + AI summary — e.g. "near a
+    school". They must NOT use ``name`` to replace the reverse-geocoded
+    road/address: this lookup runs on passive GPS/coordinate detection, not
+    a search-and-pick flow, so the user never chose this specific POI —
+    presenting it as their location name is confusing when it's merely
+    nearby. Wrapped so a POI-lookup failure never breaks location
+    resolution: any error, missing index, or empty result falls through to
+    ``None``.
     """
     try:
         poi = find_nearest_place(lat, lon, POI_MATCH_RADIUS_KM)
@@ -702,15 +705,16 @@ async def geo_lookup(
                     detail="Could not determine location name",
                 )
 
-            # ── POI refinement — prefer a very-close named POI (≤250 m) ──────
-            # If the user is essentially standing on a named POI (school,
-            # hospital, market, park), use its name/type instead of the raw
-            # reverse-geocode — richer and consistent with the platform's POI
-            # catalog. Best-effort; falls back to the reverse-geocode on miss.
+            # ── POI context — nearby named POI (≤250 m) as metadata only ─────
+            # This is GPS auto-detection, not a search-and-pick flow — the
+            # user did not choose this POI, so its name must never replace
+            # the reverse-geocoded road/address (that's what confusingly
+            # relabeled someone's street as "XYZ School" just because a
+            # school happened to be 200m away). We still surface `poiType`
+            # (school/hospital/market/park) as supplementary context for the
+            # location page + AI summary — just not as the location's name.
             poi_match = _match_nearby_poi(lat, lon)
             poi_type = poi_match.get("poiType") if poi_match else None
-            if poi_match:
-                geocoded["name"] = poi_match["name"]
 
             # ── Tight duplicate check against placesGeo (Phase 0G) ───────────
             # ONLY a 1km same-name dedup. Anything wider would snap a specific
@@ -914,12 +918,12 @@ async def add_location(request: Request):
         if not geocoded:
             raise HTTPException(status_code=422, detail="Could not determine location name")
 
-        # POI refinement — prefer a very-close named POI (≤250 m) over the raw
-        # reverse-geocode (best-effort; falls back to the reverse-geocode name).
+        # POI context — nearby named POI (≤250 m) as metadata only. These are
+        # raw coordinates, not a search-and-pick flow, so a nearby POI's name
+        # must never replace the reverse-geocoded road/address — only its
+        # `poiType` (school/hospital/market/park) is surfaced as context.
         poi_match = _match_nearby_poi(lat, lon)
         poi_type = poi_match.get("poiType") if poi_match else None
-        if poi_match:
-            geocoded["name"] = poi_match["name"]
 
         # Duplicate check (1km radius + name/country match)
         duplicate = _find_duplicate(

--- a/tests/py/test_locations.py
+++ b/tests/py/test_locations.py
@@ -1989,11 +1989,14 @@ class TestGeoLookupPoiRefinement:
     @patch("py._locations._reverse_geocode")
     @patch("py._locations.find_nearest_location")
     @patch("py._locations.places_geo_collection")
-    async def test_poi_overrides_name_and_flows_through(
+    async def test_poi_is_context_only_and_never_overrides_name(
         self, mock_coll, mock_nearest, mock_geocode, mock_poi, mock_dedup,
         mock_elev, mock_enrich, mock_upsert,
     ):
-        """A close POI replaces the reverse-geocode name and poiType is surfaced."""
+        """A close POI surfaces as context (poiType) but the reverse-geocoded
+        road/address always wins as the location's name — this is passive GPS
+        detection, not a search-and-pick flow, so the user never chose the
+        POI and must not have their street silently relabeled as it."""
         mock_nearest.return_value = None
         mock_geocode.return_value = {
             "country": "ZW", "countryName": "Zimbabwe",
@@ -2004,12 +2007,13 @@ class TestGeoLookupPoiRefinement:
         mock_dedup.return_value = None
         mock_elev.return_value = 1490
         mock_coll.return_value.find_one.return_value = None
-        mock_upsert.return_value = {"_id": "u", "slug": "prince-edward-school-abc123"}
+        mock_upsert.return_value = {"_id": "u", "slug": "fourth-street-abc123"}
 
         result = await geo_lookup(-17.83, 31.05, autoCreate=True)
         assert result["isNew"] is True
-        # POI name won over the reverse-geocode name.
-        assert result["nearest"]["name"] == "Prince Edward School"
+        # The reverse-geocode name wins — NOT the nearby POI's name.
+        assert result["nearest"]["name"] == "Fourth Street"
+        # poiType is still surfaced as supplementary context.
         assert result["nearest"]["poiType"] == "school"
         # And the POI type was stamped into the placesGeo write.
         assert mock_upsert.call_args.kwargs["mukoko_poi_type"] == "school"


### PR DESCRIPTION
## Summary

Follow-up to #78 (merged) — a related location-naming bug in the same "find my current location" flow, reported after that PR landed.

`GET /api/py/geo?autoCreate=true` and `POST /api/py/locations/add` (coordinates mode) both do a reverse-geocode of the user's GPS/lat-lon, then separately look up the nearest named POI within 250m (`_match_nearby_poi`). Previously, if a POI was found, its name **unconditionally replaced** the reverse-geocoded road/address:

```python
poi_match = _match_nearby_poi(lat, lon)
if poi_match:
    geocoded["name"] = poi_match["name"]
```

Since this is passive GPS auto-detection (not a search-and-pick flow — the user never chose that POI), this produced confusing results: someone standing on their own residential street could get relabeled as "XYZ School" purely because a school happened to be 200m away.

The fix: the reverse-geocoded road/address always wins as the location's name now. `poiType` (school/hospital/market/park) is still computed and surfaced as supplementary context for the location page and AI summary (e.g. "near a school") — it just no longer overwrites the name itself.

## Test plan

- [x] `python -m pytest tests/py/ -v` — 920 tests passing (existing POI-override test rewritten to assert the road/address name wins while `poiType` context is still surfaced)
- [x] Full Python suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW

---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_