### PR TITLE
Harden location creation: shared sequence, consistent dedup radius, TOCTOU lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1719,7 +1719,8 @@ Mukoko-weather sits on the shared **Nyuchi Platform cluster** (27 databases). Mu
 **`placesGeo` writes (Phase 0E):** `places.placesGeo` has its OWN validator that does NOT include a `bundu` field — calling `stamp_platform_fields` on it would fail. Use `api/py/_places_geo.upsert_placesgeo_city()` instead. The helper:
 
 - Builds the doc manually (no `bundu`), uses `_schemaVersion: "v3.2"`, and stamps `sourceProvenance.dataOrigin: "mukoko_user"`.
-- **Always dedupes first** via `find_nearby_placesgeo` — 5 km radius, normalised-name match (strips diacritics, road-type suffixes, leading house numbers), scoped by `parentPlaceId` (country \_id). If a match is found, the existing doc is returned with `wasExisting: True` — **no auto-suffixed slug is ever generated**.
+- **Always dedupes first** via `find_nearby_placesgeo` — `dedup_radius_km` radius (default 5 km; the mukoko location-creation flow passes its own 1 km duplicate-gate radius so the two checks can't disagree and alias a new fine-grained place onto a different same-named doc a few km away), normalised-name match (strips diacritics, road-type suffixes, leading house numbers), scoped by `parentPlaceId` (country \_id). If a match is found, the existing doc is returned with `wasExisting: True` — **no auto-suffixed slug is ever generated**.
+- **TOCTOU guard:** the dedup read + insert run under a short cross-instance creation lock (`weather.creation_locks`, `_id` = `placesgeo:{country}:{normalised name}`, 30s stale-steal) so two near-simultaneous requests for the same brand-new place can't both slip past the dedup read and double-insert.
 - Slugs are `<slugified-name>-<6-char hex>` (e.g. `harare-a1b2c3`). Suffixing with `-2`, `-3`, … is forbidden — slug collisions in `weather.locations` now raise `SlugCollisionError` and surface the existing record as a `mode: "duplicate"` response.
 
 **Fundi search-miss queue (Phase 0E — disabled in Phase 0F):** Previously mukoko ALSO enqueued a POI seed request via `_places_geo.enqueue_fundi_seed()` so the Fundi worker would populate `places.places`. Phase 0F removes this call — POI enrichment is a separate optional concern and is not P0 for mukoko-weather. Re-enable behind a flag like `MUKOKO_ENRICH_POIS_VIA_FUNDI` once the POI surface is actually consumed.
@@ -1760,9 +1761,9 @@ Resolution chain for `/harare`:
 
 `src/lib/db.ts → getLocationFromDb(slug)` now delegates straight to `resolveLocationSlug` and packages the response as a `LocationDoc`, so every existing caller (`src/app/[location]/*` server components, sitemap, etc.) keeps working with no changes.
 
-**Create-on-demand:** When a user lands on `/<unknown-slug>` AND the request has lat/lon (IP geo header or GPS), `POST /api/py/locations/add` runs `_reverse_geocode → upsert_placesgeo_city(...)` (Phase 0E helper) which:
+**Create-on-demand:** When a user lands on `/<unknown-slug>` AND the request has lat/lon (IP geo header or GPS), `POST /api/py/locations/add` runs the shared `_create_location_from_coords()` helper (`api/py/_locations.py` — the single reverse-geocode → POI check → dedupe → slug/elevation/province → placesGeo-upsert sequence also used by `GET /api/py/geo?autoCreate=true`, so the two creation paths can't drift), which calls `upsert_placesgeo_city(...)` (Phase 0E helper). The upsert:
 
-- Dedupes via `find_nearby_placesgeo` (5 km radius, normalised-name match, country-scoped) and patches the existing doc with the new `mukokoSlug` / `mukokoTags` / `mukokoNominatimAddress` when it finds one
+- Dedupes via `find_nearby_placesgeo` (1 km radius — the same `DEDUP_RADIUS_KM` as the caller's duplicate gate — normalised-name match, country-scoped) and patches the existing doc with the new `mukokoSlug` / `mukokoTags` / `mukokoNominatimAddress` when it finds one
 - Otherwise inserts a fresh placesGeo doc with `sourceProvenance.dataOrigin: "mukoko_user"` plus the mukoko-side metadata stamped into `sourceProvenance.mukoko*`
 - Returns `{ placesGeoId, placesGeoSlug, location }` so the caller can redirect
 

--- a/api/py/_locations.py
+++ b/api/py/_locations.py
@@ -839,8 +839,10 @@ def _enrich_location_with_ai(country_code: str, lat: float, lon: float) -> None:
     """
     import threading
 
-    # Country code only — user coordinates are private and must not be logged.
-    logger.info("Starting AI location enrichment for %s", country_code)
+    # Deliberately log no request-derived values: everything here (country,
+    # coords, name) traces back to the user's GPS position, which must not
+    # land in logs (CodeQL: clear-text logging of private data).
+    logger.info("Starting AI location enrichment")
 
     def _run() -> None:
         try:

--- a/api/py/_locations.py
+++ b/api/py/_locations.py
@@ -701,10 +701,9 @@ def _create_location_from_coords(lat: float, lon: float, *, source: str) -> dict
         places_geo_id = placesgeo_doc.get("_id")
         places_geo_slug = placesgeo_doc.get("slug")
         if not placesgeo_doc.get("wasExisting"):
-            logger.info(
-                "Created placesGeo entry %s for %s (%s)",
-                places_geo_id, geocoded["name"], source,
-            )
+            # Log only the opaque UUID — the reverse-geocoded name at zoom 18
+            # can be a user's street address, which must not land in logs.
+            logger.info("Created placesGeo entry %s (%s)", places_geo_id, source)
     except Exception as exc:  # noqa: BLE001
         logger.warning("Platform placesGeo write failed (%s): %s", source, exc)
 
@@ -840,7 +839,8 @@ def _enrich_location_with_ai(country_code: str, lat: float, lon: float) -> None:
     """
     import threading
 
-    logger.info("Starting AI location enrichment for %s (%.1f, %.1f)", country_code, lat, lon)
+    # Country code only — user coordinates are private and must not be logged.
+    logger.info("Starting AI location enrichment for %s", country_code)
 
     def _run() -> None:
         try:

--- a/api/py/_locations.py
+++ b/api/py/_locations.py
@@ -31,6 +31,7 @@ from ._places_resolver import (
     find_locations_by_tag,
     find_locations_in_country,
     find_nearest_location,
+    find_nearest_locations,
     search_locations_by_name,
 )
 from ._places_geo import (
@@ -191,31 +192,13 @@ async def search_locations(
             tags_agg = list(places_geo_collection().aggregate(pipeline))
             return {"tags": {t["_id"]: t["count"] for t in tags_agg}}
 
-        # Geospatial nearest (Phase 0G: placesGeo via $nearSphere).
+        # Geospatial nearest — canonical proximity query in _places_resolver.
+        # 100km radius: wider than the 50km default since search-by-coords is
+        # an explicit discovery action, not an accuracy-sensitive geo lookup.
         if lat and lon:
-            lat_f = float(lat)
-            lon_f = float(lon)
-            try:
-                docs = list(
-                    places_geo_collection().find({
-                        "geoType": {"$in": ["city", "town", "village"]},
-                        "geo": {
-                            "$nearSphere": {
-                                "$geometry": {"type": "Point", "coordinates": [lon_f, lat_f]},
-                                "$maxDistance": 100000,  # 100km
-                            }
-                        },
-                    }).limit(limit)
-                )
-            except Exception:
-                docs = []
-            results = []
-            for doc in docs:
-                adapted = adapt_placesgeo_to_location(doc)
-                if not adapted:
-                    continue
-                adapted.pop("_id", None)
-                results.append(adapted)
+            results = find_nearest_locations(float(lat), float(lon), limit=limit, max_km=100)
+            for r in results:
+                r.pop("_id", None)
             return {"locations": results, "total": len(results), "source": "mongodb"}
 
         # Text search
@@ -632,6 +615,127 @@ def _match_nearby_poi(lat: float, lon: float) -> dict | None:
     return {"name": name, "poiType": poi_type_from_place(poi)}
 
 
+def _create_location_from_coords(lat: float, lon: float, *, source: str) -> dict:
+    """Shared location-creation sequence for coordinates.
+
+    The single implementation behind both GET /api/py/geo?autoCreate=true and
+    POST /api/py/locations/add's coordinates mode: reverse-geocode (zoom 18) →
+    POI context → duplicate gate → slug/elevation/province resolution →
+    placesGeo upsert → AI season enrichment. The two route handlers only
+    differ in response shape and ``source`` tag, so any change to the create
+    flow lands in both paths by construction.
+
+    Returns one of:
+      * ``{"status": "created", "location": {...}, "placesGeoId": ...,
+        "placesGeoSlug": ...}``
+      * ``{"status": "duplicate", "existing": {...}}`` — an adapted location
+        doc (always slug-bearing) for the already-existing place.
+
+    Raises ``HTTPException(422)`` when reverse geocoding can't name the spot
+    and ``HTTPException(409)`` when a slug collision can't be resolved.
+    """
+    geocoded = _reverse_geocode(lat, lon, zoom=18)
+    if not geocoded:
+        raise HTTPException(status_code=422, detail="Could not determine location name")
+
+    # POI context — nearby named POI (≤250 m) as metadata only. These are
+    # passive coordinates, not a search-and-pick flow, so a nearby POI's name
+    # must never replace the reverse-geocoded road/address — only its
+    # `poiType` (school/hospital/market/park) is surfaced as context.
+    poi_match = _match_nearby_poi(lat, lon)
+    poi_type = poi_match.get("poiType") if poi_match else None
+
+    # Tight duplicate gate (1km + same-name, country-scoped). A match without
+    # a slug is NOT returned as a duplicate — creation proceeds and the
+    # placesGeo upsert below patches the mukoko slug onto that existing doc,
+    # which is what makes it resolvable in the first place.
+    duplicate = _find_duplicate(
+        lat, lon, DEDUP_RADIUS_KM,
+        name=geocoded["name"], country=geocoded["country"],
+    )
+    if duplicate and duplicate.get("slug"):
+        return {"status": "duplicate", "existing": duplicate}
+
+    elevation = geocoded.get("elevation", 0) or 0
+    if not elevation:
+        elevation = _get_elevation(lat, lon)
+
+    slug = _generate_slug(geocoded["name"], geocoded["country"])
+    try:
+        slug = _resolve_slug_collision(slug, geocoded)
+    except SlugCollisionError as exc:
+        # Same place — surface the existing record instead of creating a
+        # numeric-suffixed duplicate (Phase 0G: resolved via placesGeo).
+        existing = find_location(exc.existing_slug)
+        if existing:
+            return {"status": "duplicate", "existing": existing}
+        # Existing record disappeared between checks — extremely unlikely.
+        raise HTTPException(status_code=409, detail="Slug collision could not be resolved")
+
+    province = geocoded.get("admin1") or geocoded.get("countryName", "")
+    province_slug = _generate_province_slug(province, geocoded["country"])
+    tags = _infer_tags(geocoded)
+
+    # Phase 0G: write only to placesGeo — the canonical store; the resolver
+    # bridges clean URL slugs back to it. The upsert dedups with the SAME
+    # radius as the duplicate gate above (dedup_radius_km=DEDUP_RADIUS_KM) so
+    # the two checks can't disagree — a wider internal radius used to alias a
+    # new fine-grained place onto a different same-named doc a few km away.
+    places_geo_id: Optional[str] = None
+    places_geo_slug: Optional[str] = None
+    try:
+        placesgeo_doc = upsert_placesgeo_city(
+            name=geocoded["name"],
+            lat=lat,
+            lon=lon,
+            country_iso=geocoded["country"],
+            province=province,
+            elevation=elevation,
+            geo_type="city" if "city" in tags else "town",
+            dedup_radius_km=DEDUP_RADIUS_KM,
+            mukoko_slug=slug,
+            mukoko_tags=tags,
+            mukoko_nominatim_address=geocoded.get("nominatimAddress"),
+            mukoko_poi_type=poi_type,
+        )
+        places_geo_id = placesgeo_doc.get("_id")
+        places_geo_slug = placesgeo_doc.get("slug")
+        if not placesgeo_doc.get("wasExisting"):
+            logger.info(
+                "Created placesGeo entry %s for %s (%s)",
+                places_geo_id, geocoded["name"], source,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Platform placesGeo write failed (%s): %s", source, exc)
+
+    new_loc = {
+        "slug": slug,
+        "name": geocoded["name"],
+        "province": province,
+        "lat": geocoded["lat"],
+        "lon": geocoded["lon"],
+        "elevation": round(elevation),
+        "tags": tags,
+        "country": geocoded["country"],
+        "source": source,
+        "provinceSlug": province_slug,
+        "geo": {"type": "Point", "coordinates": [geocoded["lon"], geocoded["lat"]]},
+        "nominatimAddress": geocoded.get("nominatimAddress", {}),
+    }
+    if poi_type:
+        new_loc["poiType"] = poi_type
+
+    # Enrich: resolve seasons for this country if not already known
+    _enrich_location_with_ai(geocoded["country"], lat, lon)
+
+    return {
+        "status": "created",
+        "location": new_loc,
+        "placesGeoId": places_geo_id,
+        "placesGeoSlug": places_geo_slug,
+    }
+
+
 @router.get("/api/py/geo")
 async def geo_lookup(
     lat: float,
@@ -681,119 +785,24 @@ async def geo_lookup(
                     "isNew": False,
                 }
 
-        # Auto-create if requested — only NOW do we call external APIs
+        # Auto-create if requested — only NOW do we call external APIs.
+        # The full reverse-geocode → dedupe → create sequence is shared with
+        # POST /api/py/locations/add via _create_location_from_coords; this
+        # handler only maps the result to the geo-lookup response shape.
         if autoCreate:
-            geocoded = _reverse_geocode(lat, lon, zoom=18)
-            if not geocoded:
-                raise HTTPException(
-                    status_code=422,
-                    detail="Could not determine location name",
-                )
-
-            # ── POI context — nearby named POI (≤250 m) as metadata only ─────
-            # This is GPS auto-detection, not a search-and-pick flow — the
-            # user did not choose this POI, so its name must never replace
-            # the reverse-geocoded road/address (that's what confusingly
-            # relabeled someone's street as "XYZ School" just because a
-            # school happened to be 200m away). We still surface `poiType`
-            # (school/hospital/market/park) as supplementary context for the
-            # location page + AI summary — just not as the location's name.
-            poi_match = _match_nearby_poi(lat, lon)
-            poi_type = poi_match.get("poiType") if poi_match else None
-
-            # ── Tight duplicate check against placesGeo (Phase 0G) ───────────
-            # ONLY a 1km same-name dedup. Anything wider would snap a specific
-            # road/shop/address to a same-named entry up to that distance away,
-            # re-introducing the coarse-snap bug this fix removes. Distinct
-            # nearby places each resolve to their own fine-grained entry; only
-            # the exact same spot (within 1km, same name) collapses to one.
-            duplicate = _find_duplicate(
-                lat, lon, DEDUP_RADIUS_KM,
-                name=geocoded["name"], country=geocoded["country"],
-            )
-            if duplicate and duplicate.get("slug"):
-                duplicate.pop("_id", None)
+            result = _create_location_from_coords(lat, lon, source="geolocation")
+            if result["status"] == "duplicate":
+                existing = result["existing"]
+                existing.pop("_id", None)
                 return {
-                    "nearest": duplicate,
-                    "redirectTo": f"/{duplicate['slug']}",
+                    "nearest": existing,
+                    "redirectTo": f"/{existing['slug']}",
                     "isNew": False,
                 }
-
-            elevation = geocoded.get("elevation", 0) or 0
-            if not elevation:
-                elevation = _get_elevation(lat, lon)
-
-            slug = _generate_slug(geocoded["name"], geocoded["country"])
-            province = geocoded.get("admin1") or geocoded.get("countryName", "")
-            province_slug = _generate_province_slug(province, geocoded["country"])
-
-            try:
-                slug = _resolve_slug_collision(slug, geocoded)
-            except SlugCollisionError as exc:
-                # Same place — surface the existing record instead of creating
-                # a numeric-suffixed duplicate (Phase 0G: queried via placesGeo).
-                existing = find_location(exc.existing_slug)
-                if existing:
-                    existing.pop("_id", None)
-                    return {
-                        "nearest": existing,
-                        "redirectTo": f"/{existing['slug']}",
-                        "isNew": False,
-                    }
-                # Existing record disappeared between checks — extremely unlikely.
-                raise HTTPException(
-                    status_code=409,
-                    detail="Slug collision could not be resolved",
-                )
-
-            tags = _infer_tags(geocoded)
-
-            # Phase 0G: write only to placesGeo. The legacy weather.locations
-            # collection is being dropped; placesGeo is the canonical store
-            # and the resolver bridges clean URL slugs back to it.
-            try:
-                placesgeo_doc = upsert_placesgeo_city(
-                    name=geocoded["name"],
-                    lat=lat,
-                    lon=lon,
-                    country_iso=geocoded["country"],
-                    province=province,
-                    elevation=elevation,
-                    geo_type="city" if "city" in tags else "town",
-                    mukoko_slug=slug,
-                    mukoko_tags=tags,
-                    mukoko_nominatim_address=geocoded.get("nominatimAddress"),
-                    mukoko_poi_type=poi_type,
-                )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "Platform placesGeo write failed (geo autoCreate): %s", exc,
-                )
-                placesgeo_doc = None
-
-            new_loc = {
-                "slug": slug,
-                "name": geocoded["name"],
-                "province": province,
-                "lat": geocoded["lat"],
-                "lon": geocoded["lon"],
-                "elevation": round(elevation),
-                "tags": tags,
-                "country": geocoded["country"],
-                "source": "geolocation",
-                "provinceSlug": province_slug,
-                "geo": {"type": "Point", "coordinates": [geocoded["lon"], geocoded["lat"]]},
-                "nominatimAddress": geocoded.get("nominatimAddress", {}),
-            }
-            if poi_type:
-                new_loc["poiType"] = poi_type
-
-            # Enrich: resolve seasons for this country if not already known
-            _enrich_location_with_ai(geocoded["country"], lat, lon)
-
+            new_loc = result["location"]
             return {
                 "nearest": new_loc,
-                "redirectTo": f"/{slug}",
+                "redirectTo": f"/{new_loc['slug']}",
                 "isNew": True,
             }
 
@@ -898,148 +907,44 @@ async def add_location(request: Request):
         if not rate["allowed"]:
             raise HTTPException(status_code=429, detail="Rate limit exceeded. Try again later.")
 
-        # Reverse geocode with POI-level zoom — user explicitly chose coords
-        geocoded = _reverse_geocode(lat, lon, zoom=18)
-        if not geocoded:
-            raise HTTPException(status_code=422, detail="Could not determine location name")
-
-        # POI context — nearby named POI (≤250 m) as metadata only. These are
-        # raw coordinates, not a search-and-pick flow, so a nearby POI's name
-        # must never replace the reverse-geocoded road/address — only its
-        # `poiType` (school/hospital/market/park) is surfaced as context.
-        poi_match = _match_nearby_poi(lat, lon)
-        poi_type = poi_match.get("poiType") if poi_match else None
-
-        # Duplicate check (1km radius + name/country match)
-        duplicate = _find_duplicate(
-            lat, lon, DEDUP_RADIUS_KM,
-            name=geocoded["name"], country=geocoded["country"],
-        )
-        if duplicate:
+        # Reverse-geocode → dedupe → create — shared with GET /api/py/geo's
+        # autoCreate path via _create_location_from_coords; this handler only
+        # maps the result to the add-location response shape.
+        result = _create_location_from_coords(lat, lon, source="community")
+        if result["status"] == "duplicate":
+            existing = result["existing"]
             return {
                 "mode": "duplicate",
                 "existing": {
-                    "slug": duplicate["slug"],
-                    "name": duplicate["name"],
-                    "province": duplicate.get("province", ""),
-                    "country": duplicate.get("country", ""),
+                    "slug": existing["slug"],
+                    "name": existing.get("name", ""),
+                    "province": existing.get("province", ""),
+                    "country": existing.get("country", ""),
                 },
-                "message": f"A location already exists nearby: {duplicate['name']}",
+                "message": (
+                    f"A location already exists nearby: "
+                    f"{existing.get('name', existing['slug'])}"
+                ),
             }
 
-        elevation = geocoded.get("elevation", 0) or 0
-        if not elevation:
-            elevation = _get_elevation(lat, lon)
-
-        slug = _generate_slug(geocoded["name"], geocoded["country"])
-
-        try:
-            slug = _resolve_slug_collision(slug, geocoded)
-        except SlugCollisionError as exc:
-            # All enrichment paths collide — same place. Return the existing
-            # record as a duplicate instead of creating a numeric-suffixed copy.
-            # Phase 0G: existing record resolved via places.placesGeo.
-            existing = find_location(exc.existing_slug)
-            if existing:
-                return {
-                    "mode": "duplicate",
-                    "existing": {
-                        "slug": existing["slug"],
-                        "name": existing.get("name", ""),
-                        "province": existing.get("province", ""),
-                        "country": existing.get("country", ""),
-                    },
-                    "message": (
-                        f"A location already exists nearby: "
-                        f"{existing.get('name', exc.existing_slug)}"
-                    ),
-                }
-            raise HTTPException(
-                status_code=409,
-                detail="Slug collision could not be resolved",
-            )
-
-        province = geocoded.get("admin1") or geocoded.get("countryName", "")
-        province_slug = _generate_province_slug(province, geocoded["country"])
-
-        tags = _infer_tags(geocoded)
-
-        # ── Platform integration — placesGeo write (Phase 0G) ────────────────
-        # Phase 0G: ``weather.locations``, ``weather.countries``, and
-        # ``weather.provinces`` are being dropped. ``places.placesGeo`` is
-        # now the canonical store — every read flows through the resolver
-        # and writes happen here exclusively. The Phase 0E helper performs
-        # its own 5 km parent-scoped dedup, returns the existing doc with
-        # ``wasExisting: True`` when it finds one, and patches mukokoSlug /
-        # mukokoTags / nominatimAddress onto pre-existing entries so the TS
-        # resolver can find them by clean URL slug.
-        #
-        # Fundi POI enrichment (``enqueue_fundi_seed``) stays disabled —
-        # see Phase 0F note above. Re-enable behind a flag like
-        # ``MUKOKO_ENRICH_POIS_VIA_FUNDI`` when the POI surface is wired up.
-        places_geo_id: Optional[str] = None
-        places_geo_slug: Optional[str] = None
-        try:
-            placesgeo_doc = upsert_placesgeo_city(
-                name=geocoded["name"],
-                lat=lat,
-                lon=lon,
-                country_iso=geocoded["country"],
-                province=province,
-                elevation=elevation,
-                geo_type="city" if "city" in tags else "town",
-                mukoko_slug=slug,
-                mukoko_tags=tags,
-                mukoko_nominatim_address=geocoded.get("nominatimAddress"),
-                mukoko_poi_type=poi_type,
-            )
-            places_geo_id = placesgeo_doc.get("_id")
-            places_geo_slug = placesgeo_doc.get("slug")
-            if not placesgeo_doc.get("wasExisting"):
-                logger.info(
-                    "Created placesGeo entry %s for %s",
-                    places_geo_id, geocoded["name"],
-                )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "Platform placesGeo write failed: %s", exc,
-            )
-
-        new_loc = {
-            "slug": slug,
-            "name": geocoded["name"],
-            "province": province,
-            "lat": geocoded["lat"],
-            "lon": geocoded["lon"],
-            "elevation": round(elevation),
-            "tags": tags,
-            "country": geocoded["country"],
-            "source": "community",
-            "provinceSlug": province_slug,
-            "geo": {"type": "Point", "coordinates": [geocoded["lon"], geocoded["lat"]]},
-            "nominatimAddress": geocoded.get("nominatimAddress", {}),
-        }
-
-        # Enrich: resolve seasons for this country if not already known
-        _enrich_location_with_ai(geocoded["country"], lat, lon)
-
+        new_loc = result["location"]
         location_payload = {
             "slug": new_loc["slug"],
             "name": new_loc["name"],
             "province": new_loc["province"],
-            "country": new_loc.get("country", geocoded["country"]),
+            "country": new_loc["country"],
             "lat": new_loc["lat"],
             "lon": new_loc["lon"],
             "elevation": new_loc["elevation"],
         }
-        if poi_type:
-            location_payload["poiType"] = poi_type
+        if new_loc.get("poiType"):
+            location_payload["poiType"] = new_loc["poiType"]
 
         return {
             "mode": "created",
             "location": location_payload,
-            "placesGeoId": places_geo_id,
-            "placesGeoSlug": places_geo_slug,
+            "placesGeoId": result["placesGeoId"],
+            "placesGeoSlug": result["placesGeoSlug"],
         }
     except HTTPException:
         raise

--- a/api/py/_places_geo.py
+++ b/api/py/_places_geo.py
@@ -20,12 +20,15 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 import unicodedata
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Optional
 
-from ._db import places_collection, places_db, places_geo_collection
+from pymongo.errors import DuplicateKeyError
+
+from ._db import places_collection, places_db, places_geo_collection, weather_db
 
 logger = logging.getLogger(__name__)
 
@@ -302,12 +305,64 @@ def find_nearest_place(
 # ---------------------------------------------------------------------------
 
 
-#: Dedup radius for placesGeo upserts. Cities/towns have wide footprints — OSM
-#: may put two centroids for the same place a few km apart, so we use a
-#: generous radius. The dedup is *also* gated on parent country + name match,
-#: which keeps unrelated places with the same name in different countries
-#: separate (e.g. two "Springfield"s).
+#: Default dedup radius for placesGeo upserts. Cities/towns have wide
+#: footprints — OSM may put two centroids for the same place a few km apart,
+#: so the default is generous. Callers creating FINE-GRAINED entries (roads,
+#: POIs, suburbs from zoom-18 reverse geocoding) must pass a tighter
+#: ``dedup_radius_km`` matching their own duplicate gate — otherwise two
+#: distinct same-named places a few km apart (e.g. "Westgate" suburb vs
+#: "Westgate Mall") alias onto one document. The dedup is *also* gated on
+#: parent country + name match, which keeps unrelated places with the same
+#: name in different countries separate (e.g. two "Springfield"s).
 PLACESGEO_DEDUP_RADIUS_KM: float = 5
+
+
+# ---------------------------------------------------------------------------
+# Cross-instance creation lock (TOCTOU guard)
+# ---------------------------------------------------------------------------
+
+#: How long a creation lock may be held before another instance may steal it.
+#: Creation (dedup read + insert) takes well under a second; 30s only matters
+#: when a holder crashed mid-create.
+CREATE_LOCK_TTL_S = 30
+
+
+def _acquire_create_lock(lock_id: str) -> bool:
+    """Best-effort cross-instance lock via ``_id`` uniqueness.
+
+    ``insert_one`` on a fixed ``_id`` is atomic on the primary, so exactly one
+    concurrent caller wins — no index setup or transactions needed. Returns
+    ``True`` when the lock was acquired (or the lock infrastructure is down,
+    in which case creation proceeds unlocked — a rare duplicate beats failing
+    the user's request). Returns ``False`` when another instance holds a
+    fresh lock for the same place.
+    """
+    now = datetime.now(timezone.utc)
+    try:
+        coll = weather_db()["creation_locks"]
+        coll.insert_one({"_id": lock_id, "createdAt": now})
+        return True
+    except DuplicateKeyError:
+        # Steal locks whose holder crashed mid-create.
+        try:
+            stale_cutoff = now - timedelta(seconds=CREATE_LOCK_TTL_S)
+            removed = coll.delete_one({"_id": lock_id, "createdAt": {"$lt": stale_cutoff}})
+            if removed.deleted_count:
+                coll.insert_one({"_id": lock_id, "createdAt": now})
+                return True
+        except Exception:  # noqa: BLE001
+            pass
+        return False
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("creation lock unavailable (%s); proceeding unlocked", exc)
+        return True
+
+
+def _release_create_lock(lock_id: str) -> None:
+    try:
+        weather_db()["creation_locks"].delete_one({"_id": lock_id})
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def upsert_placesgeo_city(
@@ -321,6 +376,7 @@ def upsert_placesgeo_city(
     geo_type: str = "town",
     data_origin: str = "mukoko_user",
     data_confidence: float = 0.6,
+    dedup_radius_km: float = PLACESGEO_DEDUP_RADIUS_KM,
     mukoko_slug: Optional[str] = None,
     mukoko_tags: Optional[list[str]] = None,
     mukoko_nominatim_address: Optional[dict] = None,
@@ -330,8 +386,13 @@ def upsert_placesgeo_city(
 
     Behaviour:
       1. **Always dedup first.** Calls :func:`find_nearby_placesgeo` with a
-         5 km radius, normalised-name match, and country-scoped
-         ``parentPlaceId`` filter.
+         ``dedup_radius_km`` radius (default 5 km — pass the caller's own
+         duplicate-gate radius so the two checks can't disagree), a
+         normalised-name match, and country-scoped ``parentPlaceId`` filter.
+         The dedup read + insert run under a short cross-instance creation
+         lock keyed by country + normalised name, so two near-simultaneous
+         requests for the same brand-new place can't both slip past the
+         dedup read and double-insert (TOCTOU).
       2. If a match is found, the existing document is returned with an
          added ``wasExisting: True`` marker. NO insert is performed and NO
          suffixed/alternate slug is generated — that would create the kind
@@ -352,11 +413,67 @@ def upsert_placesgeo_city(
     """
     parent_place_id = get_country_id(country_iso) if country_iso else None
 
+    # TOCTOU guard — serialize creation of the same place across instances so
+    # two near-simultaneous requests can't both pass the dedup read below and
+    # double-insert. The lock key is country + normalised name: over-broad
+    # (two same-named places far apart briefly serialize), never under-broad.
+    lock_id = f"placesgeo:{(country_iso or '').upper()}:{normalize_name(name)}"
+    got_lock = _acquire_create_lock(lock_id)
+    if not got_lock:
+        # Another instance is creating this place right now — give its insert
+        # a moment to land so the dedup read below finds it.
+        time.sleep(0.3)
+
+    try:
+        return _dedup_or_insert(
+            name=name,
+            lat=lat,
+            lon=lon,
+            country_iso=country_iso,
+            province=province,
+            elevation=elevation,
+            geo_type=geo_type,
+            data_origin=data_origin,
+            data_confidence=data_confidence,
+            dedup_radius_km=dedup_radius_km,
+            mukoko_slug=mukoko_slug,
+            mukoko_tags=mukoko_tags,
+            mukoko_nominatim_address=mukoko_nominatim_address,
+            mukoko_poi_type=mukoko_poi_type,
+            parent_place_id=parent_place_id,
+        )
+    finally:
+        if got_lock:
+            _release_create_lock(lock_id)
+
+
+def _dedup_or_insert(
+    *,
+    name: str,
+    lat: float,
+    lon: float,
+    country_iso: str,
+    province: Optional[str],
+    elevation: Optional[float],
+    geo_type: str,
+    data_origin: str,
+    data_confidence: float,
+    dedup_radius_km: float,
+    mukoko_slug: Optional[str],
+    mukoko_tags: Optional[list[str]],
+    mukoko_nominatim_address: Optional[dict],
+    mukoko_poi_type: Optional[str],
+    parent_place_id: Optional[str],
+) -> dict:
+    """The dedup-read + insert body of :func:`upsert_placesgeo_city`.
+
+    Runs under the creation lock acquired by the caller.
+    """
     # Dedup gate — no auto-suffixing, ever.
     existing = find_nearby_placesgeo(
         lat=lat,
         lon=lon,
-        max_distance_km=PLACESGEO_DEDUP_RADIUS_KM,
+        max_distance_km=dedup_radius_km,
         name=name,
         parent_place_id=parent_place_id,
     )

--- a/api/py/_places_resolver.py
+++ b/api/py/_places_resolver.py
@@ -393,19 +393,24 @@ def find_locations_in_country(iso: str, *, limit: int = 200) -> list[dict]:
         return []
 
 
-def find_nearest_location(
+def find_nearest_locations(
     lat: float,
     lon: float,
     *,
+    limit: int = 20,
     max_km: float = 50,
-) -> Optional[dict]:
-    """Return the nearest mukoko-discoverable placesGeo entry to (lat, lon).
+) -> list[dict]:
+    """Return the nearest mukoko-discoverable placesGeo entries to (lat, lon),
+    closest first.
 
-    Uses ``$nearSphere`` on the 2dsphere index. Returns ``None`` if
-    nothing is within ``max_km`` or the index is unavailable.
+    The canonical ``$nearSphere`` proximity query — GET /api/py/search's
+    geospatial branch and :func:`find_nearest_location` both route through
+    here so the query shape (geoType scoping, index use) can't drift between
+    callers. Returns ``[]`` if nothing is within ``max_km`` or the index is
+    unavailable.
     """
     try:
-        doc = places_geo_collection().find_one({
+        docs = places_geo_collection().find({
             "geoType": {"$in": ["city", "town", "village"]},
             "geo": {
                 "$nearSphere": {
@@ -413,13 +418,27 @@ def find_nearest_location(
                     "$maxDistance": max(0.0, max_km) * 1000,
                 }
             },
-        })
-        if not doc:
-            return None
-        return adapt_placesgeo_to_location(doc)
+        }).limit(max(1, limit))
+        results = []
+        for doc in docs:
+            adapted = adapt_placesgeo_to_location(doc)
+            if adapted:
+                results.append(adapted)
+        return results
     except Exception as exc:  # noqa: BLE001
         logger.debug("placesGeo nearest query failed: %s", exc)
-        return None
+        return []
+
+
+def find_nearest_location(
+    lat: float,
+    lon: float,
+    *,
+    max_km: float = 50,
+) -> Optional[dict]:
+    """Nearest single mukoko-discoverable placesGeo entry, or ``None``."""
+    results = find_nearest_locations(lat, lon, limit=1, max_km=max_km)
+    return results[0] if results else None
 
 
 def search_locations_by_name(

--- a/tests/py/test_locations.py
+++ b/tests/py/test_locations.py
@@ -32,7 +32,7 @@ from py._locations import (
     SLUG_RE,
     DEDUP_RADIUS_KM,
 )
-from py._places_resolver import search_locations_by_name
+from py._places_resolver import find_nearest_locations, search_locations_by_name
 
 
 # ---------------------------------------------------------------------------
@@ -595,23 +595,17 @@ class TestSearchLocations:
         assert "score" not in result["locations"][0]
 
     @pytest.mark.asyncio
-    @patch("py._locations.places_geo_collection")
-    async def test_geospatial_search(self, mock_coll):
-        placesgeo_doc = {
-            "_id": "uuid-harare",
-            "name": "Harare",
-            "slug": "harare-a1b2c3",
-            "geoType": "city",
-            "geo": {"type": "Point", "coordinates": [31.05, -17.83]},
-            "sourceProvenance": {"mukokoSlug": "harare", "mukokoTags": ["city"]},
-        }
-        mock_find = MagicMock()
-        mock_find.limit.return_value = [placesgeo_doc]
-        mock_coll.return_value.find.return_value = mock_find
+    @patch("py._locations.find_nearest_locations")
+    async def test_geospatial_search(self, mock_nearest):
+        """The geo branch delegates to the canonical resolver helper (100km)."""
+        mock_nearest.return_value = [
+            {"slug": "harare", "name": "Harare", "tags": ["city"]},
+        ]
 
         result = await search_locations(lat="-17.83", lon="31.05")
         assert result["source"] == "mongodb"
         assert len(result["locations"]) == 1
+        mock_nearest.assert_called_once_with(-17.83, 31.05, limit=20, max_km=100)
 
     @pytest.mark.asyncio
     @patch("py._locations.find_locations_by_tag")
@@ -674,6 +668,36 @@ class TestSearchLocationsByName:
     def test_db_error_returns_empty(self, mock_coll):
         mock_coll.return_value.find.side_effect = RuntimeError("boom")
         assert search_locations_by_name("harare") == []
+
+
+class TestFindNearestLocations:
+    """find_nearest_locations (py._places_resolver) — the canonical
+    $nearSphere proximity query shared by find_nearest_location and
+    GET /api/py/search's geospatial branch."""
+
+    @patch("py._places_resolver.places_geo_collection")
+    def test_scopes_to_consumer_facing_geo_types_and_radius(self, mock_coll):
+        mock_coll.return_value.find.return_value.limit.return_value = []
+        find_nearest_locations(-17.83, 31.05, limit=5, max_km=100)
+
+        query = mock_coll.return_value.find.call_args[0][0]
+        assert query["geoType"] == {"$in": ["city", "town", "village"]}
+        near = query["geo"]["$nearSphere"]
+        assert near["$geometry"]["coordinates"] == [31.05, -17.83]
+        assert near["$maxDistance"] == 100000
+        mock_coll.return_value.find.return_value.limit.assert_called_once_with(5)
+
+    @patch("py._places_resolver.places_geo_collection")
+    def test_db_error_returns_empty_list(self, mock_coll):
+        mock_coll.return_value.find.side_effect = RuntimeError("no index")
+        assert find_nearest_locations(0, 0) == []
+
+    @patch("py._places_resolver.find_nearest_locations")
+    def test_singular_delegates_to_plural(self, mock_plural):
+        from py._places_resolver import find_nearest_location as singular
+        mock_plural.return_value = [{"slug": "harare"}]
+        assert singular(-17.83, 31.05, max_km=150) == {"slug": "harare"}
+        mock_plural.assert_called_once_with(-17.83, 31.05, limit=1, max_km=150)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/py/test_places_geo.py
+++ b/tests/py/test_places_geo.py
@@ -20,6 +20,17 @@ def _reset_country_cache():
     pg._COUNTRY_CACHE_LOADED = False
 
 
+@pytest.fixture(autouse=True)
+def _mock_creation_lock_db():
+    """Give the creation-lock helpers a working mock DB by default.
+
+    Individual TOCTOU tests override this to exercise contention paths.
+    """
+    with patch("py._places_geo.weather_db") as mock_db:
+        mock_db.return_value.__getitem__.return_value = MagicMock()
+        yield mock_db
+
+
 # ---------------------------------------------------------------------------
 # get_country_id
 # ---------------------------------------------------------------------------
@@ -242,6 +253,18 @@ class TestUpsertPlacesGeoCity:
         pg.upsert_placesgeo_city(name="X", lat=0, lon=0, country_iso="ZW")
         kwargs = mock_dedup.call_args.kwargs
         assert kwargs["max_distance_km"] == 5
+
+    @patch("py._places_geo.find_nearby_placesgeo", return_value=None)
+    @patch("py._places_geo.get_country_id", return_value="zw-parent")
+    @patch("py._places_geo.places_geo_collection")
+    def test_dedup_radius_overridable_by_caller(self, mock_coll, _mock_parent, mock_dedup):
+        """Fine-grained creators pass their own duplicate-gate radius (issue #93)."""
+        pg.upsert_placesgeo_city(
+            name="Westgate Mall", lat=0, lon=0, country_iso="ZW",
+            dedup_radius_km=1,
+        )
+        kwargs = mock_dedup.call_args.kwargs
+        assert kwargs["max_distance_km"] == 1
 
     @patch("py._places_geo.find_nearby_placesgeo", return_value=None)
     @patch("py._places_geo.get_country_id", return_value="zw-parent")
@@ -509,3 +532,73 @@ class TestUpsertStampsPoiType:
         assert result["wasExisting"] is True
         patch_set = mock_coll.return_value.update_one.call_args.args[1]["$set"]
         assert patch_set["sourceProvenance.mukokoPoiType"] == "school"
+
+
+# ---------------------------------------------------------------------------
+# Creation lock (TOCTOU guard — issue #94)
+# ---------------------------------------------------------------------------
+
+
+class TestCreationLock:
+    def test_acquires_lock_on_clean_insert(self, _mock_creation_lock_db):
+        coll = _mock_creation_lock_db.return_value.__getitem__.return_value
+        assert pg._acquire_create_lock("placesgeo:ZW:harare") is True
+        coll.insert_one.assert_called_once()
+        assert coll.insert_one.call_args[0][0]["_id"] == "placesgeo:ZW:harare"
+
+    def test_contended_lock_returns_false(self, _mock_creation_lock_db):
+        from pymongo.errors import DuplicateKeyError as DKE
+        coll = _mock_creation_lock_db.return_value.__getitem__.return_value
+        coll.insert_one.side_effect = DKE("duplicate")
+        coll.delete_one.return_value.deleted_count = 0  # fresh lock — not stale
+        assert pg._acquire_create_lock("placesgeo:ZW:harare") is False
+
+    def test_stale_lock_is_stolen(self, _mock_creation_lock_db):
+        from pymongo.errors import DuplicateKeyError as DKE
+        coll = _mock_creation_lock_db.return_value.__getitem__.return_value
+        # First insert collides; the stale delete removes one doc; retry succeeds.
+        coll.insert_one.side_effect = [DKE("duplicate"), None]
+        coll.delete_one.return_value.deleted_count = 1
+        assert pg._acquire_create_lock("placesgeo:ZW:harare") is True
+        assert coll.insert_one.call_count == 2
+
+    def test_lock_infra_down_proceeds_unlocked(self, _mock_creation_lock_db):
+        coll = _mock_creation_lock_db.return_value.__getitem__.return_value
+        coll.insert_one.side_effect = RuntimeError("db down")
+        assert pg._acquire_create_lock("x") is True
+
+    @patch("py._places_geo.find_nearby_placesgeo", return_value=None)
+    @patch("py._places_geo.get_country_id", return_value="zw-parent")
+    @patch("py._places_geo.places_geo_collection")
+    def test_upsert_releases_lock_after_insert(
+        self, _mock_coll, _mock_parent, _mock_dedup, _mock_creation_lock_db
+    ):
+        coll = _mock_creation_lock_db.return_value.__getitem__.return_value
+        pg.upsert_placesgeo_city(name="Bindura", lat=-17.3, lon=31.33, country_iso="ZW")
+        coll.insert_one.assert_called_once()  # lock acquired
+        coll.delete_one.assert_called_once()  # lock released
+        assert coll.delete_one.call_args[0][0]["_id"].startswith("placesgeo:ZW:")
+
+    @patch("py._places_geo.time.sleep")
+    @patch("py._places_geo.get_country_id", return_value="zw-parent")
+    @patch("py._places_geo.places_geo_collection")
+    @patch("py._places_geo.find_nearby_placesgeo")
+    def test_contended_upsert_waits_then_dedupes_to_competitor(
+        self, mock_dedup, mock_coll, _mock_parent, mock_sleep, _mock_creation_lock_db
+    ):
+        """When another instance holds the lock, wait briefly and re-check —
+        the competitor's just-inserted doc must be returned, not re-inserted."""
+        from pymongo.errors import DuplicateKeyError as DKE
+        lock_coll = _mock_creation_lock_db.return_value.__getitem__.return_value
+        lock_coll.insert_one.side_effect = DKE("held by other instance")
+        lock_coll.delete_one.return_value.deleted_count = 0
+        mock_dedup.return_value = {
+            "_id": "competitor-uuid", "slug": "harare-abc123", "name": "Harare",
+        }
+
+        result = pg.upsert_placesgeo_city(name="Harare", lat=-17.83, lon=31.05, country_iso="ZW")
+
+        mock_sleep.assert_called_once()          # gave the competitor time to land
+        assert result["wasExisting"] is True     # deduped to the competitor's doc
+        assert result["_id"] == "competitor-uuid"
+        mock_coll.return_value.insert_one.assert_not_called()


### PR DESCRIPTION
## Summary
- **#105** — Extracted `_create_location_from_coords()` in `api/py/_locations.py`: the single reverse-geocode → POI check → duplicate gate → slug/elevation/province → placesGeo-upsert → AI-enrichment sequence behind both `GET /api/py/geo?autoCreate=true` and `POST /api/py/locations/add`'s coordinates mode, which previously duplicated it almost line-for-line. The two handlers now only map the shared result to their response shapes. Also added `find_nearest_locations()` (plural) to `_places_resolver.py` as the canonical `$nearSphere` proximity query — `GET /api/py/search`'s geospatial branch routes through it (100 km, now explicit at the call site) and `find_nearest_location` is a thin limit-1 wrapper.
- **#93** — `upsert_placesgeo_city` now takes `dedup_radius_km` (default unchanged at 5 km), and the mukoko creation flow passes its own 1 km duplicate-gate radius. Previously the upsert's internal 5 km/substring dedup could find a *different* same-named place 2–4 km away (e.g. "Westgate" suburb vs "Westgate Mall") and patch the new location's slug onto that unrelated doc, so the new URL resolved to the wrong place.
- **#94** — The dedup read + insert inside `upsert_placesgeo_city` now run under a short cross-instance creation lock (`weather.creation_locks`, atomic `_id`-keyed insert — no index setup needed, 30 s stale-steal for crashed holders). A contended caller waits briefly and re-checks, deduping to the competitor's just-inserted doc instead of double-inserting. If the lock infrastructure is down, creation proceeds unlocked (a rare duplicate beats failing the request).

One deliberate unification: `add_location`'s duplicate gate now requires the matched doc to carry a slug (matching `geo_lookup`'s existing behavior) — a slugless match proceeds to creation, where the upsert patches the mukoko slug onto that doc, making it resolvable.

Fixes #93, fixes #94, fixes #105.

## Test plan
- [x] New tests: `dedup_radius_km` pass-through, lock acquire/contention/stale-steal/infra-down, lock release after insert, contended-upsert-dedupes-to-competitor, `find_nearest_locations` query shape + delegation
- [x] `python -m pytest tests/py/ -v` — 957 passed
- [x] `npm test` — 1987 passed; `npm run lint` — 0 errors; `npx tsc --noEmit` — clean; `npm run build` — clean; prettier (CLAUDE.md) — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_