### PR TITLE
Consolidate duplicated location-search query into one helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,7 +548,7 @@ All data handling, AI operations, database CRUD, and rule evaluation run in Pyth
 - `/api/py/ai/followup` — POST, inline follow-up chat for AI summaries. Pre-seeded with the AI summary as conversation context. Max 5 exchanges then redirects to Shamwari. Rate-limited 30 req/hour/IP
 - `/api/py/ai/prompts` — GET, database-driven AI prompt library. Returns system prompts and suggested prompt rules
 - `/api/py/ai/suggested-rules` — GET, dynamic suggested prompt rules for contextual prompts
-- `/api/py/search` — GET, location search (text search, tag filter, geospatial nearest, pagination)
+- `/api/py/search` — GET, location search (text search, tag filter, geospatial nearest, pagination). Text search delegates to `search_locations_by_name()` in `api/py/_places_resolver.py` — the same helper the Shamwari chat tool's `search_locations` uses, so the two can't drift apart
 - `/api/py/geo` — GET, nearest location lookup (query: `lat`, `lon`, optional `autoCreate=true` for auto-creating community locations)
 - `/api/py/locations` — GET, list/filter locations from MongoDB (by slug, tag, or all; includes stats mode)
 - `/api/py/locations/add` — POST, add locations via search (`{ query }`) or coordinates (`{ lat, lon }`). Rate-limited to 5 creations/hour/IP

--- a/api/py/_chat.py
+++ b/api/py/_chat.py
@@ -42,6 +42,7 @@ from ._places_resolver import (
     find_location,
     find_locations_by_tag,
     count_all_locations,
+    search_locations_by_name,
 )
 from ._circuit_breaker import anthropic_breaker, CircuitOpenError
 
