### PR TITLE
Consolidate 8 route error.tsx boundaries into shared RouteErrorBoundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -583,10 +583,11 @@ All data handling, AI operations, database CRUD, and rule evaluation run in Pyth
 
 2. **Per-section error boundaries** — Every weather section in `WeatherDashboard.tsx` is wrapped in `ChartErrorBoundary`. If any one component crashes (e.g., chart render failure on low-memory mobile), only that section shows the fallback. Other sections keep working.
 
-3. **Page-level error boundaries** (last resort) — Only triggered if the entire page fails to render:
+3. **Page-level error boundaries** (last resort) — Only triggered if the entire page fails to render. All 8 route-level `error.tsx` files are thin wrappers around the shared `RouteErrorBoundary` (`src/components/layout/RouteErrorBoundary.tsx`) — each supplies only its copy (title/message/source/label); the retry tracking, analytics reporting, issue-report link, and JSX shell live once in the shared component:
    - `src/app/error.tsx` — global fallback ("Something went wrong")
-   - `src/app/[location]/error.tsx` — weather page fallback ("Weather Unavailable")
-   - `src/app/history/error.tsx` — history page fallback ("History Unavailable")
+   - `src/app/[location]/error.tsx` — weather page fallback ("Weather Unavailable", extra "View historical data" link)
+   - `src/app/history/error.tsx`, `src/app/shamwari/error.tsx`, `src/app/aviation/error.tsx` — per-page fallbacks
+   - `src/app/explore/country/**/error.tsx` (3 files) — lightweight variants (`retryTracking={false}`: plain retry, non-fatal analytics, no issue link)
    - Retry count is tracked in `sessionStorage` to prevent infinite reload loops (max 3 retries)
 
 4. **Inline degradation** — `WeatherUnavailableBanner` shown when all weather providers fail but the page still renders with seasonal estimates

--- a/src/app/[location]/error.tsx
+++ b/src/app/[location]/error.tsx
@@ -1,85 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { reportErrorToAnalytics, buildIssueUrl } from "@/lib/observability";
-import { getRetryCount, setRetryCount, clearRetryCount, MAX_RETRIES } from "@/lib/error-retry";
+import { RouteErrorBoundary, type RouteErrorProps } from "@/components/layout/RouteErrorBoundary";
 
