### PR TITLE
Consolidate sub-route back-navigation into a shared Breadcrumb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,8 @@ mukoko-weather/
 │   │   ├── layout/
 │   │   │   ├── Header.tsx            # Sticky header + mobile bottom nav (Weather/Explore/History/My Weather; Shamwari paused, see FLAGS.shamwari_chat)
 │   │   │   ├── HeaderSkeleton.tsx    # Header loading skeleton
+│   │   │   ├── Breadcrumb.tsx        # Shared Home / Location / Current-page trail (atmosphere, forecast, map sub-routes)
+│   │   │   ├── Breadcrumb.test.ts
 │   │   │   └── Footer.tsx            # Footer with site stats, copyright, links, Ubuntu philosophy
 │   │   ├── weather/
 │   │   │   ├── CurrentConditions.tsx  # Large temp display, feels-like, daily high/low
@@ -506,6 +508,8 @@ All data handling, AI operations, database CRUD, and rule evaluation run in Pyth
 ### Routing
 
 **Philosophy:** The main location page (`/[location]`) is a compact overview — current conditions, AI summary, activity insights, and metric cards. Detail-heavy sections (charts, atmospheric trends, hourly/daily forecasts) live on dedicated sub-route pages. This reduces initial page load weight and prevents mobile OOM crashes from mounting all components simultaneously.
+
+**Sub-route back-navigation:** `/[location]/atmosphere`, `/[location]/forecast`, and `/[location]/map` all render the shared `Breadcrumb` component (`src/components/layout/Breadcrumb.tsx` — `Home / {location.name} / {current page}`) instead of each hand-rolling its own trail. `/[location]/map` previously used a floating "← Back to weather" pill overlay on the map; it now uses the same breadcrumb bar as the other two sub-routes for a consistent back-navigation pattern across all three.
 
 - `/` — GPS-first landing via `HomeLanding` (see "HomeLanding (Smart Home Page)" below): first-time visitors get a full auto-GPS prompt; returning visitors see their cached location immediately with a silent background GPS recheck for travel detection
 - `/[location]` — dynamic weather pages — overview: current conditions, AI summary, activity insights, atmospheric metric cards
@@ -1358,6 +1362,7 @@ _Page/component tests:_
 - `src/components/explore/ExploreChatbot.test.ts` — chatbot component tests, MarkdownErrorBoundary, contextual navigation
 - `src/components/explore/ExploreSearch.test.ts` — AI search structure, search flow, results rendering, Shamwari context
 - `src/components/embed/MukokoWeatherEmbed.test.ts` — widget rendering, data fetching
+- `src/components/layout/Breadcrumb.test.ts` — shared sub-route breadcrumb trail, aria-current, usage across atmosphere/forecast/map dashboards
 - `src/components/ui/chart-fallbacks.test.ts` — CSS fallback table key parity (light/dark sync)
 - `src/components/ui/primitives.test.ts` — UI primitive variants (StatusIndicator, CTACard, ToggleGroup, InfoRow, SectionHeader)
 - `src/components/weather/charts.test.ts` — chart data preparation (hourly + daily + atmospheric), hexWithAlpha

--- a/src/app/[location]/atmosphere/AtmosphereDashboard.tsx
+++ b/src/app/[location]/atmosphere/AtmosphereDashboard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { lazy, Suspense } from "react";
-import Link from "next/link";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
+import { Breadcrumb } from "@/components/layout/Breadcrumb";
 import { AtmosphericSummary } from "@/components/weather/AtmosphericSummary";
 import { SeasonBadge } from "@/components/weather/SeasonBadge";
 import { LazySection } from "@/components/weather/LazySection";
@@ -45,25 +45,13 @@ export function AtmosphereDashboard({
     <>
       <Header />
 
-      <nav aria-label="Breadcrumb" className="mx-auto max-w-5xl px-4 pt-4 sm:px-6 md:px-8">
-        <ol className="flex items-center gap-1 text-base text-text-tertiary">
-          <li>
-            <Link href="/" className="hover:text-text-secondary transition-colors focus-visible:outline-2 focus-visible:outline-primary focus-visible:rounded">
-              Home
-            </Link>
-          </li>
-          <li aria-hidden="true">/</li>
-          <li>
-            <Link href={`/${location.slug}`} className="hover:text-text-secondary transition-colors focus-visible:outline-2 focus-visible:outline-primary focus-visible:rounded">
-              {location.name}
-            </Link>
-          </li>
-          <li aria-hidden="true">/</li>
-          <li aria-current="page">
-            <span className="font-medium text-text-primary">Atmosphere</span>
-          </li>
-        </ol>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: location.name, href: `/${location.slug}` },
+          { label: "Atmosphere" },
+        ]}
+      />
 
       <main
         id="main-content"

