### PR TITLE
Consolidate the Shamwari CTA into one shared component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,8 @@ mukoko-weather/
 │   │   │   ├── AISummaryChat.test.ts
 │   │   │   ├── HistoryAnalysis.tsx   # AI-powered historical weather analysis (button-triggered)
 │   │   │   ├── HistoryAnalysis.test.ts
+│   │   │   ├── ShamwariCTA.tsx        # Shared "continue in Shamwari" link (feature-flag gate + context handoff)
+│   │   │   ├── ShamwariCTA.test.ts
 │   │   │   ├── ActivityInsights.tsx   # Category-specific weather insight cards
 │   │   │   ├── reports/               # Waze-style community weather reporting
 │   │   │   │   ├── WeatherReportModal.tsx   # 3-step wizard: select type → AI clarify → confirm
@@ -906,7 +908,8 @@ All skeletons include `role="status"` and `aria-label="Loading"` for screen read
 - Rendered with `react-markdown` inside Tailwind `prose` classes
 - Cached in MongoDB with tiered TTL (30/60/120 min by location tier)
 - If `ANTHROPIC_API_KEY` is unset, a basic weather summary fallback is generated
-- **Inline follow-up chat:** `AISummary` fires `onSummaryLoaded(text)` callback; `WeatherDashboard` passes the summary to `AISummaryChat` which allows up to 5 follow-up messages before redirecting to Shamwari
+- **Inline follow-up chat:** `AISummary` fires `onSummaryLoaded(text)` callback; `WeatherDashboard` passes the summary to `AISummaryChat` which allows up to 5 follow-up messages before rendering the shared `ShamwariCTA` (`source: "location"`) to redirect to Shamwari
+- **Shared Shamwari handoff:** `src/components/weather/ShamwariCTA.tsx` centralizes the `FLAGS.shamwari_chat` gate + `setShamwariContext` call + styled `/shamwari` link that `AISummaryChat`, `HistoryAnalysis`, and `ExploreSearch` all render — previously each hand-rolled its own copy of this logic. Renders `null` while the flag is off. Exposes 4 visual variants (`tanzanite`, `primary`, `subtle`, `text`) matching each call site's prior styling
 - **Ask Shamwari link:** AISummary includes a "Ask Shamwari about this" link that sets `ShamwariContext` with the current location/weather/summary before navigating to `/shamwari`
 
 ### AI Prompt Library (Database-Driven)
@@ -1018,7 +1021,7 @@ All AI system prompts, suggested prompt rules, and model configurations are stor
 - **Route:** `/history` — client-side dashboard for exploring recorded weather data
 - **Components:** `src/app/history/page.tsx` (server, metadata) + `src/app/history/HistoryDashboard.tsx` (client)
 - **Features:** location search, configurable time period (7d–1y), comprehensive charts, summary statistics, daily records table, and AI-powered analysis
-- **AI analysis:** `src/components/weather/HistoryAnalysis.tsx` — button-triggered analysis ("Analyze with Shamwari"). Server-side aggregation computes compact stats (~800 tokens) from raw records, sends to Claude for trend/pattern analysis. Results rendered as markdown with tanzanite border. "Discuss in Shamwari" link carries analysis context via `ShamwariContext`. Cached 1h server-side
+- **AI analysis:** `src/components/weather/HistoryAnalysis.tsx` — button-triggered analysis ("Analyze with Shamwari"). Server-side aggregation computes compact stats (~800 tokens) from raw records, sends to Claude for trend/pattern analysis. Results rendered as markdown with tanzanite border. Renders the shared `ShamwariCTA` (`source: "history"` + `historyDays` + `historyAnalysis`) as its "Discuss in Shamwari" link. Cached 1h server-side
 - **Data source:** `GET /api/history?location=<slug>&days=<n>` backed by MongoDB `weather_history` collection
 - **Charts:** Reusable chart components from `src/components/weather/charts/` (Canvas 2D via Chart.js)
 
@@ -1221,7 +1224,7 @@ All pages use a **TikTok-style sequential mounting** pattern — only ONE sectio
 **Components:**
 
 - `src/app/explore/page.tsx` — server component (ISR 1h), fetches tag counts and featured tags, renders AI search + Shamwari CTA card + category browse grid + country browse link