-export default function LocationError({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
-  const [exhausted, setExhausted] = useState(() => getRetryCount() >= MAX_RETRIES);
-
-  useEffect(() => {
-    console.error("Weather page error:", error);
-    reportErrorToAnalytics(`location:${error.message}`, true);
-  }, [error]);
-
-  const handleRetry = () => {
-    const count = getRetryCount() + 1;
-    setRetryCount(count);
-
-    if (count >= MAX_RETRIES) {
-      setExhausted(true);
-      return;
-    }
-
-    reset();
-  };
-
-  const handleNavigate = () => {
-    clearRetryCount();
-  };
-
+export default function LocationError(props: RouteErrorProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <h1 className="font-heading text-4xl font-bold text-text-primary">
-        Weather Unavailable
-      </h1>
-      <p className="mt-4 max-w-md text-center text-text-secondary">
-        {exhausted
-          ? "This location\u2019s weather data is temporarily unavailable. Try a different location or check back later."
-          : "We couldn\u2019t load weather data right now. This is usually a temporary issue with our weather providers."}
-      </p>
-
-      <div className="mt-8 flex flex-col items-center gap-3">
-        {!exhausted && (
-          <Button size="lg" onClick={handleRetry}>
-            Try again
-          </Button>
-        )}
-
-        <Button variant="outline" size="lg" asChild>
-          <Link href="/" onClick={handleNavigate}>
-            Go to Harare weather
-          </Link>
-        </Button>
-
-        <Button variant="link" asChild>
-          <Link href="/history" onClick={handleNavigate}>
-            View historical data instead
-          </Link>
-        </Button>
-        <a
-          href={buildIssueUrl({
-            title: "Weather page error",
-            source: "location",
-            message: error.message,
-            page: typeof window !== "undefined" ? window.location.pathname : undefined,
-            digest: error.digest,
-          })}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-2 text-base text-text-tertiary underline hover:text-text-secondary transition-colors"
-        >
-          Report this issue
-        </a>
-      </div>
-    </div>
+    <RouteErrorBoundary
+      {...props}
+      title="Weather Unavailable"
+      message="We couldn’t load weather data right now. This is usually a temporary issue with our weather providers."
+      exhaustedMessage="This location’s weather data is temporarily unavailable. Try a different location or check back later."
+      source="location"
+      label="Weather page error"
+      homeLabel="Go to Harare weather"
+      extraLinks={[{ label: "View historical data instead", href: "/history" }]}
+    />
   );
 }

--- a/src/app/aviation/aviation.test.ts
+++ b/src/app/aviation/aviation.test.ts
@@ -73,13 +73,10 @@ describe("Aviation error boundary", () => {
   it("is a client component", () => {
     expect(errorSrc).toContain('"use client"');
   });
-  it("exports a default error component with error + reset props", () => {
+  it("exports a default error component wrapping the shared RouteErrorBoundary", () => {
     expect(errorSrc).toContain("export default function AviationError");
-    expect(errorSrc).toContain("reset");
-  });
-  it("reports to analytics and offers retry", () => {
-    expect(errorSrc).toContain("reportErrorToAnalytics");
-    expect(errorSrc).toContain("Try again");
+    expect(errorSrc).toContain("RouteErrorBoundary");
+    expect(errorSrc).toContain('source="aviation"');
   });
 });
 

--- a/src/app/aviation/error.tsx
+++ b/src/app/aviation/error.tsx
@@ -1,77 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { reportErrorToAnalytics, buildIssueUrl } from "@/lib/observability";
-import { getRetryCount, setRetryCount, clearRetryCount, MAX_RETRIES } from "@/lib/error-retry";
+import { RouteErrorBoundary, type RouteErrorProps } from "@/components/layout/RouteErrorBoundary";
 
-export default function AviationError({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
-  const [exhausted, setExhausted] = useState(() => getRetryCount() >= MAX_RETRIES);
-
-  useEffect(() => {
-    console.error("Aviation page error:", error);
-    reportErrorToAnalytics(`aviation:${error.message}`, true);
-  }, [error]);
-
-  const handleRetry = () => {
-    const count = getRetryCount() + 1;
-    setRetryCount(count);
-
-    if (count >= MAX_RETRIES) {
-      setExhausted(true);
-      return;
-    }
-
-    reset();
-  };
-
-  const handleNavigate = () => {
-    clearRetryCount();
-  };
-
+export default function AviationError(props: RouteErrorProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <h1 className="font-heading text-4xl font-bold text-text-primary">
-        Briefing Unavailable
-      </h1>
-      <p className="mt-4 max-w-md text-center text-text-secondary">
-        {exhausted
-          ? "The aviation weather briefing is temporarily unavailable. Please try again later."
-          : "We couldn’t load the aviation weather briefing right now. This may be a temporary issue with METAR/TAF data."}
-      </p>
-      <div className="mt-8 flex flex-col items-center gap-3">
-        {!exhausted && (
-          <Button size="lg" onClick={handleRetry}>
-            Try again
-          </Button>
-        )}
-        <Button variant="outline" size="lg" asChild>
-          <Link href="/" onClick={handleNavigate}>
-            Go home
-          </Link>
-        </Button>
-        <a
-          href={buildIssueUrl({
-            title: "Aviation page error",
-            source: "aviation",
-            message: error.message,
-            page: "/aviation",
-            digest: error.digest,
-          })}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-2 text-base text-text-tertiary underline hover:text-text-secondary transition-colors"
-        >
-          Report this issue
-        </a>
-      </div>
-    </div>
+    <RouteErrorBoundary
+      {...props}
+      title="Briefing Unavailable"
+      message="We couldn’t load the aviation weather briefing right now. This may be a temporary issue with METAR/TAF data."
+      exhaustedMessage="The aviation weather briefing is temporarily unavailable. Please try again later."
+      source="aviation"
+      label="Aviation page error"
+    />
   );
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,77 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { reportErrorToAnalytics, buildIssueUrl } from "@/lib/observability";
-import { getRetryCount, setRetryCount, clearRetryCount, MAX_RETRIES } from "@/lib/error-retry";
+import { RouteErrorBoundary, type RouteErrorProps } from "@/components/layout/RouteErrorBoundary";
 
-export default function GlobalError({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
-  const [exhausted, setExhausted] = useState(() => getRetryCount() >= MAX_RETRIES);
-
-  useEffect(() => {
-    console.error("Application error:", error);
-    reportErrorToAnalytics(`global:${error.message}`, true);
-  }, [error]);
-
-  const handleRetry = () => {
-    const count = getRetryCount() + 1;
-    setRetryCount(count);
-
-    if (count >= MAX_RETRIES) {
-      setExhausted(true);
-      return;
-    }
-
-    reset();
-  };
-
-  const handleNavigate = () => {
-    clearRetryCount();
-  };
-
+export default function GlobalError(props: RouteErrorProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <h1 className="font-heading text-4xl font-bold text-text-primary">
-        Something went wrong
-      </h1>
-      <p className="mt-4 max-w-md text-center text-text-secondary">
-        {exhausted
-          ? "This page is experiencing persistent issues. Please try a different page or check back later."
-          : "An unexpected error occurred. Please try again or return to the home page."}
-      </p>
-      <div className="mt-8 flex flex-col items-center gap-3">
-        {!exhausted && (
-          <Button size="lg" onClick={handleRetry}>
-            Try again
-          </Button>
-        )}
-        <Button variant="outline" size="lg" asChild>
-          <Link href="/" onClick={handleNavigate}>
-            Go home
-          </Link>
-        </Button>
-        <a
-          href={buildIssueUrl({
-            title: "Application error",
-            source: "global",
-            message: error.message,
-            page: typeof window !== "undefined" ? window.location.pathname : undefined,
-            digest: error.digest,
-          })}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-2 text-base text-text-tertiary underline hover:text-text-secondary transition-colors"
-        >
-          Report this issue
-        </a>
-      </div>
-    </div>
+    <RouteErrorBoundary
+      {...props}
+      title="Something went wrong"
+      message="An unexpected error occurred. Please try again or return to the home page."
+      exhaustedMessage="This page is experiencing persistent issues. Please try a different page or check back later."
+      source="global"
+      label="Application error"
+    />
   );
 }

--- a/src/app/explore/country/[code]/[province]/error.tsx
+++ b/src/app/explore/country/[code]/[province]/error.tsx
@@ -1,38 +1,18 @@
 "use client";
 
-import { useEffect } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { reportErrorToAnalytics } from "@/lib/observability";
+import { RouteErrorBoundary, type RouteErrorProps } from "@/components/layout/RouteErrorBoundary";
 
-export default function ProvinceDetailError({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
-  useEffect(() => {
-    console.error("Province detail error:", error);
-    reportErrorToAnalytics(`explore-province-detail:${error.message}`, false);
-  }, [error]);
-
+export default function ProvinceDetailError(props: RouteErrorProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <h1 className="font-heading text-3xl font-bold text-text-primary">
-        Could not load province
-      </h1>
-      <p className="mt-4 max-w-md text-center text-text-secondary">
-        There was a problem loading this province&apos;s data. This is usually a temporary issue.
-      </p>
-      <div className="mt-8 flex flex-col items-center gap-3">
-        <Button size="lg" onClick={reset}>
-          Try again
-        </Button>
-        <Button variant="outline" size="lg" asChild>
-          <Link href="/explore/country">Browse all countries</Link>
-        </Button>
-      </div>
-    </div>
+    <RouteErrorBoundary
+      {...props}
+      title="Could not load province"
+      message="There was a problem loading this province’s data. This is usually a temporary issue."
+      source="explore-province-detail"
+      label="Province detail error"
+      retryTracking={false}
+      homeHref="/explore/country"
+      homeLabel="Browse all countries"
+    />
   );
 }

--- a/src/app/explore/country/[code]/error.tsx
+++ b/src/app/explore/country/[code]/error.tsx
@@ -1,38 +1,18 @@
 "use client";
 
-import { useEffect } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { reportErrorToAnalytics } from "@/lib/observability";
+import { RouteErrorBoundary, type RouteErrorProps } from "@/components/layout/RouteErrorBoundary";
 
-export default function CountryDetailError({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
-  useEffect(() => {
-    console.error("Country detail error:", error);
-    reportErrorToAnalytics(`explore-country-detail:${error.message}`, false);
-  }, [error]);
-
+export default function CountryDetailError(props: RouteErrorProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <h1 className="font-heading text-3xl font-bold text-text-primary">
-        Could not load country
-      </h1>
-      <p className="mt-4 max-w-md text-center text-text-secondary">
-        There was a problem loading this country&apos;s data. This is usually a temporary issue.
-      </p>
-      <div className="mt-8 flex flex-col items-center gap-3">
-        <Button size="lg" onClick={reset}>
-          Try again
-        </Button>
-        <Button variant="outline" size="lg" asChild>
-          <Link href="/explore/country">Browse all countries</Link>
-        </Button>
-      </div>
-    </div>
+    <RouteErrorBoundary
+      {...props}
+      title="Could not load country"
+      message="There was a problem loading this country’s data. This is usually a temporary issue."
+      source="explore-country-detail"
+      label="Country detail error"
+      retryTracking={false}
+      homeHref="/explore/country"
+      homeLabel="Browse all countries"
+    />
   );
 }

--- a/src/app/explore/country/error.tsx
+++ b/src/app/explore/country/error.tsx
@@ -1,38 +1,18 @@
 "use client";
 
-import { useEffect } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { reportErrorToAnalytics } from "@/lib/observability";
+import { RouteErrorBoundary, type RouteErrorProps } from "@/components/layout/RouteErrorBoundary";
 
-export default function ExploreCountryError({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
-  useEffect(() => {
-    console.error("Country explore error:", error);
-    reportErrorToAnalytics(`explore-country:${error.message}`, false);
-  }, [error]);
-
+export default function ExploreCountryError(props: RouteErrorProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <h1 className="font-heading text-3xl font-bold text-text-primary">
-        Could not load countries
-      </h1>
-      <p className="mt-4 max-w-md text-center text-text-secondary">
-        There was a problem loading the country list. This is usually a temporary issue.
-      </p>
-      <div className="mt-8 flex flex-col items-center gap-3">
-        <Button size="lg" onClick={reset}>
-          Try again
-        </Button>
-        <Button variant="outline" size="lg" asChild>
-          <Link href="/explore">Back to Explore</Link>
-        </Button>
-      </div>
-    </div>
+    <RouteErrorBoundary
+      {...props}
+      title="Could not load countries"
+      message="There was a problem loading the country list. This is usually a temporary issue."
+      source="explore-country"
+      label="Country explore error"
+      retryTracking={false}
+      homeHref="/explore"
+      homeLabel="Back to Explore"
+    />
   );
 }

--- a/src/app/history/error.tsx
+++ b/src/app/history/error.tsx
@@ -1,77 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { reportErrorToAnalytics, buildIssueUrl } from "@/lib/observability";
-import { getRetryCount, setRetryCount, clearRetryCount, MAX_RETRIES } from "@/lib/error-retry";
+import { RouteErrorBoundary, type RouteErrorProps } from "@/components/layout/RouteErrorBoundary";
 
-export default function HistoryError({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
-  const [exhausted, setExhausted] = useState(() => getRetryCount() >= MAX_RETRIES);
-
-  useEffect(() => {
-    console.error("History page error:", error);
-    reportErrorToAnalytics(`history:${error.message}`, true);
-  }, [error]);
-
-  const handleRetry = () => {
-    const count = getRetryCount() + 1;
-    setRetryCount(count);
-
-    if (count >= MAX_RETRIES) {
-      setExhausted(true);
-      return;
-    }
-
-    reset();
-  };
-
-  const handleNavigate = () => {
-    clearRetryCount();
-  };
-
+export default function HistoryError(props: RouteErrorProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <h1 className="font-heading text-4xl font-bold text-text-primary">
-        History Unavailable
-      </h1>
-      <p className="mt-4 max-w-md text-center text-text-secondary">
-        {exhausted
-          ? "Historical data is temporarily unavailable. Please try again later."
-          : "We couldn\u2019t load historical weather data right now. This may be a temporary database issue."}
-      </p>
-      <div className="mt-8 flex flex-col items-center gap-3">
-        {!exhausted && (
-          <Button size="lg" onClick={handleRetry}>
-            Try again
-          </Button>
-        )}
-        <Button variant="outline" size="lg" asChild>
-          <Link href="/" onClick={handleNavigate}>
-            Go home
-          </Link>
-        </Button>
-        <a
-          href={buildIssueUrl({
-            title: "History page error",
-            source: "history",
-            message: error.message,
-            page: "/history",
-            digest: error.digest,
-          })}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-2 text-base text-text-tertiary underline hover:text-text-secondary transition-colors"
-        >
-          Report this issue
-        </a>
-      </div>
-    </div>
+    <RouteErrorBoundary
+      {...props}
+      title="History Unavailable"
+      message="We couldn’t load historical weather data right now. This may be a temporary database issue."
+      exhaustedMessage="Historical data is temporarily unavailable. Please try again later."
+      source="history"
+      label="History page error"
+    />
   );
 }

--- a/src/app/shamwari/error.tsx
+++ b/src/app/shamwari/error.tsx
@@ -1,77 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { reportErrorToAnalytics, buildIssueUrl } from "@/lib/observability";
-import { getRetryCount, setRetryCount, clearRetryCount, MAX_RETRIES } from "@/lib/error-retry";
+import { RouteErrorBoundary, type RouteErrorProps } from "@/components/layout/RouteErrorBoundary";
 
-export default function ShamwariError({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
-  const [exhausted, setExhausted] = useState(() => getRetryCount() >= MAX_RETRIES);
-
-  useEffect(() => {
-    console.error("Shamwari page error:", error);
-    reportErrorToAnalytics(`shamwari:${error.message}`, true);
-  }, [error]);
-
-  const handleRetry = () => {
-    const count = getRetryCount() + 1;
-    setRetryCount(count);
-
-    if (count >= MAX_RETRIES) {
-      setExhausted(true);
-      return;
-    }
-
-    reset();
-  };
-
-  const handleNavigate = () => {
-    clearRetryCount();
-  };
-
+export default function ShamwariError(props: RouteErrorProps) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <h1 className="font-heading text-4xl font-bold text-text-primary">
-        Chat Unavailable
-      </h1>
-      <p className="mt-4 max-w-md text-center text-text-secondary">
-        {exhausted
-          ? "Shamwari Explorer is temporarily unavailable. Please try again later."
-          : "We couldn\u2019t load Shamwari Explorer right now. This may be a temporary issue."}
-      </p>
-      <div className="mt-8 flex flex-col items-center gap-3">
-        {!exhausted && (
-          <Button size="lg" onClick={handleRetry}>
-            Try again
-          </Button>
-        )}
-        <Button variant="outline" size="lg" asChild>
-          <Link href="/" onClick={handleNavigate}>
-            Go home
-          </Link>
-        </Button>
-        <a
-          href={buildIssueUrl({
-            title: "Shamwari page error",
-            source: "shamwari",
-            message: error.message,
-            page: "/shamwari",
-            digest: error.digest,
-          })}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-2 text-base text-text-tertiary underline hover:text-text-secondary transition-colors"
-        >
-          Report this issue
-        </a>
-      </div>
-    </div>
+    <RouteErrorBoundary
+      {...props}
+      title="Chat Unavailable"
+      message="We couldn’t load Shamwari Explorer right now. This may be a temporary issue."
+      exhaustedMessage="Shamwari Explorer is temporarily unavailable. Please try again later."
+      source="shamwari"
+      label="Shamwari page error"
+    />
   );
 }

--- a/src/app/shamwari/shamwari.test.ts
+++ b/src/app/shamwari/shamwari.test.ts
@@ -125,24 +125,12 @@ describe("shamwari error boundary", () => {
     expect(errorSource).toContain("Chat Unavailable");
   });
 
-  it("uses retry count tracking from error-retry", () => {
-    expect(errorSource).toContain("getRetryCount");
-    expect(errorSource).toContain("setRetryCount");
-    expect(errorSource).toContain("MAX_RETRIES");
-  });
-
-  it("reports errors to analytics", () => {
-    expect(errorSource).toContain("reportErrorToAnalytics");
-    expect(errorSource).toContain("shamwari:");
-  });
-
-  it("provides issue reporting link", () => {
-    expect(errorSource).toContain("buildIssueUrl");
-    expect(errorSource).toContain("Report this issue");
-  });
-
-  it("provides home navigation link", () => {
-    expect(errorSource).toContain('href="/"');
-    expect(errorSource).toContain("Go home");
+  it("delegates retry tracking, analytics, and issue reporting to the shared RouteErrorBoundary", () => {
+    // The boundary shell (getRetryCount/setRetryCount/MAX_RETRIES,
+    // reportErrorToAnalytics, buildIssueUrl, home link) lives once in
+    // RouteErrorBoundary — this file only supplies the copy (issue #102).
+    expect(errorSource).toContain("RouteErrorBoundary");
+    expect(errorSource).toContain('source="shamwari"');
+    expect(errorSource).not.toContain("getRetryCount");
   });
 });

--- a/src/components/layout/RouteErrorBoundary.test.ts
+++ b/src/components/layout/RouteErrorBoundary.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for RouteErrorBoundary — the single shared body behind every
+ * route-level error.tsx (issue #102). Structural checks: the boundary logic
+ * (retry tracking, analytics, issue reporting) exists exactly once here, and
+ * all 8 route error files are thin wrappers around it.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const source = readFileSync(resolve(__dirname, "RouteErrorBoundary.tsx"), "utf-8");
+
+const ERROR_FILES: Record<string, { source: string; retryTracked: boolean }> = {
+  "../../app/error.tsx": { source: "global", retryTracked: true },
+  "../../app/shamwari/error.tsx": { source: "shamwari", retryTracked: true },
+  "../../app/history/error.tsx": { source: "history", retryTracked: true },
+  "../../app/[location]/error.tsx": { source: "location", retryTracked: true },
+  "../../app/aviation/error.tsx": { source: "aviation", retryTracked: true },
+  "../../app/explore/country/error.tsx": { source: "explore-country", retryTracked: false },
+  "../../app/explore/country/[code]/error.tsx": { source: "explore-country-detail", retryTracked: false },
+  "../../app/explore/country/[code]/[province]/error.tsx": { source: "explore-province-detail", retryTracked: false },
+};
+
+describe("RouteErrorBoundary — shared boundary body", () => {
+  it("owns the retry-tracking logic (sessionStorage cap via error-retry)", () => {
+    expect(source).toContain("getRetryCount");
+    expect(source).toContain("setRetryCount");
+    expect(source).toContain("clearRetryCount");
+    expect(source).toContain("MAX_RETRIES");
+  });
+
+  it("reports to analytics with the caller's source prefix, fatal only when retry-tracked", () => {
+    expect(source).toContain("reportErrorToAnalytics(`${source}:${error.message}`, retryTracking)");
+  });
+
+  it("renders the issue-report link only for retry-tracked boundaries", () => {
+    expect(source).toContain("buildIssueUrl");
+    expect(source).toContain("{retryTracking && (");
+  });
+
+  it("lightweight mode retries directly without touching the retry counter", () => {
+    expect(source).toMatch(/if \(!retryTracking\) \{\s*reset\(\);/);
+  });
+});
+
+describe("route error.tsx files — thin wrappers (issue #102)", () => {
+  for (const [file, meta] of Object.entries(ERROR_FILES)) {
+    it(`${file} wraps RouteErrorBoundary with source="${meta.source}"`, () => {
+      const src = readFileSync(resolve(__dirname, file), "utf-8");
+      expect(src).toContain("RouteErrorBoundary");
+      expect(src).toContain(`source="${meta.source}"`);
+      // No re-implemented boundary logic anywhere.
+      expect(src).not.toContain("getRetryCount");
+      expect(src).not.toContain("reportErrorToAnalytics");
+      expect(src).not.toContain("buildIssueUrl");
+      if (!meta.retryTracked) {
+        expect(src).toContain("retryTracking={false}");
+      } else {
+        expect(src).not.toContain("retryTracking={false}");
+      }
+    });
+  }
+
+  it("retry-tracked wrappers provide the exhausted-retries copy", () => {
+    for (const [file, meta] of Object.entries(ERROR_FILES)) {
+      if (!meta.retryTracked) continue;
+      const src = readFileSync(resolve(__dirname, file), "utf-8");
+      expect(src).toContain("exhaustedMessage");
+    }
+  });
+});

--- a/src/components/layout/RouteErrorBoundary.tsx
+++ b/src/components/layout/RouteErrorBoundary.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { reportErrorToAnalytics, buildIssueUrl } from "@/lib/observability";
+import { getRetryCount, setRetryCount, clearRetryCount, MAX_RETRIES } from "@/lib/error-retry";
+
+/** The props Next.js passes to every route-level error.tsx. */
+export interface RouteErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+interface RouteErrorBoundaryProps extends RouteErrorProps {
+  /** Heading, e.g. "Weather Unavailable" */
+  title: string;
+  /** Body copy for the first few failures */
+  message: string;
+  /** Body copy once retries are exhausted (used with retryTracking) */
+  exhaustedMessage?: string;
+  /** Analytics/observability source key, e.g. "location" — prefixes the GA4 exception and tags the GitHub issue */
+  source: string;
+  /** Human label used for the console log and the GitHub issue title, e.g. "Weather page error" */
+  label: string;
+  /**
+   * sessionStorage-tracked retry cap (max 3), fatal analytics flag, and the
+   * "Report this issue" link. On for full page boundaries (default); off for
+   * lightweight browse pages where a plain retry suffices.
+   */
+  retryTracking?: boolean;
+  /** Escape-hatch destination (default "/") */
+  homeHref?: string;
+  /** Escape-hatch label (default "Go home") */
+  homeLabel?: string;
+  /** Optional secondary links, e.g. "View historical data instead" */
+  extraLinks?: { label: string; href: string }[];
+}
+
+/**
+ * Shared route-level error boundary body. Every route error.tsx renders this
+ * with its own copy — previously each of the 8 files reimplemented the same
+ * retry-tracking logic, callbacks, and JSX shell line-for-line (issue #102).
+ */
+export function RouteErrorBoundary({
+  error,
+  reset,
+  title,
+  message,
+  exhaustedMessage,
+  source,
+  label,
+  retryTracking = true,
+  homeHref = "/",
+  homeLabel = "Go home",
+  extraLinks,
+}: RouteErrorBoundaryProps) {
+  const [exhausted, setExhausted] = useState(
+    () => retryTracking && getRetryCount() >= MAX_RETRIES,
+  );
+
+  useEffect(() => {
+    console.error(`${label}:`, error);
+    // Retry-tracked boundaries guard whole-page failures — report as fatal.
+    reportErrorToAnalytics(`${source}:${error.message}`, retryTracking);
+  }, [error, label, source, retryTracking]);
+
+  const handleRetry = () => {
+    if (!retryTracking) {
+      reset();
+      return;
+    }
+    const count = getRetryCount() + 1;
+    setRetryCount(count);
+
+    if (count >= MAX_RETRIES) {
+      setExhausted(true);
+      return;
+    }
+
+    reset();
+  };
+
+  const handleNavigate = () => {
+    if (retryTracking) clearRetryCount();
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+      <h1 className="font-heading text-4xl font-bold text-text-primary">{title}</h1>
+      <p className="mt-4 max-w-md text-center text-text-secondary">
+        {exhausted && exhaustedMessage ? exhaustedMessage : message}
+      </p>
+      <div className="mt-8 flex flex-col items-center gap-3">
+        {!exhausted && (
+          <Button size="lg" onClick={handleRetry}>
+            Try again
+          </Button>
+        )}
+        <Button variant="outline" size="lg" asChild>
+          <Link href={homeHref} onClick={handleNavigate}>
+            {homeLabel}
+          </Link>
+        </Button>
+        {extraLinks?.map((link) => (
+          <Button key={link.href} variant="link" asChild>
+            <Link href={link.href} onClick={handleNavigate}>
+              {link.label}
+            </Link>
+          </Button>
+        ))}
+        {retryTracking && (
+          <a
+            href={buildIssueUrl({
+              title: label,
+              source,
+              message: error.message,
+              page: typeof window !== "undefined" ? window.location.pathname : undefined,
+              digest: error.digest,
+            })}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 text-base text-text-tertiary underline hover:text-text-secondary transition-colors"
+          >
+            Report this issue
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `src/components/layout/RouteErrorBoundary.tsx` — the single body behind every route-level `error.tsx`. Five files (global, `[location]`, history, shamwari, aviation) previously reimplemented the identical sessionStorage retry-tracking logic (`getRetryCount`/`setRetryCount`/`clearRetryCount`/`MAX_RETRIES`), fatal analytics reporting, GitHub issue-report link, and JSX shell line-for-line; the three `explore/country` variants duplicated the same shell without retry tracking.
- Each `error.tsx` is now a thin wrapper supplying only its copy: title, message, exhausted-retries message, `source` (analytics key + issue tag), `label` (console + issue title), and optional home/extra links. The explore variants pass `retryTracking={false}` — plain retry, non-fatal analytics, no issue link — matching their previous behavior.
- Two small deliberate unifications: the `buildIssueUrl` `page` param now always uses `window.location.pathname` (shamwari/history previously hardcoded their route — same value in practice), and the explore variants' headings move from `text-3xl` to the standard `text-4xl`.

Purely mechanical otherwise — same behavior, same retry semantics.

Fixes #102.

## Test plan
- [x] New `RouteErrorBoundary.test.ts`: boundary logic exists once (retry tracking, analytics with source prefix, conditional issue link, lightweight-mode direct reset), all 8 wrappers verified (correct `source`, no reimplemented logic, `retryTracking={false}` on explore variants, exhausted copy on tracked ones)
- [x] Updated shamwari/aviation structural tests that asserted the old inline implementations
- [x] `npm test` — 1996 passed; `python -m pytest tests/py/` — 947 passed
- [x] `npm run lint` — 0 errors; `npx tsc --noEmit` — clean; `npm run build` — clean; prettier (CLAUDE.md) — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_