@@ -232,24 +233,11 @@ TOOLS = [
 
 
 def _execute_search_locations(query: str) -> dict:
-    """Search placesGeo by name/slug via case-insensitive regex (Phase 0G).
-
-    Atlas Search and ``$text`` indexes lived on ``weather.locations``, which
-    is being dropped. Until equivalent indexes are provisioned on
-    ``places.placesGeo``, we fall back to a regex name match scoped to
-    cities/towns/villages.
-    """
-    q = query.strip()[:200]
-    if not q:
-        return {"locations": [], "total": 0}
-
-    from ._db import places_geo_collection
-    from ._places_resolver import adapt_placesgeo_to_location
-
-    def _format(docs: list) -> dict:
-        adapted = [
-            adapt_placesgeo_to_location(d) for d in docs
-        ]
+    """Search placesGeo by name/slug via the shared regex search helper —
+    same query shape as GET /api/py/search's text-search branch, so the
+    two can't silently drift apart."""
+    try:
+        adapted = search_locations_by_name(query, limit=10)
         return {
             "locations": [
                 {
@@ -259,29 +247,10 @@ def _execute_search_locations(query: str) -> dict:
                     "tags": r.get("tags", []),
                 }
                 for r in adapted
-                if r and r.get("slug")
+                if r.get("slug")
             ],
             "total": len(adapted),
         }
-
-    try:
-        regex = {"$regex": re.escape(q), "$options": "i"}
-        # Search name + mukokoSlug + platform slug; scope to consumer-facing
-        # geoTypes so we never return a country/province as a "location".
-        results = list(
-            places_geo_collection()
-            .find({
-                "geoType": {"$in": ["city", "town", "village"]},
-                "$or": [
-                    {"name": regex},
-                    {"slug": regex},
-                    {"sourceProvenance.mukokoSlug": regex},
-                ],
-            })
-            .limit(10)
-            .max_time_ms(3000)
-        )
-        return _format(results)
     except Exception:
         return {"locations": [], "total": 0, "error": "Search unavailable"}
 

--- a/api/py/_locations.py
+++ b/api/py/_locations.py
@@ -30,6 +30,7 @@ from ._places_resolver import (
     find_locations_by_tag,
     find_locations_in_country,
     find_nearest_location,
+    search_locations_by_name,
 )
 from ._places_geo import (
     find_nearby_placesgeo,
@@ -233,34 +234,7 @@ async def search_locations(
             for r in results:
                 r.pop("_id", None)
         elif q:
-            q_clean = q.strip()[:200]
-            regex = {"$regex": re.escape(q_clean), "$options": "i"}
-            query_filter = {
-                "geoType": {"$in": ["city", "town", "village"]},
-                "$or": [
-                    {"name": regex},
-                    {"slug": regex},
-                    {"sourceProvenance.mukokoSlug": regex},
-                ],
-            }
-            if tag:
-                query_filter["sourceProvenance.mukokoTags"] = tag
-            try:
-                docs = list(
-                    places_geo_collection().find(query_filter)
-                    .sort([("name", 1)])
-                    .skip(skip)
-                    .limit(limit)
-                    .max_time_ms(3000)
-                )
-            except Exception:
-                docs = []
-            for doc in docs:
-                adapted = adapt_placesgeo_to_location(doc)
-                if not adapted:
-                    continue
-                adapted.pop("_id", None)
-                results.append(adapted)
+            results = search_locations_by_name(q, limit=limit, skip=skip, tag=tag)
 
         # If text search returned no results, fall back to Open-Meteo
         # geocoding API for address-level discovery (like Apple/Google Weather).

--- a/api/py/_places_resolver.py
+++ b/api/py/_places_resolver.py
@@ -420,3 +420,57 @@ def find_nearest_location(
     except Exception as exc:  # noqa: BLE001
         logger.debug("placesGeo nearest query failed: %s", exc)
         return None
+
+
+def search_locations_by_name(
+    query: str,
+    *,
+    limit: int = 10,
+    skip: int = 0,
+    tag: Optional[str] = None,
+) -> list[dict]:
+    """Case-insensitive regex search across placesGeo name/slug/mukokoSlug,
+    scoped to consumer-facing geoTypes (city/town/village).
+
+    Shared by GET /api/py/search's text-search branch and the Shamwari chat
+    tool's search_locations, so the query shape can't drift between the two.
+    Atlas Search and $text indexes lived on weather.locations, which is
+    dropped — until equivalent indexes are provisioned on places.placesGeo,
+    this regex match is the interim text-search implementation.
+    """
+    q = query.strip()[:200]
+    if not q:
+        return []
+
+    regex = {"$regex": re.escape(q), "$options": "i"}
+    query_filter: dict = {
+        "geoType": {"$in": ["city", "town", "village"]},
+        "$or": [
+            {"name": regex},
+            {"slug": regex},
+            {"sourceProvenance.mukokoSlug": regex},
+        ],
+    }
+    if tag:
+        query_filter["sourceProvenance.mukokoTags"] = tag
+
+    try:
+        docs = list(
+            places_geo_collection()
+            .find(query_filter)
+            .sort([("name", 1)])
+            .skip(skip)
+            .limit(limit)
+            .max_time_ms(3000)
+        )
+    except Exception:
+        return []
+
+    results = []
+    for doc in docs:
+        adapted = adapt_placesgeo_to_location(doc)
+        if not adapted:
+            continue
+        adapted.pop("_id", None)
+        results.append(adapted)
+    return results

--- a/tests/py/test_chat.py
+++ b/tests/py/test_chat.py
@@ -189,6 +189,19 @@ class TestSearchLocations:
         result = _execute_search_locations("   ")
         assert result["total"] == 0
 
+    @patch("py._chat.search_locations_by_name")
+    def test_delegates_to_shared_search_helper(self, mock_search):
+        """Uses the same search_locations_by_name (py._places_resolver) as
+        GET /api/py/search's text-search branch, so the query shape can't
+        drift between the chat tool and the public search endpoint."""
+        mock_search.return_value = [
+            {"slug": "harare", "name": "Harare", "province": "Harare", "tags": ["city"]},
+        ]
+        result = _execute_search_locations("harare")
+        mock_search.assert_called_once_with("harare", limit=10)
+        assert result["total"] == 1
+        assert result["locations"][0]["slug"] == "harare"
+
 
 # ---------------------------------------------------------------------------
 # Tool: get_weather (slug validation)

--- a/tests/py/test_locations.py
+++ b/tests/py/test_locations.py
@@ -32,6 +32,7 @@ from py._locations import (
     SLUG_RE,
     DEDUP_RADIUS_KM,
 )
+from py._places_resolver import search_locations_by_name
 
 
 # ---------------------------------------------------------------------------
@@ -568,9 +569,11 @@ class TestSearchLocations:
     """Phase 0G: search queries placesGeo (regex on name/slug + mukokoSlug)."""
 
     @pytest.mark.asyncio
-    @patch("py._locations.places_geo_collection")
+    @patch("py._places_resolver.places_geo_collection")
     async def test_text_search(self, mock_coll):
-        # placesGeo doc shape — adapter converts to legacy LocationDoc shape
+        # placesGeo doc shape — adapter converts to legacy LocationDoc shape.
+        # Query now runs inside search_locations_by_name (py._places_resolver),
+        # shared with the Shamwari chat tool's search_locations.
         placesgeo_doc = {
             "_id": "uuid-harare",
             "name": "Harare",
@@ -633,6 +636,44 @@ class TestSearchLocations:
         ]
         result = await search_locations(mode="tags")
         assert "tags" in result
+
+
+class TestSearchLocationsByName:
+    """search_locations_by_name (py._places_resolver) — shared regex search
+    used by both GET /api/py/search's text-search branch and the Shamwari
+    chat tool's search_locations, so their query shape can't drift apart."""
+
+    def test_empty_query_returns_empty_without_querying_db(self):
+        assert search_locations_by_name("") == []
+        assert search_locations_by_name("   ") == []
+
+    @patch("py._places_resolver.places_geo_collection")
+    def test_scopes_to_consumer_facing_geo_types(self, mock_coll):
+        mock_cursor = MagicMock()
+        mock_cursor.sort.return_value.skip.return_value.limit.return_value.max_time_ms.return_value = []
+        mock_coll.return_value.find.return_value = mock_cursor
+
+        search_locations_by_name("harare")
+
+        query_filter = mock_coll.return_value.find.call_args[0][0]
+        assert query_filter["geoType"] == {"$in": ["city", "town", "village"]}
+        assert {"name": {"$regex": "harare", "$options": "i"}} in query_filter["$or"]
+
+    @patch("py._places_resolver.places_geo_collection")
+    def test_tag_filter_is_optional(self, mock_coll):
+        mock_cursor = MagicMock()
+        mock_cursor.sort.return_value.skip.return_value.limit.return_value.max_time_ms.return_value = []
+        mock_coll.return_value.find.return_value = mock_cursor
+
+        search_locations_by_name("harare", tag="farming")
+
+        query_filter = mock_coll.return_value.find.call_args[0][0]
+        assert query_filter["sourceProvenance.mukokoTags"] == "farming"
+
+    @patch("py._places_resolver.places_geo_collection")
+    def test_db_error_returns_empty(self, mock_coll):
+        mock_coll.return_value.find.side_effect = RuntimeError("boom")
+        assert search_locations_by_name("harare") == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Found via a follow-up codebase-wide audit for duplicate/parallel implementations (the "reuse, don't rebuild" pass).

`_chat.py`'s `search_locations` tool (used by the Shamwari chatbot) and `GET /api/py/search`'s text-search branch each independently built the exact same MongoDB regex query — same `geoType` scope (`city`/`town`/`village`), same `$or` over `name`/`slug`/`mukokoSlug`, same escaping — just copy-pasted between the two files.

Extracted `search_locations_by_name()` into `api/py/_places_resolver.py` (the module that already owns the other canonical location-lookup helpers — `find_location`, `find_nearest_location`, etc.) and had both call sites delegate to it, so the query shape can't silently drift between the chatbot and the public search endpoint.

## Changes
- `api/py/_places_resolver.py`: new `search_locations_by_name(query, *, limit, skip, tag)` helper.
- `api/py/_locations.py`: `search_locations`'s text-search branch now calls the shared helper instead of hand-rolling the query.
- `api/py/_chat.py`: `_execute_search_locations` now calls the shared helper instead of hand-rolling the query.
- Updated `test_locations.py`'s `test_text_search` to mock the query at its new location; added `TestSearchLocationsByName` covering the shared helper directly (geo-type scoping, tag filter, DB-error fallback).
- Added a test to `test_chat.py` asserting the chat tool delegates to the shared helper.

## Test plan
- [x] `python -m pytest tests/py/` — 946 tests passing
- [x] `npm run lint` — 0 errors (15 pre-existing warnings, unchanged)
- [x] `npx tsc --noEmit` — clean

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW


---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_