### PR TITLE
Consolidate UI duplication: Spinner, BreadcrumbSkeleton, geo copy, DB-driven chat prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,7 @@ mukoko-weather/
 │   │   │   ├── dialog.tsx            # Dialog (Radix, portal, overlay, animations)
 │   │   │   ├── input.tsx             # Input (styled with CSS custom properties)
 │   │   │   ├── skeleton.tsx         # Skeleton, CardSkeleton, ChartSkeleton, BadgeSkeleton, MetricCardSkeleton, ChatSkeleton
+│   │   │   ├── spinner.tsx          # Spinner (shared loading ring — size/ring colors compose via className)
 │   │   │   ├── alert.tsx             # Alert, AlertTitle, AlertDescription (6 severity variants)
 │   │   │   ├── accordion.tsx        # Accordion (Radix, animated open/close)
 │   │   │   ├── section-header.tsx   # SectionHeader (title + optional action link/button)
@@ -929,7 +930,7 @@ All AI system prompts, suggested prompt rules, and model configurations are stor
 **Collections:**
 
 - `ai_prompts` — system prompts keyed by `promptKey` (e.g., `system:weather_summary`, `system:history_analysis`, `system:explore_search`, `system:report_clarification`, `greeting:location`, `greeting:explore`, `greeting:history`). Each document has: `promptKey`, `template` (with `{variable}` placeholders), `model`, `maxTokens`, `active`, `updatedAt`
-- `ai_suggested_rules` — dynamic suggested prompt rules. Each rule has: `ruleKey`, `condition` (weather field + operator + threshold), `prompt` (template with `{location}` placeholders), `category` (weather/activity/general), `priority`, `active`. Condition operators: `gt`, `gte`, `lt`, `lte`, `eq`, `in`. The `in` operator checks if any user-selected activity matches an array of activity IDs (source: `"activities"`) or if a weather value falls within an array (source: `"weather"` or `"hourly"`)
+- `ai_suggested_rules` — dynamic suggested prompt rules. Each rule has: `ruleKey`, `condition` (weather field + operator + threshold), `prompt` (template with `{location}` placeholders), `category` (weather/activity/general), `priority`, `active`, and optional `surface` (`"location"` default / `"explore"`). Condition operators: `gt`, `gte`, `lt`, `lte`, `eq`, `in`. The `in` operator checks if any user-selected activity matches an array of activity IDs (source: `"activities"`) or if a weather value falls within an array (source: `"weather"` or `"hourly"`). `surface: "explore"` rules are context-free chips (no `{placeholders}`, `condition: null`) consumed only by `getExplorePrompts()` for the standalone Shamwari chat's empty state — `generateSuggestedPrompts()` (location-page follow-ups) skips them, so the two surfaces can't cross-contaminate
 
 **Seed data:** `src/lib/seed-ai-prompts.ts` — seeded via `/api/db-init`
 

--- a/src/app/HomeLanding.test.ts
+++ b/src/app/HomeLanding.test.ts
@@ -168,9 +168,13 @@ describe("HomeLanding — GPS button (stage 2)", () => {
     expect(source).toContain("gpsState");
   });
 
-  it("shows error message when GPS is denied", () => {
+  it("shows error message when GPS is denied (via shared i18n copy)", () => {
     expect(source).toContain("denied");
-    expect(source).toContain("Location access denied");
+    // Copy is single-sourced in i18n's geo.denied / geo.error keys — the
+    // literal string must NOT be hand-rolled here anymore.
+    expect(source).toContain('t("geo.denied")');
+    expect(source).toContain('t("geo.error")');
+    expect(source).not.toContain("Location access denied —");
   });
 });
 

--- a/src/app/HomeLanding.tsx
+++ b/src/app/HomeLanding.tsx
@@ -7,6 +7,7 @@ import type { WeatherLocation } from "@/lib/locations";
 import { detectUserLocation } from "@/lib/geolocation";
 import { useAppStore } from "@/lib/store";
 import { SearchIcon, NavigationIcon } from "@/lib/weather-icons";
