### PR TITLE
Consolidate duplicated validation constants; remove dead search helper

### DIFF
--- a/api/py/_ai_followup.py
+++ b/api/py/_ai_followup.py
@@ -24,6 +24,8 @@ from ._db import (
     get_api_key,
     ai_prompts_collection,
     filter_known_activities,
+    MAX_HISTORY,
+    MAX_MESSAGE_LEN,
 )
 from ._circuit_breaker import anthropic_breaker, CircuitOpenError
 
@@ -33,8 +35,6 @@ router = APIRouter()
 # Constants
 # ---------------------------------------------------------------------------
 
-MAX_HISTORY = 10
-MAX_MESSAGE_LEN = 2000
 MAX_MESSAGES_PER_CONVERSATION = 5
 RATE_LIMIT_MAX = 30
 RATE_LIMIT_WINDOW = 3600  # 1 hour

--- a/api/py/_chat.py
+++ b/api/py/_chat.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
@@ -36,6 +35,9 @@ from ._db import (
     activities_collection,
     suitability_rules_collection,
     ai_prompts_collection,
+    SLUG_RE,
+    MAX_HISTORY,
+    MAX_MESSAGE_LEN,
 )
 from ._places_resolver import (
     find_all_locations,
@@ -52,9 +54,6 @@ router = APIRouter()
 # Constants
 # ---------------------------------------------------------------------------
 
-SLUG_RE = re.compile(r"^[a-z0-9-]{1,80}$")
-MAX_HISTORY = 10
-MAX_MESSAGE_LEN = 2000
 MAX_ACTIVITIES = 20  # user-selected activities from client
 MAX_TOOL_ITERATIONS = 5
 TOOL_TIMEOUT_S = 15  # applied to each tool execution via asyncio.wait_for

--- a/api/py/_db.py
+++ b/api/py/_db.py
@@ -17,6 +17,7 @@ will reject malformed writes. Use ``stamp_platform_fields()`` to add these.
 from __future__ import annotations
 
 import os
+import re
 import time as _time
 from datetime import datetime, timezone, timedelta
 from typing import Optional
@@ -27,6 +28,21 @@ from pymongo import MongoClient
 from pymongo.database import Database
 
 _client: Optional[MongoClient] = None
+
+# ---------------------------------------------------------------------------
+# Shared validation constants — single source so slug format and message/
+# history caps can't drift between endpoints.
+# ---------------------------------------------------------------------------
+
+#: Location slug format, shared by _chat.py, _devices.py, _explore_search.py,
+#: and _locations.py.
+SLUG_RE = re.compile(r"^[a-z0-9-]{1,80}$")
+
+#: Chat/follow-up message length cap, shared by _chat.py and _ai_followup.py.
+MAX_MESSAGE_LEN = 2000
+
+#: Conversation history length cap, shared by _chat.py and _ai_followup.py.
+MAX_HISTORY = 10
 
 
 # ---------------------------------------------------------------------------

--- a/api/py/_devices.py
+++ b/api/py/_devices.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 import uuid
 from datetime import datetime, timezone
 from typing import Optional
@@ -11,7 +10,12 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 from pymongo.errors import DuplicateKeyError
 
-from ._db import device_profiles_collection, get_client_ip, check_rate_limit
+from ._db import (
+    device_profiles_collection,
+    get_client_ip,
+    check_rate_limit,
+    SLUG_RE,
+)
 
 router = APIRouter()
 
@@ -30,7 +34,6 @@ VALID_FORECAST_MODELS = {
 }
 MAX_ACTIVITIES = 30
 MAX_SAVED_LOCATIONS = 10
-SLUG_RE = re.compile(r"^[a-z0-9-]{1,80}$")
 
 
 class Preferences(BaseModel):

--- a/api/py/_explore_search.py
+++ b/api/py/_explore_search.py
@@ -11,7 +11,6 @@ System prompt is fetched from the database (system:explore_search).
 from __future__ import annotations
 
 import os
-import re
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -26,6 +25,7 @@ from ._db import (
     get_api_key,
     weather_cache_collection,
     ai_prompts_collection,
+    SLUG_RE,
 )
 from ._places_resolver import find_all_locations
 from ._circuit_breaker import anthropic_breaker, CircuitOpenError
@@ -36,7 +36,6 @@ router = APIRouter()
 # Constants
 # ---------------------------------------------------------------------------
 
-SLUG_RE = re.compile(r"^[a-z0-9-]{1,80}$")
 RATE_LIMIT_MAX = 15
 RATE_LIMIT_WINDOW = 3600  # 1 hour
 MAX_QUERY_LEN = 500

--- a/api/py/_locations.py
+++ b/api/py/_locations.py
@@ -21,6 +21,7 @@ from ._db import (
     get_client_ip,
     places_geo_collection,
     check_rate_limit,
+    SLUG_RE,
 )
 from ._places_resolver import (
     adapt_placesgeo_to_location,
@@ -43,7 +44,6 @@ from ._places_geo import (
 
 router = APIRouter()
 
-SLUG_RE = re.compile(r"^[a-z0-9-]{1,80}$")
 _http_client: Optional[httpx.Client] = None
 
 # City-states where state/province fields are meaningless (postal codes or same as country).

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1046,11 +1046,6 @@ export async function findDuplicateLocation(
 // Search operations (Phase 0F — placesGeo-backed)
 // ---------------------------------------------------------------------------
 
-export interface SearchResult {
-  locations: LocationDoc[];
-  total: number;
-}
-
 /** Retained for backwards-compat with existing tests/imports. */
 const ATLAS_RETRY_AFTER_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -1066,39 +1061,6 @@ function isAtlasSearchIndexMissing(err: unknown): boolean {
     if (msg.includes("index not found")) return true;
   }
   return false;
-}
-
-/**
- * Search locations. Phase 0F: runs a name/regex search against the static
- * seed list and a normalised-name lookup against `places.placesGeo` for
- * user-created entries. Atlas Search on `weather.locations` is gone.
- */
-export async function searchLocationsFromDb(
-  query: string,
-  options: { tag?: string; limit?: number; skip?: number } = {},
-): Promise<SearchResult> {
-  const { tag, limit = 20, skip = 0 } = options;
-  const q = query.trim();
-  if (!q && !tag) return { locations: [], total: 0 };
-
-  const lowered = q.toLowerCase();
-  const seedMatches = LOCATIONS.filter((loc) => {
-    if (tag && !loc.tags.includes(tag)) return false;
-    if (!q) return true;
-    return (
-      loc.name.toLowerCase().includes(lowered) ||
-      loc.slug.includes(lowered) ||
-      loc.province.toLowerCase().includes(lowered)
-    );
-  });
-
-  const total = seedMatches.length;
-  const page = seedMatches.slice(skip, skip + limit);
-  const now = new Date();
-  return {
-    locations: page.map((loc) => ({ ...loc, updatedAt: now })) as LocationDoc[],
-    total,
-  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- `SLUG_RE` was defined verbatim in four Python modules (`_chat.py`, `_devices.py`, `_explore_search.py`, `_locations.py`); `MAX_MESSAGE_LEN`/`MAX_HISTORY` were duplicated in two (`_chat.py`, `_ai_followup.py`). All five now import these from a single source in `api/py/_db.py`, so slug format and message/history caps can't drift between endpoints.
- Removed `searchLocationsFromDb()` and its `SearchResult` interface from `src/lib/db.ts` — dead code with zero remaining callers now that location text search runs through `search_locations_by_name()` in the Python backend against `places.placesGeo`.

Both are small mechanical fixes from the ongoing parallel-implementation audit (validation-constants and dead-code findings).

## Test plan
- [x] `python -m pytest tests/py/ -v` — 947 passed
- [x] `npm test` — 1987 passed
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_