--- a/src/app/[location]/forecast/ForecastDashboard.tsx
+++ b/src/app/[location]/forecast/ForecastDashboard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { lazy, Suspense } from "react";
-import Link from "next/link";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
+import { Breadcrumb } from "@/components/layout/Breadcrumb";
 import { SeasonBadge } from "@/components/weather/SeasonBadge";
 import { LazySection } from "@/components/weather/LazySection";
 import { ChartErrorBoundary } from "@/components/weather/ChartErrorBoundary";
@@ -36,25 +36,13 @@ export function ForecastDashboard({
     <>
       <Header />
 
-      <nav aria-label="Breadcrumb" className="mx-auto max-w-5xl px-4 pt-4 sm:px-6 md:px-8">
-        <ol className="flex items-center gap-1 text-base text-text-tertiary">
-          <li>
-            <Link href="/" className="hover:text-text-secondary transition-colors focus-visible:outline-2 focus-visible:outline-primary focus-visible:rounded">
-              Home
-            </Link>
-          </li>
-          <li aria-hidden="true">/</li>
-          <li>
-            <Link href={`/${location.slug}`} className="hover:text-text-secondary transition-colors focus-visible:outline-2 focus-visible:outline-primary focus-visible:rounded">
-              {location.name}
-            </Link>
-          </li>
-          <li aria-hidden="true">/</li>
-          <li aria-current="page">
-            <span className="font-medium text-text-primary">Forecast</span>
-          </li>
-        </ol>
-      </nav>
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: location.name, href: `/${location.slug}` },
+          { label: "Forecast" },
+        ]}
+      />
 
       <main
         id="main-content"

--- a/src/app/[location]/map/MapDashboard.tsx
+++ b/src/app/[location]/map/MapDashboard.tsx
@@ -2,8 +2,8 @@
 
 import { useCallback, useState } from "react";
 import dynamic from "next/dynamic";
-import Link from "next/link";
 import { Header } from "@/components/layout/Header";
+import { Breadcrumb } from "@/components/layout/Breadcrumb";
 import { MapSkeleton } from "@/components/weather/map/MapSkeleton";
 import { WeatherLayerPanel } from "@/components/weather/map/WeatherLayerPanel";
 import { DEFAULT_LAYER } from "@/lib/map-layers";
@@ -32,6 +32,15 @@ export function MapDashboard({ location }: MapDashboardProps) {
     <div className="flex h-[100dvh] flex-col">
       <Header />
 
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: location.name, href: `/${location.slug}` },
+          { label: "Map" },
+        ]}
+        className="pb-3"
+      />
+
       {/* Full-viewport map with overlaid controls */}
       <main
         id="main-content"