+import { t } from "@/lib/i18n";
 import { WeatherLoadingScene } from "@/components/weather/WeatherLoadingScene";
 
 interface Props {
@@ -314,7 +315,7 @@ export function HomeLanding({ detectedLocation, isReturningUser }: Props) {
 
           {(gpsState === "denied" || gpsState === "error") && (
             <p className="text-sm text-severity-moderate" role="alert">
-              {gpsState === "denied" ? "Location access denied — please search for your city." : "Could not detect location — please search for your city."}
+              {gpsState === "denied" ? t("geo.denied") : t("geo.error")}
             </p>
           )}
         </section>

--- a/src/app/[location]/atmosphere/loading.tsx
+++ b/src/app/[location]/atmosphere/loading.tsx
@@ -1,20 +1,12 @@
 import { HeaderSkeleton } from "@/components/layout/HeaderSkeleton";
+import { BreadcrumbSkeleton } from "@/components/layout/Breadcrumb";
 
 export default function AtmosphereLoading() {
   return (
     <>
       <HeaderSkeleton />
 
-      {/* Breadcrumb skeleton */}
-      <div className="mx-auto max-w-5xl px-4 pt-4 sm:px-6 md:px-8">
-        <div className="flex items-center gap-1">
-          <div className="h-3 w-10 animate-pulse rounded bg-text-tertiary/15" />
-          <span className="text-text-tertiary/30">/</span>
-          <div className="h-3 w-14 animate-pulse rounded bg-text-tertiary/15" />
-          <span className="text-text-tertiary/30">/</span>
-          <div className="h-3 w-20 animate-pulse rounded bg-text-tertiary/15" />
-        </div>
-      </div>
+      <BreadcrumbSkeleton />
 
       <main className="mx-auto max-w-5xl px-4 py-8 pb-24 sm:pb-8 sm:px-6 md:px-8">
         {/* Title skeleton */}

--- a/src/app/[location]/forecast/loading.tsx
+++ b/src/app/[location]/forecast/loading.tsx
@@ -1,20 +1,12 @@
 import { HeaderSkeleton } from "@/components/layout/HeaderSkeleton";
+import { BreadcrumbSkeleton } from "@/components/layout/Breadcrumb";
 
 export default function ForecastLoading() {
   return (
     <>
       <HeaderSkeleton />
 
-      {/* Breadcrumb skeleton */}
-      <div className="mx-auto max-w-5xl px-4 pt-4 sm:px-6 md:px-8">
-        <div className="flex items-center gap-1">
-          <div className="h-3 w-10 animate-pulse rounded bg-text-tertiary/15" />
-          <span className="text-text-tertiary/30">/</span>
-          <div className="h-3 w-14 animate-pulse rounded bg-text-tertiary/15" />
-          <span className="text-text-tertiary/30">/</span>
-          <div className="h-3 w-16 animate-pulse rounded bg-text-tertiary/15" />
-        </div>
-      </div>
+      <BreadcrumbSkeleton />
 
       <main className="mx-auto max-w-5xl px-4 py-8 pb-24 sm:pb-8 sm:px-6 md:px-8">
         {/* Title skeleton */}

--- a/src/app/[location]/map/loading.tsx
+++ b/src/app/[location]/map/loading.tsx
@@ -1,20 +1,12 @@
 import { HeaderSkeleton } from "@/components/layout/HeaderSkeleton";
+import { BreadcrumbSkeleton } from "@/components/layout/Breadcrumb";
 
 export default function MapLoading() {
   return (
     <div className="flex h-[100dvh] flex-col">
       <HeaderSkeleton />
 
-      {/* Breadcrumb skeleton */}
-      <div className="shrink-0 px-4 pt-2 pb-1 sm:px-6">
-        <div className="flex items-center gap-1">
-          <div className="h-3 w-10 animate-pulse rounded bg-text-tertiary/15" />
-          <span className="text-text-tertiary/30">/</span>
-          <div className="h-3 w-14 animate-pulse rounded bg-text-tertiary/15" />
-          <span className="text-text-tertiary/30">/</span>
-          <div className="h-3 w-8 animate-pulse rounded bg-text-tertiary/15" />
-        </div>
-      </div>
+      <BreadcrumbSkeleton className="w-full shrink-0 pb-3" />
 
       {/* Layer switcher skeleton */}
       <div className="flex shrink-0 gap-2 px-4 py-2">

--- a/src/app/history/HistoryDashboard.tsx
+++ b/src/app/history/HistoryDashboard.tsx
@@ -30,6 +30,7 @@ import {
   heatStressLevel,
   uvConcernLabel,
 } from "@/components/weather/ActivityInsights";
+import { Spinner } from "@/components/ui/spinner";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -709,7 +710,7 @@ export function HistoryDashboard() {
 
       {loading && (
         <div className="flex items-center justify-center py-12">
-          <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          <Spinner className="h-8 w-8" />
           <span className="ml-3 text-base text-text-secondary">Loading history...</span>
         </div>
       )}

--- a/src/components/explore/ExploreChatbot.test.ts
+++ b/src/components/explore/ExploreChatbot.test.ts
@@ -111,8 +111,11 @@ describe("error handling", () => {
 });
 
 describe("suggested prompts", () => {
-  it("defines DEFAULT_SUGGESTED_PROMPTS array", () => {
-    expect(source).toContain("const DEFAULT_SUGGESTED_PROMPTS");
+  it("routes default prompts through the shared suggested-prompts module with a hardcoded fallback", () => {
+    expect(source).toContain("fetchSuggestedRules");
+    expect(source).toContain("getExplorePrompts");
+    expect(source).toContain("const FALLBACK_SUGGESTED_PROMPTS");
+    expect(source).not.toContain("DEFAULT_SUGGESTED_PROMPTS");
   });
 
   it("shows EmptyState when no messages", () => {
@@ -124,8 +127,9 @@ describe("suggested prompts", () => {
     expect(source).toContain("onSuggestionClick(prompt.query)");
   });
 
-  it("suggestion buttons meet 56px touch target", () => {
-    expect(source).toContain("min-h-[var(--touch-target-min)]");
+  it("suggestion chips use the shared .quail fauna class (touch target included)", () => {
+    // .quail carries min-h-[var(--touch-target-min)] in globals.css
+    expect(source).toContain('className="quail');
   });
 });
 
@@ -452,7 +456,7 @@ function getContextualPrompts(ctx: { source: string; locationName?: string; hist
       { label: "Best option", query: `Which location is best for outdoor activities right now?` },
     ];
   }
-  // Falls through to DEFAULT_SUGGESTED_PROMPTS in the real component
+  // Falls through to FALLBACK_SUGGESTED_PROMPTS in the real component
   return [];
 }
 

--- a/src/components/explore/ExploreChatbot.tsx
+++ b/src/components/explore/ExploreChatbot.tsx
@@ -9,6 +9,11 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { useAppStore, isShamwariContextValid, type ShamwariContext } from "@/lib/store";
 import { getScrollBehavior } from "@/lib/utils";
 import { trackEvent } from "@/lib/analytics";
+import {
+  fetchSuggestedRules,
+  getExplorePrompts,
+  type SuggestedPrompt,
+} from "@/lib/suggested-prompts";
 
 // ---------------------------------------------------------------------------
 // Inline error boundary for ReactMarkdown — prevents malformed markdown from
@@ -85,7 +90,13 @@ const markdownComponents = {
 /** Cap rendered messages to prevent unbounded memory growth in long conversations. */
 const MAX_RENDERED_MESSAGES = 30;
 
-const DEFAULT_SUGGESTED_PROMPTS = [
+/**
+ * Hardcoded safety net for when the database-driven prompt rules are
+ * unavailable. The live defaults come from the AI prompt library
+ * (`ai_suggested_rules` with surface:"explore") via getExplorePrompts() —
+ * same DB-first-with-fallback pattern as AISummaryChat.
+ */
+const FALLBACK_SUGGESTED_PROMPTS: SuggestedPrompt[] = [
   { label: "Drone flying today", query: "Can I fly a drone today?" },
   { label: "Farming advice", query: "What's the best time to plant crops this season?" },
   { label: "Safari weather", query: "What's the weather like for safari this weekend?" },
@@ -125,7 +136,7 @@ function getContextualPrompts(ctx: ShamwariContext): { label: string; query: str
     ];
   }
 
-  return DEFAULT_SUGGESTED_PROMPTS;
+  return FALLBACK_SUGGESTED_PROMPTS;
 }
 
 /**
@@ -189,6 +200,9 @@ export function ExploreChatbot() {
   const [loading, setLoading] = useState(false);
   const [showScrollBtn, setShowScrollBtn] = useState(false);
   const [contextualPrompts, setContextualPrompts] = useState<{ label: string; query: string }[] | null>(null);
+  // Database-driven default prompts (surface:"explore" rules from the AI
+  // prompt library); the hardcoded set is only the unavailable-DB fallback.
+  const [defaultPrompts, setDefaultPrompts] = useState<SuggestedPrompt[]>(FALLBACK_SUGGESTED_PROMPTS);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -227,6 +241,22 @@ export function ExploreChatbot() {
   // Cancel in-flight fetch on unmount to prevent state updates on unmounted component
   useEffect(() => {
     return () => { abortRef.current?.abort(); };
+  }, []);
+
+  // Load the database-driven default prompts (5-min client cache inside
+  // fetchSuggestedRules). Keep the hardcoded fallback when the DB has no
+  // explore-surface rules or the API is unavailable.
+  useEffect(() => {
+    let alive = true;
+    fetchSuggestedRules()
+      .then((rules) => {
+        const fromDb = getExplorePrompts(rules);
+        if (alive && fromDb.length > 0) setDefaultPrompts(fromDb);
+      })
+      .catch(() => {
+        // API unavailable — the hardcoded fallback stays in place.
+      });
+    return () => { alive = false; };
   }, []);
 
   // Auto-scroll to bottom when new messages arrive — but only if the user is
@@ -368,7 +398,7 @@ export function ExploreChatbot() {
         <ScrollArea viewportRef={viewportRef} className="h-full" fixRadixTableLayout>
           <div className="px-4 py-5 space-y-6 overflow-x-hidden" aria-live="polite" aria-relevant="additions">
             {messages.length === 0 && (
-              <EmptyState onSuggestionClick={handleSuggestion} loading={loading} />
+              <EmptyState prompts={defaultPrompts} onSuggestionClick={handleSuggestion} loading={loading} />
             )}
             {messages.length > 0 && contextualPrompts && contextualPrompts.length > 0 && messages.length === 1 && (
               <div className="mt-2 flex flex-wrap gap-2">
@@ -376,7 +406,7 @@ export function ExploreChatbot() {
                   <button
                     key={prompt.query}
                     onClick={() => handleSuggestion(prompt.query)}
-                    className="flex items-center rounded-[var(--radius-card)] border border-border bg-surface-card px-3 py-2 text-left text-base text-text-secondary transition-colors hover:bg-surface-base hover:text-text-primary hover:border-primary/30 focus-visible:outline-2 focus-visible:outline-primary min-h-[var(--touch-target-min)]"
+                    className="quail flex items-center text-left"
                     type="button"
                     disabled={loading}
                   >
@@ -459,9 +489,15 @@ export function ExploreChatbot() {
 // Empty state with suggested prompts
 // ---------------------------------------------------------------------------
 
-function EmptyState({ onSuggestionClick, loading }: { onSuggestionClick: (query: string) => void; loading?: boolean }) {
-  const prompts = DEFAULT_SUGGESTED_PROMPTS;
-
+function EmptyState({
+  prompts,
+  onSuggestionClick,
+  loading,
+}: {
+  prompts: SuggestedPrompt[];
+  onSuggestionClick: (query: string) => void;
+  loading?: boolean;
+}) {
   return (
     <div className="flex flex-col items-center justify-center py-8">
       <div className="hoopoe-xl">
@@ -484,7 +520,7 @@ function EmptyState({ onSuggestionClick, loading }: { onSuggestionClick: (query:
             <button
               key={prompt.query}
               onClick={() => onSuggestionClick(prompt.query)}
-              className="flex items-center rounded-[var(--radius-card)] border border-border bg-surface-card px-3 py-3 text-left text-base text-text-secondary transition-colors hover:bg-surface-base hover:text-text-primary hover:border-primary/30 focus-visible:outline-2 focus-visible:outline-primary min-h-[var(--touch-target-min)] disabled:cursor-not-allowed disabled:opacity-50"
+              className="quail flex items-center text-left disabled:cursor-not-allowed disabled:opacity-50"
               type="button"
               disabled={loading}
             >

--- a/src/components/explore/ExploreSearch.test.ts
+++ b/src/components/explore/ExploreSearch.test.ts
@@ -136,7 +136,8 @@ describe("UI patterns", () => {
   });
 
   it("shows loading spinner in button", () => {
-    expect(source).toContain("animate-spin");
+    // Spinner is the shared primitive (src/components/ui/spinner.tsx)
+    expect(source).toContain("<Spinner");
   });
 
   it("shows empty state when no results", () => {

--- a/src/components/explore/ExploreSearch.tsx
+++ b/src/components/explore/ExploreSearch.tsx
@@ -8,6 +8,7 @@ import { weatherCodeToInfo } from "@/lib/weather";
 import { trackEvent } from "@/lib/analytics";
 import { ShamwariCTA } from "@/components/weather/ShamwariCTA";
 import { useLocationQuickSearch } from "@/lib/use-location-quick-search";
+import { Spinner } from "@/components/ui/spinner";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -147,7 +148,7 @@ export function ExploreSearch() {
           aria-label="Search"
         >
           {loading ? (
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
+            <Spinner className="border-primary-foreground" />
           ) : (
             <SearchIcon size={16} />
           )}

--- a/src/components/layout/Breadcrumb.test.ts
+++ b/src/components/layout/Breadcrumb.test.ts
@@ -56,3 +56,31 @@ describe("Breadcrumb usage sites", () => {
     expect(mapSource).not.toContain("Back to weather");
   });
 });
+
+describe("BreadcrumbSkeleton (issue #104)", () => {
+  const source = readFileSync(resolve(__dirname, "Breadcrumb.tsx"), "utf-8");
+
+  it("exports a skeleton matching the real trail's container classes", () => {
+    expect(source).toContain("export function BreadcrumbSkeleton");
+    // Same outer classes as the real Breadcrumb nav — no layout shift on hydrate.
+    const occurrences = source.split("mx-auto max-w-5xl px-4 pt-4 sm:px-6 md:px-8").length - 1;
+    expect(occurrences).toBe(2); // skeleton + real component
+  });
+
+  it("is announced as a loading status", () => {
+    expect(source).toContain('role="status"');
+    expect(source).toContain('aria-label="Loading"');
+  });
+
+  it("replaces the hand-rolled skeletons in all three sub-route loading files", () => {
+    for (const file of [
+      "../../app/[location]/atmosphere/loading.tsx",
+      "../../app/[location]/forecast/loading.tsx",
+      "../../app/[location]/map/loading.tsx",
+    ]) {
+      const loadingSource = readFileSync(resolve(__dirname, file), "utf-8");
+      expect(loadingSource).toContain("<BreadcrumbSkeleton");
+      expect(loadingSource).not.toContain('<span className="text-text-tertiary/30">/</span>');
+    }
+  });
+});

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -17,6 +17,32 @@ interface BreadcrumbProps {
  * map). Centralizes the Home / Location / Current-page pattern previously
  * hand-rolled separately in each sub-route dashboard.
  */
+/**
+ * Loading placeholder matching the 3-segment Breadcrumb trail — same outer
+ * container classes as the real component so there's no layout shift when the
+ * page hydrates. Used by the atmosphere/forecast/map loading.tsx files, which
+ * previously each hand-rolled an identical skeleton block.
+ */
+export function BreadcrumbSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className={["mx-auto max-w-5xl px-4 pt-4 sm:px-6 md:px-8", className]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <div className="flex items-center gap-1">
+        <div className="h-3 w-10 animate-pulse rounded bg-text-tertiary/15" />
+        <span aria-hidden="true" className="text-text-tertiary/30">/</span>
+        <div className="h-3 w-14 animate-pulse rounded bg-text-tertiary/15" />
+        <span aria-hidden="true" className="text-text-tertiary/30">/</span>
+        <div className="h-3 w-16 animate-pulse rounded bg-text-tertiary/15" />
+      </div>
+    </div>
+  );
+}
+
 export function Breadcrumb({ items, className }: BreadcrumbProps) {
   return (
     <nav

--- a/src/components/ui/primitives.test.ts
+++ b/src/components/ui/primitives.test.ts
@@ -381,3 +381,31 @@ describe("ActivityCard", () => {
     expect(mod.ActivityCard).toBeDefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Spinner — shared loading-ring primitive (issue #104)
+// ---------------------------------------------------------------------------
+
+describe("Spinner", () => {
+  it("exports the Spinner component", async () => {
+    const mod = await import("./spinner");
+    expect(mod.Spinner).toBeDefined();
+  });
+
+  it("is the single spinning-ring implementation — no hand-rolled copies remain", async () => {
+    const { readFileSync } = await import("fs");
+    const { resolve } = await import("path");
+    const callSites = [
+      "../explore/ExploreSearch.tsx",
+      "../weather/MyWeatherModal.tsx",
+      "../weather/HistoryAnalysis.tsx",
+      "../weather/reports/RecentReports.tsx",
+      "../../app/history/HistoryDashboard.tsx",
+    ];
+    for (const file of callSites) {
+      const source = readFileSync(resolve(__dirname, file), "utf-8");
+      expect(source).toContain("<Spinner");
+      expect(source).not.toContain("animate-spin rounded-full border-2");
+    }
+  });
+});

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared loading spinner — the single source for the spinning-ring loading
+ * indicator previously hand-rolled in six components. Size and ring colors
+ * compose via className (tailwind-merge resolves the conflicts):
+ *
+ *   <Spinner />                                          // 16px, primary ring
+ *   <Spinner className="h-8 w-8" />                      // larger
+ *   <Spinner className="border-primary-foreground" />    // on a filled button
+ *
+ * Decorative by default (aria-hidden) — pair it with visible text or wrap it
+ * in a role="status" container for screen readers.
+ */
+export function Spinner({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent",
+        className,
+      )}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/weather/HistoryAnalysis.tsx
+++ b/src/components/weather/HistoryAnalysis.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { useAppStore } from "@/lib/store";
 import { trackEvent } from "@/lib/analytics";
 import { ShamwariCTA } from "./ShamwariCTA";
+import { Spinner } from "@/components/ui/spinner";
 
 // ---------------------------------------------------------------------------
 // Markdown error boundary
@@ -145,7 +146,7 @@ export function HistoryAnalysis({
 
       {loading && (
         <div className="mt-3 flex items-center gap-2" role="status">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          <Spinner />
           <span className="text-base text-text-secondary">
             Analyzing {days}-day history...
           </span>

--- a/src/components/weather/MyWeatherModal.tsx
+++ b/src/components/weather/MyWeatherModal.tsx
@@ -23,6 +23,8 @@ import { useLocationQuickSearch } from "@/lib/use-location-quick-search";
 import { cn, slugToDisplayName } from "@/lib/utils";
 import { trackEvent } from "@/lib/analytics";
 import { ForecastModel, FORECAST_MODEL_LABELS } from "@/lib/weather";
+import { t } from "@/lib/i18n";
+import { Spinner } from "@/components/ui/spinner";
 
 /** Default category style for unknown categories */
 const DEFAULT_CATEGORY_STYLE = {
@@ -235,7 +237,7 @@ function SavedTab({
           className="flex min-h-[var(--touch-target-min)] w-full items-center justify-start gap-3 text-primary"
         >
           {geoLoading ? (
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary/30 border-t-primary" />
+            <Spinner className="border-primary/30 border-t-primary" />
           ) : (
             <NavigationIcon size={16} className="text-primary" />
           )}
@@ -244,10 +246,10 @@ function SavedTab({
           </span>
         </Button>
         {geoState?.status === "denied" && (
-          <p className="px-3 pb-1 text-base text-text-tertiary">Location access denied.</p>
+          <p className="px-3 pb-1 text-base text-text-tertiary">{t("geo.denied")}</p>
         )}
         {geoState?.status === "error" && geoState?.coords && (
-          <p className="px-3 pb-1 text-base text-text-tertiary">Could not detect your location. Try again later.</p>
+          <p className="px-3 pb-1 text-base text-text-tertiary">{t("geo.error")}</p>
         )}
       </div>
 

--- a/src/components/weather/reports/RecentReports.test.ts
+++ b/src/components/weather/reports/RecentReports.test.ts
@@ -37,7 +37,8 @@ describe("data fetching", () => {
   it("shows loading spinner", () => {
     expect(source).toContain('role="status"');
     expect(source).toContain("sr-only");
-    expect(source).toContain("animate-spin");
+    // Spinner is the shared primitive (src/components/ui/spinner.tsx)
+    expect(source).toContain("<Spinner");
   });
 });
 

--- a/src/components/weather/reports/RecentReports.tsx
+++ b/src/components/weather/reports/RecentReports.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from "@/lib/store";
 import { trackEvent } from "@/lib/analytics";
 import { CloudSunIcon, MegaphoneIcon } from "@/lib/weather-icons";
 import { getReportTypeInfo } from "@/lib/report-types";
+import { Spinner } from "@/components/ui/spinner";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -129,7 +130,7 @@ export function RecentReports({ locationSlug }: { locationSlug: string }) {
 
       {loading && (
         <div className="flex items-center gap-2 py-4" role="status">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-mineral-copper border-t-transparent" />
+          <Spinner className="border-mineral-copper" />
           <span className="text-base text-text-secondary">Loading reports...</span>
           <span className="sr-only">Loading community weather reports</span>
         </div>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -26,8 +26,12 @@ const messages: Record<string, Record<string, string>> = {
     "nav.searchLocations": "Search locations...",
     "nav.useMyLocation": "Use my location",
     "nav.detectingLocation": "Detecting location...",
-    "nav.locationDenied": "Location access denied. Enable it in your browser settings.",
     "nav.locationFailed": "Unable to detect your location. Select one below.",
+
+    // Geolocation status — the single source for denied/error copy, shared
+    // by HomeLanding and MyWeatherModal (previously three hand-rolled copies).
+    "geo.denied": "Location access denied — please search for your city.",
+    "geo.error": "Could not detect location — please search for your city.",
 
     // Weather
     "weather.current": "Current weather conditions in {location}",

--- a/src/lib/seed-ai-prompts.test.ts
+++ b/src/lib/seed-ai-prompts.test.ts
@@ -95,9 +95,16 @@ describe("AI_SUGGESTED_PROMPT_RULES uniqueness and structure", () => {
     }
   });
 
-  it("queryTemplate includes at least one interpolation placeholder", () => {
+  it("location-surface templates interpolate; explore-surface templates are context-free", () => {
     for (const rule of AI_SUGGESTED_PROMPT_RULES) {
-      expect(rule.queryTemplate).toMatch(/\{[a-zA-Z]+\}/);
+      if (rule.surface === "explore") {
+        // The standalone chat's empty state has no weather/location context —
+        // a placeholder here would render literally as "{location}".
+        expect(rule.queryTemplate).not.toMatch(/\{[a-zA-Z]+\}/);
+        expect(rule.condition).toBeNull();
+      } else {
+        expect(rule.queryTemplate).toMatch(/\{[a-zA-Z]+\}/);
+      }
     }
   });
 

--- a/src/lib/seed-ai-prompts.ts
+++ b/src/lib/seed-ai-prompts.ts
@@ -56,6 +56,12 @@ export interface AISuggestedPromptRule {
   active: boolean;
   /** Sort order within its category (lower = higher priority) */
   order: number;
+  /**
+   * Which surface the rule targets. Missing/"location" = weather-page
+   * follow-up chat; "explore" = the standalone Shamwari chat's default
+   * prompt chips (context-free — no {placeholders}, condition null).
+   */
+  surface?: "location" | "explore";
 }
 
 // ---------------------------------------------------------------------------
@@ -489,5 +495,71 @@ export const AI_SUGGESTED_PROMPT_RULES: Omit<AISuggestedPromptRule, "updatedAt">
     condition: null,
     active: true,
     order: 100,
+  },
+
+  // --- Explore-surface default prompts (standalone Shamwari chat) ---
+  // Context-free by design: the empty chat has no weather or location, so
+  // these templates must contain NO {placeholders}. Consumed exclusively by
+  // getExplorePrompts() — generateSuggestedPrompts() skips surface:"explore".
+
+  {
+    ruleId: "explore:drone",
+    label: "Drone flying today",
+    queryTemplate: "Can I fly a drone today?",
+    category: "generic",
+    condition: null,
+    active: true,
+    order: 200,
+    surface: "explore",
+  },
+  {
+    ruleId: "explore:farming",
+    label: "Farming advice",
+    queryTemplate: "What's the best time to plant crops this season?",
+    category: "generic",
+    condition: null,
+    active: true,
+    order: 201,
+    surface: "explore",
+  },
+  {
+    ruleId: "explore:safari",
+    label: "Safari weather",
+    queryTemplate: "What's the weather like for safari this weekend?",
+    category: "generic",
+    condition: null,
+    active: true,
+    order: 202,
+    surface: "explore",
+  },
+  {
+    ruleId: "explore:compare",
+    label: "Compare cities",
+    queryTemplate: "Compare weather in Nairobi and Bangkok",
+    category: "generic",
+    condition: null,
+    active: true,
+    order: 203,
+    surface: "explore",
+  },
+  {
+    ruleId: "explore:road_trip",
+    label: "Road trip",
+    queryTemplate: "Is it safe for a road trip today?",
+    category: "generic",
+    condition: null,
+    active: true,
+    order: 204,
+    surface: "explore",
+  },
+  {
+    ruleId: "explore:weekend",
+    label: "Weekend plans",
+    queryTemplate: "What outdoor activities can I do this weekend?",
+    category: "generic",
+    condition: null,
+    active: true,
+    order: 205,
+    surface: "explore",
   },
 ];

--- a/src/lib/suggested-prompts.test.ts
+++ b/src/lib/suggested-prompts.test.ts
@@ -341,3 +341,47 @@ describe("generateSuggestedPrompts", () => {
     expect(result.some((p) => p.label === "Rain impact")).toBe(true);
   });
 });
+
+describe("getExplorePrompts (explore-surface rules)", () => {
+  const exploreRule: SuggestedPromptRule = {
+    ruleId: "explore:drone",
+    label: "Drone flying today",
+    queryTemplate: "Can I fly a drone today?",
+    category: "generic",
+    condition: null,
+    active: true,
+    order: 200,
+    surface: "explore",
+  };
+
+  it("returns only active explore-surface rules, sorted by order", async () => {
+    const { getExplorePrompts } = await import("./suggested-prompts");
+    const second: SuggestedPromptRule = { ...exploreRule, ruleId: "explore:b", label: "B", order: 201 };
+    const inactive: SuggestedPromptRule = { ...exploreRule, ruleId: "explore:c", label: "C", active: false };
+    const locationRule: SuggestedPromptRule = {
+      ...exploreRule, ruleId: "generic:plan", label: "Plan my day",
+      queryTemplate: "What should I plan for today in {location}?", surface: undefined,
+    };
+    const prompts = getExplorePrompts([second, inactive, locationRule, exploreRule]);
+    expect(prompts).toEqual([
+      { label: "Drone flying today", query: "Can I fly a drone today?" },
+      { label: "B", query: "Can I fly a drone today?" },
+    ]);
+  });
+
+  it("skips explore rules whose template still has placeholders (would render literally)", async () => {
+    const { getExplorePrompts } = await import("./suggested-prompts");
+    const bad: SuggestedPromptRule = { ...exploreRule, queryTemplate: "Plan my day in {location}" };
+    expect(getExplorePrompts([bad])).toEqual([]);
+  });
+
+  it("generateSuggestedPrompts never surfaces explore rules on the location page", () => {
+    const prompts = generateSuggestedPrompts(
+      makeWeather(),
+      { name: "Harare", slug: "harare" },
+      [],
+      [exploreRule],
+    );
+    expect(prompts.find((p) => p.label === "Drone flying today")).toBeUndefined();
+  });
+});

--- a/src/lib/suggested-prompts.ts
+++ b/src/lib/suggested-prompts.ts
@@ -29,6 +29,13 @@ export interface SuggestedPromptRule {
   } | null;
   active: boolean;
   order: number;
+  /**
+   * Which surface the rule targets. Missing/"location" = the weather-page
+   * follow-up chat (needs weather + location context for interpolation);
+   * "explore" = the standalone Shamwari chat's default prompts (must be
+   * context-free — no {placeholders}, no weather condition).
+   */
+  surface?: "location" | "explore";
 }
 
 // ---------------------------------------------------------------------------
@@ -185,6 +192,9 @@ export function generateSuggestedPrompts(
 
   for (const rule of sorted) {
     if (!rule.active) continue;
+    // Explore-surface rules are context-free chips for the standalone chat's
+    // empty state (see getExplorePrompts) — never location-page follow-ups.
+    if (rule.surface === "explore") continue;
     if (evaluateCondition(rule.condition, weather, activities)) {
       prompts.push({
         label: rule.label,
@@ -205,6 +215,26 @@ export function generateSuggestedPrompts(
   }
 
   return unique;
+}
+
+/**
+ * Database-driven default prompts for the standalone Shamwari chat's empty
+ * state — the surface with NO weather or location context. Only explore-surface
+ * rules with a context-free template (no {placeholders}) qualify; anything
+ * else would render raw template variables. Returns [] when the database has
+ * no explore rules, so the caller falls back to its hardcoded set.
+ */
+export function getExplorePrompts(rules: SuggestedPromptRule[]): SuggestedPrompt[] {
+  return rules
+    .filter(
+      (r) =>
+        r.active &&
+        r.surface === "explore" &&
+        r.condition === null &&
+        !/\{\w+\}/.test(r.queryTemplate),
+    )
+    .sort((a, b) => a.order - b.order)
+    .map((r) => ({ label: r.label, query: r.queryTemplate }));
 }
 
 /**


### PR DESCRIPTION
## Summary
- **#104 (1)** — New `Spinner` primitive (`src/components/ui/spinner.tsx`); replaces the hand-rolled spinning-ring `div` in `ExploreSearch`, `MyWeatherModal`, `HistoryAnalysis`, `RecentReports`, and `HistoryDashboard`. Size and ring colors compose via `className` (tailwind-merge resolves conflicts).
- **#104 (2)** — New `BreadcrumbSkeleton` alongside the shared `Breadcrumb`, using the same container classes so the loading state can't drift from the real trail. The three sub-route `loading.tsx` files (atmosphere/forecast/map) use it instead of three hand-rolled skeleton blocks.
- **#104 (3)** — Geolocation denied/error copy single-sourced in i18n (`geo.denied` / `geo.error`), used by both `HomeLanding` and `MyWeatherModal`; dropped the dead `nav.locationDenied` key.
- **#104 (4)** — `ExploreChatbot`'s suggested-prompt chips (contextual + empty-state) use the established `.quail` fauna class instead of hand-rolled chains.
- **#98** — `ExploreChatbot`'s default prompts now come from the database-driven AI prompt library: new `surface: "explore"` rules seeded in `seed-ai-prompts.ts` (context-free by design — no `{placeholders}`, `condition: null`), consumed via `fetchSuggestedRules()` + new `getExplorePrompts()` in `suggested-prompts.ts`. The hardcoded array remains only as the unavailable-DB fallback, matching AISummaryChat's pattern. `generateSuggestedPrompts()` explicitly skips explore-surface rules so they can never leak into location-page follow-up chips (and vice versa).

Fixes #98, fixes #104.

## Test plan
- [x] New tests: Spinner export + no hand-rolled copies remain, BreadcrumbSkeleton structure/a11y/usage, `getExplorePrompts` filtering/sorting/placeholder guard, explore-rules-never-on-location-page, seed rule surface constraints
- [x] Updated structural tests that asserted the old implementations (spinner div, DEFAULT_SUGGESTED_PROMPTS, literal geo copy, per-rule placeholder requirement)
- [x] `npm test` — 1995 passed; `python -m pytest tests/py/` — 947 passed
- [x] `npm run lint` — 0 errors; `npx tsc --noEmit` — clean; `npm run build` — clean; prettier (CLAUDE.md) — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_