-- `src/components/explore/ExploreSearch.tsx` — client component with two layers: (1) **instant quick matches** — the same debounced (300ms) fast name/tag search used by `MyWeatherModal`'s location picker (`GET /api/py/search?q=...&limit=6`, `AbortController`-cancelled on rapid typing), shown live as the user types, as plain location links; (2) **AI search** — natural-language query (e.g., "farming areas with low frost risk"), submitted explicitly, results render as location cards with inline weather data. This keeps the quick-match experience consistent everywhere in the app search is offered, while AI search remains an additional, deliberate step. "Ask Shamwari for more" link sets `ShamwariContext` with `source: "explore"` + `exploreQuery` (gated behind the `shamwari_chat` feature flag)
+- `src/components/explore/ExploreSearch.tsx` — client component with two layers: (1) **instant quick matches** — the same debounced (300ms) fast name/tag search used by `MyWeatherModal`'s location picker (`GET /api/py/search?q=...&limit=6`, `AbortController`-cancelled on rapid typing), shown live as the user types, as plain location links; (2) **AI search** — natural-language query (e.g., "farming areas with low frost risk"), submitted explicitly, results render as location cards with inline weather data. This keeps the quick-match experience consistent everywhere in the app search is offered, while AI search remains an additional, deliberate step. Renders the shared `ShamwariCTA` (`source: "explore"` + `exploreQuery`) as its "Ask Shamwari for more" link
 - **API:** `GET /api/py/search` — fast literal name/tag/geo text search (same endpoint as `MyWeatherModal`'s saved-locations search). `POST /api/py/explore/search` — uses Claude with `search_locations` + `get_weather` tools for natural-language queries. Falls back to text search if AI unavailable. Rate-limited 15 req/hour/IP
 
 **Sub-routes:**
@@ -1373,6 +1376,7 @@ _Page/component tests:_
 - `src/components/weather/SupportBanner.test.ts` — BMC support card structure, accessibility, error isolation, no hardcoded styles
 - `src/components/weather/AISummaryChat.test.ts` — inline follow-up chat structure, max message cap, accessibility
 - `src/components/weather/HistoryAnalysis.test.ts` — analysis structure, endpoint, request body, ShamwariContext, accessibility
+- `src/components/weather/ShamwariCTA.test.ts` — shared Shamwari handoff link: feature-flag gate, context handoff, variants
 - `src/components/weather/SavedLocationsModal.test.ts` — modal structure, icons, search, geolocation, loading skeleton, capacity management, accessibility
 - `src/components/weather/WeatherLoadingScene.test.ts` — KNOWN_ROUTES guard, reduced-motion support, Three.js integration, slug display, accessibility
 - `src/components/weather/reports/WeatherReportModal.test.ts` — 3-step wizard, report types, severity, accessibility

--- a/src/components/explore/ExploreSearch.test.ts
+++ b/src/components/explore/ExploreSearch.test.ts
@@ -111,9 +111,13 @@ describe("results rendering", () => {
 });
 
 describe("Shamwari context integration", () => {
-  it("imports useAppStore for context setting", () => {
-    expect(source).toContain("useAppStore");
-    expect(source).toContain("setShamwariContext");
+  // The feature-flag gate + setShamwariContext handoff + link rendering now
+  // live in the shared <ShamwariCTA> component (@/components/weather/ShamwariCTA)
+  // instead of being hand-rolled here — see ShamwariCTA's own tests for that
+  // behavior. This file only asserts ExploreSearch builds the right context.
+  it("imports ShamwariCTA", () => {
+    expect(source).toContain("ShamwariCTA");
+    expect(source).toContain("@/components/weather/ShamwariCTA");
   });
 
   it("sets explore context when navigating to Shamwari", () => {
@@ -121,14 +125,8 @@ describe("Shamwari context integration", () => {
     expect(source).toContain("exploreQuery: query");
   });
 
-  it("has an 'Ask Shamwari for more' link", () => {
+  it("has an 'Ask Shamwari for more' CTA", () => {
     expect(source).toContain("Ask Shamwari for more");
-    expect(source).toContain('href="/shamwari"');
-  });
-
-  it("gates the link behind the shamwari_chat feature flag", () => {
-    expect(source).toContain('isFeatureEnabled("shamwari_chat")');
-    expect(source).toContain("shamwariEnabled &&");
   });
 });
 

--- a/src/components/explore/ExploreSearch.tsx
+++ b/src/components/explore/ExploreSearch.tsx
@@ -4,11 +4,10 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import Link from "next/link";
 import { SearchIcon, MapPinIcon, SparklesIcon } from "@/lib/weather-icons";
 import { Button } from "@/components/ui/button";
-import { useAppStore } from "@/lib/store";
-import { isFeatureEnabled } from "@/lib/feature-flags";
 import { weatherCodeToInfo } from "@/lib/weather";
 import { trackEvent } from "@/lib/analytics";
 import { useDebounce } from "@/lib/use-debounce";
+import { ShamwariCTA } from "@/components/weather/ShamwariCTA";
 
 interface QuickResult {
   slug: string;
@@ -50,8 +49,6 @@ export function ExploreSearch() {
   const [error, setError] = useState<string | null>(null);
   const [searched, setSearched] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const setShamwariContext = useAppStore((s) => s.setShamwariContext);
-  const shamwariEnabled = isFeatureEnabled("shamwari_chat");
 
   // Instant quick matches (same fast name/tag search + debounce pattern as
   // the My Weather modal's location search) — shown live as the user types,
@@ -130,13 +127,10 @@ export function ExploreSearch() {
     search(query);
   };
 
-  const handleAskShamwari = () => {
-    setShamwariContext({
-      source: "explore",
-      exploreQuery: query,
-      activities: [],
-      timestamp: Date.now(),
-    });
+  const shamwariContext = {
+    source: "explore" as const,
+    exploreQuery: query,
+    activities: [],
   };
 
   return (
@@ -291,16 +285,13 @@ export function ExploreSearch() {
         </div>
       )}
 
-      {shamwariEnabled && searched && results.length > 0 && (
+      {searched && results.length > 0 && (
         <div className="flex justify-center">
-          <Link
-            href="/shamwari"
-            onClick={handleAskShamwari}
-            className="press-scale inline-flex items-center gap-1.5 rounded-[var(--radius-input)] bg-primary/10 px-4 py-2 text-base font-medium text-primary transition-all hover:bg-primary/20 min-h-[var(--touch-target-min)]"
-          >
-            <SparklesIcon size={14} />
-            Ask Shamwari for more
-          </Link>
+          <ShamwariCTA
+            context={shamwariContext}
+            label="Ask Shamwari for more"
+            variant="subtle"
+          />
         </div>
       )}
     </section>

--- a/src/components/weather/AISummaryChat.tsx
+++ b/src/components/weather/AISummaryChat.tsx
@@ -4,10 +4,11 @@ import { useState, useRef, useEffect, useCallback, Component, type ReactNode } f
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import ReactMarkdown from "react-markdown";
-import { SparklesIcon, MapPinIcon } from "@/lib/weather-icons";
+import { SparklesIcon } from "@/lib/weather-icons";
 import { Button } from "@/components/ui/button";
 import { useAppStore } from "@/lib/store";
 import { isFeatureEnabled } from "@/lib/feature-flags";
+import { ShamwariCTA } from "./ShamwariCTA";
 import { getScrollBehavior } from "@/lib/utils";
 import {
   generateSuggestedPrompts,
@@ -131,7 +132,6 @@ export function AISummaryChat({ weather, location, initialSummary, season, user 
   const [loading, setLoading] = useState(false);
   const [suggestedPrompts, setSuggestedPrompts] = useState<SuggestedPrompt[]>([]);
   const selectedActivities = useAppStore((s) => s.selectedActivities);
-  const setShamwariContext = useAppStore((s) => s.setShamwariContext);
   const shamwariEnabled = isFeatureEnabled("shamwari_chat");
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -242,18 +242,15 @@ export function AISummaryChat({ weather, location, initialSummary, season, user 
     sendMessage(input);
   };
 
-  const handleContinueInShamwari = () => {
-    setShamwariContext({
-      source: "location",
-      locationSlug: location.slug,
-      locationName: location.name,
-      province: location.province,
-      weatherSummary: initialSummary || undefined,
-      temperature: weather.current.temperature_2m,
-      condition: String(weather.current.weather_code),
-      activities: selectedActivities,
-      timestamp: Date.now(),
-    });
+  const shamwariContext = {
+    source: "location" as const,
+    locationSlug: location.slug,
+    locationName: location.name,
+    province: location.province,
+    weatherSummary: initialSummary || undefined,
+    temperature: weather.current.temperature_2m,
+    condition: String(weather.current.weather_code),
+    activities: selectedActivities,
   };
 
   if (!initialSummary) return null;
@@ -354,14 +351,12 @@ export function AISummaryChat({ weather, location, initialSummary, season, user 
                     <p className="gazelle">
                       For a deeper conversation, continue in Shamwari chat.
                     </p>
-                    <Link
-                      href="/shamwari"
-                      onClick={handleContinueInShamwari}
-                      className="mt-2 inline-flex items-center gap-1.5 rounded-[var(--radius-badge)] bg-tanzanite px-4 py-2 text-base font-medium text-mineral-tanzanite-fg transition-colors hover:bg-tanzanite/90 min-h-[var(--touch-target-min)]"
-                    >
-                      <SparklesIcon size={14} />
-                      Continue in Shamwari
-                    </Link>
+                    <ShamwariCTA
+                      context={shamwariContext}
+                      label="Continue in Shamwari"
+                      variant="tanzanite"
+                      className="mt-2"
+                    />
                   </>
                 ) : (
                   <p className="gazelle">
@@ -413,16 +408,14 @@ export function AISummaryChat({ weather, location, initialSummary, season, user 
             )}
 
             {/* Link to Shamwari (always visible when there are messages) */}
-            {shamwariEnabled && messages.length > 0 && !atMessageLimit && (
+            {messages.length > 0 && !atMessageLimit && (
               <div className="mt-2 text-center">
-                <Link
-                  href="/shamwari"
-                  onClick={handleContinueInShamwari}
-                  className="inline-flex items-center gap-1 text-base text-text-tertiary transition-colors hover:text-tanzanite"
-                >
-                  <MapPinIcon size={10} />
-                  Continue in Shamwari for a deeper conversation
-                </Link>
+                <ShamwariCTA
+                  context={shamwariContext}
+                  label="Continue in Shamwari for a deeper conversation"
+                  variant="text"
+                  icon="map-pin"
+                />
               </div>
             )}
           </div>

--- a/src/components/weather/HistoryAnalysis.test.ts
+++ b/src/components/weather/HistoryAnalysis.test.ts
@@ -60,22 +60,23 @@ describe("HistoryAnalysis", () => {
     expect(source).toContain("min-h-[var(--touch-target-min)]");
   });
 
-  it("sets ShamwariContext for discuss-in-shamwari navigation", async () => {
+  it("builds ShamwariContext for discuss-in-shamwari navigation", async () => {
     const { readFileSync } = await import("fs");
     const { resolve } = await import("path");
     const source = readFileSync(resolve(__dirname, "HistoryAnalysis.tsx"), "utf-8");
-    expect(source).toContain("setShamwariContext");
     expect(source).toContain('source: "history"');
     expect(source).toContain("historyDays");
     expect(source).toContain("historyAnalysis");
   });
 
-  it("gates the Discuss in Shamwari link behind the shamwari_chat feature flag", async () => {
+  it("uses the shared ShamwariCTA component for the Discuss link", async () => {
+    // The feature-flag gate + setShamwariContext handoff + link rendering
+    // now live in @/components/weather/ShamwariCTA — see its own tests.
     const { readFileSync } = await import("fs");
     const { resolve } = await import("path");
     const source = readFileSync(resolve(__dirname, "HistoryAnalysis.tsx"), "utf-8");
-    expect(source).toContain('isFeatureEnabled("shamwari_chat")');
-    expect(source).toContain("{shamwariEnabled &&");
+    expect(source).toContain("ShamwariCTA");
+    expect(source).toContain("./ShamwariCTA");
   });
 
   it("uses tanzanite border for AI styling", async () => {

--- a/src/components/weather/HistoryAnalysis.tsx
+++ b/src/components/weather/HistoryAnalysis.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useState, useCallback, Component, type ReactNode } from "react";
-import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import { SparklesIcon } from "@/lib/weather-icons";
 import { Button } from "@/components/ui/button";
 import { useAppStore } from "@/lib/store";
-import { isFeatureEnabled } from "@/lib/feature-flags";
 import { trackEvent } from "@/lib/analytics";
+import { ShamwariCTA } from "./ShamwariCTA";
 
 // ---------------------------------------------------------------------------
 // Markdown error boundary
@@ -60,8 +59,6 @@ export function HistoryAnalysis({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const selectedActivities = useAppStore((s) => s.selectedActivities);
-  const setShamwariContext = useAppStore((s) => s.setShamwariContext);
-  const shamwariEnabled = isFeatureEnabled("shamwari_chat");
 
   const analyze = useCallback(async () => {
     setLoading(true);
@@ -101,16 +98,13 @@ export function HistoryAnalysis({
     }
   }, [locationSlug, days, selectedActivities]);
 
-  const handleContinueInShamwari = () => {
-    setShamwariContext({
-      source: "history",
-      locationSlug,
-      locationName,
-      historyDays: days,
-      historyAnalysis: analysis ?? undefined,
-      activities: selectedActivities,
-      timestamp: Date.now(),
-    });
+  const shamwariContext = {
+    source: "history" as const,
+    locationSlug,
+    locationName,
+    historyDays: days,
+    historyAnalysis: analysis ?? undefined,
+    activities: selectedActivities,
   };
 
   return (
@@ -192,16 +186,11 @@ export function HistoryAnalysis({
             >
               Re-analyze
             </Button>
-            {shamwariEnabled && (
-              <Link
-                href="/shamwari"
-                onClick={handleContinueInShamwari}
-                className="inline-flex items-center gap-1 rounded-[var(--radius-input)] bg-primary px-3 py-2 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90 min-h-[var(--touch-target-min)]"
-              >
-                <SparklesIcon size={12} />
-                Discuss in Shamwari
-              </Link>
-            )}
+            <ShamwariCTA
+              context={shamwariContext}
+              label="Discuss in Shamwari"
+              variant="primary"
+            />
           </div>
         </div>
       )}

--- a/src/components/weather/ShamwariCTA.test.ts
+++ b/src/components/weather/ShamwariCTA.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const source = readFileSync(resolve(__dirname, "ShamwariCTA.tsx"), "utf-8");
+
+/**
+ * ShamwariCTA — shared "continue this conversation in Shamwari" link.
+ *
+ * Centralizes the feature-flag gate + setShamwariContext handoff previously
+ * hand-rolled separately in AISummaryChat, HistoryAnalysis, and ExploreSearch.
+ */
+
+describe("ShamwariCTA structure", () => {
+  it("is a client component", () => {
+    expect(source).toContain('"use client"');
+  });
+
+  it("exports ShamwariCTA", () => {
+    expect(source).toContain("export function ShamwariCTA");
+  });
+
+  it("gates rendering behind the shamwari_chat feature flag", () => {
+    expect(source).toContain('isFeatureEnabled("shamwari_chat")');
+    expect(source).toContain("return null");
+  });
+
+  it("hands off context via setShamwariContext on click", () => {
+    expect(source).toContain("setShamwariContext");
+    expect(source).toContain('href="/shamwari"');
+  });
+});
+
+describe("ShamwariCTA variants", () => {
+  it("defines tanzanite, primary, subtle, and text variants", () => {
+    expect(source).toContain("tanzanite:");
+    expect(source).toContain("primary:");
+    expect(source).toContain("subtle:");
+    expect(source).toContain("text:");
+  });
+
+  it("supports both sparkles and map-pin icons", () => {
+    expect(source).toContain("SparklesIcon");
+    expect(source).toContain("MapPinIcon");
+    expect(source).toContain('"map-pin"');
+  });
+
+  it("uses global styles only — no hardcoded colors", () => {
+    expect(source).not.toMatch(/#[0-9a-fA-F]{3,8}[^)]/);
+    expect(source).not.toContain("style={{");
+  });
+});

--- a/src/components/weather/ShamwariCTA.tsx
+++ b/src/components/weather/ShamwariCTA.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { SparklesIcon, MapPinIcon } from "@/lib/weather-icons";
+import { useAppStore, type ShamwariContext } from "@/lib/store";
+import { isFeatureEnabled } from "@/lib/feature-flags";
+
+export type ShamwariCTAVariant = "tanzanite" | "primary" | "subtle" | "text";
+
+const VARIANT_CLASSES: Record<ShamwariCTAVariant, string> = {
+  tanzanite:
+    "inline-flex items-center gap-1.5 rounded-[var(--radius-badge)] bg-tanzanite px-4 py-2 text-base font-medium text-mineral-tanzanite-fg transition-colors hover:bg-tanzanite/90 min-h-[var(--touch-target-min)]",
+  primary:
+    "inline-flex items-center gap-1 rounded-[var(--radius-input)] bg-primary px-3 py-2 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90 min-h-[var(--touch-target-min)]",
+  subtle:
+    "press-scale inline-flex items-center gap-1.5 rounded-[var(--radius-input)] bg-primary/10 px-4 py-2 text-base font-medium text-primary transition-all hover:bg-primary/20 min-h-[var(--touch-target-min)]",
+  text: "inline-flex items-center gap-1 text-base text-text-tertiary transition-colors hover:text-tanzanite",
+};
+
+const VARIANT_ICON_SIZE: Record<ShamwariCTAVariant, number> = {
+  tanzanite: 14,
+  primary: 12,
+  subtle: 14,
+  text: 10,
+};
+
+export interface ShamwariCTAProps {
+  /** Context handed off to /shamwari on click — timestamp is stamped by the store */
+  context: Omit<ShamwariContext, "timestamp">;
+  label: string;
+  variant?: ShamwariCTAVariant;
+  icon?: "sparkles" | "map-pin";
+  className?: string;
+}
+
+/**
+ * Shared "continue this conversation in Shamwari" link. Centralizes the
+ * feature-flag gate + setShamwariContext handoff previously hand-rolled in
+ * AISummaryChat, HistoryAnalysis, and ExploreSearch. Renders nothing while
+ * FLAGS.shamwari_chat is off.
+ */
+export function ShamwariCTA({
+  context,
+  label,
+  variant = "primary",
+  icon = "sparkles",
+  className,
+}: ShamwariCTAProps) {
+  const setShamwariContext = useAppStore((s) => s.setShamwariContext);
+
+  if (!isFeatureEnabled("shamwari_chat")) return null;
+
+  const Icon = icon === "map-pin" ? MapPinIcon : SparklesIcon;
+
+  return (
+    <Link
+      href="/shamwari"
+      onClick={() => setShamwariContext(context)}
+      className={[VARIANT_CLASSES[variant], className].filter(Boolean).join(" ")}
+    >
+      <Icon size={VARIANT_ICON_SIZE[variant]} />
+      {label}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- `AISummaryChat.tsx`, `HistoryAnalysis.tsx`, and `ExploreSearch.tsx` each hand-rolled their own copy of the same "continue this in Shamwari" logic: check `FLAGS.shamwari_chat`, call `setShamwariContext(...)` with a source-specific context object, render a styled `Link` into `/shamwari` on click.
- Extracted `src/components/weather/ShamwariCTA.tsx` — one component that takes a `context` object, a `label`, and a visual `variant`, self-gates on the feature flag (renders `null` while `shamwari_chat` is paused), and owns the click handler + `setShamwariContext` call.
- Preserves each call site's exact prior styling as one of four variants (`tanzanite`, `primary`, `subtle`, `text`) — this is a pure refactor, no visual changes.
- Wired into all 4 previous CTA locations: `AISummaryChat`'s message-limit CTA + persistent follow-up link, `HistoryAnalysis`'s "Discuss in Shamwari", and `ExploreSearch`'s "Ask Shamwari for more".
- Left `src/app/explore/page.tsx`'s static "Ask Shamwari / Start chatting" promo card untouched — it doesn't call `setShamwariContext` (no context handoff), so it isn't the same duplicated pattern.
- Added `src/components/weather/ShamwariCTA.test.ts`; updated `ExploreSearch.test.ts` and `HistoryAnalysis.test.ts` to reflect the extracted component.
- Updated CLAUDE.md to document the shared component and its call sites.

## Test plan
- [x] `npm test` — 2006 tests passing (89 files)
- [x] `npm run lint` — 0 errors (15 pre-existing warnings, unchanged)
- [x] `npx tsc --noEmit` — clean

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW


---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_