@@ -49,18 +58,6 @@ export function MapDashboard({ location }: MapDashboardProps) {
           weatherLayer={activeLayer}
           className="h-full w-full"
         />
-
-        {/* Top-left overlay: location name + back link */}
-        <div className="pointer-events-none absolute left-3 top-3 z-10 flex flex-col gap-1.5">
-          <div className="pointer-events-auto">
-            <Link
-              href={`/${location.slug}`}
-              className="inline-flex items-center gap-1.5 rounded-full border border-primary/10 bg-surface-card/90 px-3 py-1.5 text-sm font-medium text-text-secondary shadow backdrop-blur-sm transition-colors hover:bg-surface-card hover:text-text-primary"
-            >
-              ← Back to weather
-            </Link>
-          </div>
-        </div>
 
         {/* Bottom-right overlay: weather layer panel. The map's attribution
             control is pinned bottom-left (see MapLibreMap) so the two never

--- a/src/components/layout/Breadcrumb.test.ts
+++ b/src/components/layout/Breadcrumb.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const source = readFileSync(resolve(__dirname, "Breadcrumb.tsx"), "utf-8");
+
+/**
+ * Breadcrumb — shared trail for location sub-routes (atmosphere, forecast,
+ * map). Centralizes the Home / Location / Current-page pattern previously
+ * hand-rolled separately in each sub-route dashboard.
+ */
+
+describe("Breadcrumb structure", () => {
+  it("exports Breadcrumb", () => {
+    expect(source).toContain("export function Breadcrumb");
+  });
+
+  it("uses a nav with aria-label=Breadcrumb", () => {
+    expect(source).toContain('aria-label="Breadcrumb"');
+  });
+
+  it("marks the current page with aria-current and no link", () => {
+    expect(source).toContain('aria-current={item.href ? undefined : "page"}');
+  });
+
+  it("hides separators from assistive tech", () => {
+    expect(source).toContain('aria-hidden="true"');
+  });
+
+  it("uses global styles only — no hardcoded colors", () => {
+    expect(source).not.toMatch(/#[0-9a-fA-F]{3,8}[^)]/);
+    expect(source).not.toContain("style={{");
+  });
+});
+
+describe("Breadcrumb usage sites", () => {
+  const usageFiles = [
+    "../../app/[location]/atmosphere/AtmosphereDashboard.tsx",
+    "../../app/[location]/forecast/ForecastDashboard.tsx",
+    "../../app/[location]/map/MapDashboard.tsx",
+  ];
+
+  it("is imported by all three location sub-route dashboards", () => {
+    for (const file of usageFiles) {
+      const dashboardSource = readFileSync(resolve(__dirname, file), "utf-8");
+      expect(dashboardSource).toContain("@/components/layout/Breadcrumb");
+      expect(dashboardSource).toContain("<Breadcrumb");
+    }
+  });
+
+  it("MapDashboard no longer renders a floating back-to-weather pill", () => {
+    const mapSource = readFileSync(
+      resolve(__dirname, "../../app/[location]/map/MapDashboard.tsx"),
+      "utf-8"
+    );
+    expect(mapSource).not.toContain("Back to weather");
+  });
+});

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -1,0 +1,49 @@
+import { Fragment } from "react";
+import Link from "next/link";
+
+export interface BreadcrumbItem {
+  label: string;
+  /** Omit for the current page — rendered as plain text with aria-current="page" */
+  href?: string;
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+/**
+ * Shared breadcrumb trail for location sub-routes (atmosphere, forecast,
+ * map). Centralizes the Home / Location / Current-page pattern previously
+ * hand-rolled separately in each sub-route dashboard.
+ */
+export function Breadcrumb({ items, className }: BreadcrumbProps) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={["mx-auto max-w-5xl px-4 pt-4 sm:px-6 md:px-8", className]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <ol className="flex items-center gap-1 text-base text-text-tertiary">
+        {items.map((item, i) => (
+          <Fragment key={item.label}>
+            {i > 0 && <li aria-hidden="true">/</li>}
+            <li aria-current={item.href ? undefined : "page"}>
+              {item.href ? (
+                <Link
+                  href={item.href}
+                  className="hover:text-text-secondary transition-colors focus-visible:outline-2 focus-visible:outline-primary focus-visible:rounded"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <span className="font-medium text-text-primary">{item.label}</span>
+              )}
+            </li>
+          </Fragment>
+        ))}
+      </ol>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- `AtmosphereDashboard.tsx` and `ForecastDashboard.tsx` each hand-rolled an identical `Home / Location / Current-page` breadcrumb nav, while `MapDashboard.tsx` used a different pattern entirely — a floating `← Back to weather` pill overlaid on the map. Three sub-routes, two different back-navigation UIs.
- Extracted `src/components/layout/Breadcrumb.tsx` — takes a list of `{ label, href? }` items, renders the trail with `aria-current="page"` on the current (href-less) item.
- Wired it into all three sub-route dashboards. `MapDashboard` now renders the same breadcrumb bar above its full-viewport map instead of the floating pill (the pill is fully removed).
- Added `src/components/layout/Breadcrumb.test.ts`.
- Updated CLAUDE.md to document the shared component and the routing consistency.

## Test plan
- [x] `npm test` — 2007 tests passing (89 files)
- [x] `npm run lint` — 0 errors (15 pre-existing warnings, unchanged)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW


---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_