### PR TITLE
Extend shared quick-search hook to HistoryDashboard and AviationPlanner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ mukoko-weather/
 │   │   ├── error-retry.test.ts
 │   │   ├── use-debounce.ts         # Shared useDebounce hook (generic, reusable across components)
 │   │   ├── use-debounce.test.ts
-│   │   ├── use-location-quick-search.ts      # Shared debounced /api/py/search hook (MyWeatherModal + ExploreSearch)
+│   │   ├── use-location-quick-search.ts      # Shared debounced /api/py/search hook (MyWeatherModal, ExploreSearch, HistoryDashboard, AviationPlanner)
 │   │   ├── use-location-quick-search.test.ts
 │   │   ├── utils.ts               # Tailwind class merging helper (cn) + getScrollBehavior (reduced-motion-aware scrolling)
 │   │   ├── utils.test.ts
@@ -1314,7 +1314,7 @@ _Library tests:_
 - `src/lib/accessibility.test.ts` — accessibility helpers
 - `src/lib/seed-ai-prompts.test.ts` — AI prompt/rule uniqueness, LOCATION DISCOVERY guardrails presence, structural integrity
 - `src/lib/use-debounce.test.ts` — useDebounce hook structure, exports, generic typing
-- `src/lib/use-location-quick-search.test.ts` — shared quick-search hook: debounce/limit defaults, cancellation, reset, deferred setState
+- `src/lib/use-location-quick-search.test.ts` — shared quick-search hook: debounce/limit/minLength defaults, cancellation, reset, error flag, deferred setState, all four consumer surfaces
 - `src/lib/weather-scenes/cache.test.ts` — weather hint cache (set/get, 2h TTL expiry, LRU eviction early-exit, localStorage cleanup)
 - `src/lib/weather-scenes/create-scene.test.ts` — scene factory (exports, dispose, scene types, fallback, cleanup)
 - `src/lib/weather-scenes/resolve-scene.test.ts` — weather code → scene type mapping (WMO codes, day/night, edge cases)

--- a/src/app/aviation/AviationPlanner.tsx
+++ b/src/app/aviation/AviationPlanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import { useDebounce } from "@/lib/use-debounce";
+import { useLocationQuickSearch } from "@/lib/use-location-quick-search";
 import { getIcaoForSlug, getAirportByIcao } from "@/lib/icao-codes";
 import { SearchIcon, MapPinIcon, NavigationIcon } from "@/lib/weather-icons";
 import { getFlightCategoryClass } from "@/lib/flight-category-styles";
@@ -26,7 +26,7 @@ function cloudsStr(obs: MetarObs): string {
   return obs.clouds.map((c) => `${c.cover} ${c.base_ft}ft`).join(", ");
 }
 
-interface LocationResult { slug: string; name: string; province: string; country?: string }
+interface LocationResult { slug: string; name: string; province?: string; country?: string }
 
 function AirportSearch({
   label,
@@ -37,45 +37,17 @@ function AirportSearch({
   value: LocationResult | null;
   onChange: (loc: LocationResult | null) => void;
 }) {
-  const [query, setQuery] = useState(value?.name ?? "");
-  const [results, setResults] = useState<LocationResult[]>([]);
-  const [loading, setLoading] = useState(false);
+  // Shared debounced /api/py/search hook — same debounce, AbortController
+  // cancellation, and error surfacing as every other quick location search
+  // (issue #103). minLength 2 preserves this picker's previous behavior.
+  const { query, setQuery, results, loading, error: searchFailed, reset } =
+    useLocationQuickSearch({ limit: 8, minLength: 2 });
   const [open, setOpen] = useState(false);
-  const [searchError, setSearchError] = useState<string | null>(null);
-  const debounced = useDebounce(query, 300);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const search = useCallback(async (q: string) => {
-    if (q.trim().length < 2) { setResults([]); return; }
-    setLoading(true);
-    setSearchError(null);
-    try {
-      const res = await fetch(`/api/py/search?q=${encodeURIComponent(q)}&limit=8`);
-      if (res.ok) {
-        const data = await res.json();
-        setResults((data.locations ?? []).map((l: { slug: string; name: string; province: string; country?: string }) => ({
-          slug: l.slug, name: l.name, province: l.province, country: l.country,
-        })));
-      } else {
-        setResults([]);
-        setSearchError("Airport search failed. Please try again.");
-      }
-    } catch {
-      // A network failure here previously escaped as an unhandled rejection and
-      // left the spinner stuck — surface it and clear the loading state instead.
-      setResults([]);
-      setSearchError("Airport search failed. Check your connection and try again.");
-    } finally { setLoading(false); }
-  }, []);
-
-  // Trigger search on debounced value (must be useEffect to re-fire as user types)
-  useEffect(() => {
-    if (debounced.trim().length < 2) {
-      setResults([]);
-      return;
-    }
-    if (debounced !== (value?.name ?? "")) search(debounced);
-  }, [debounced, value, search]);
+  const searchError = searchFailed
+    ? "Airport search failed. Check your connection and try again."
+    : null;
 
   const icaoForResult = (r: LocationResult) => getIcaoForSlug(r.slug);
 
@@ -83,10 +55,9 @@ function AirportSearch({
     onChange(r);
     setQuery(r.name);
     setOpen(false);
-    setResults([]);
   };
 
-  const clear = () => { onChange(null); setQuery(""); setResults([]); setSearchError(null); };
+  const clear = () => { onChange(null); reset(); };
 
   return (
     <div ref={containerRef} className="relative">

--- a/src/app/aviation/aviation.test.ts
+++ b/src/app/aviation/aviation.test.ts
@@ -61,11 +61,12 @@ describe("AviationPlanner — Harare-bug fixes", () => {
     expect(plannerSrc).not.toContain("d.weather?.daily");
   });
 
-  it("catches airport-search failures so the spinner never sticks", () => {
-    expect(plannerSrc).toContain("catch");
+  it("surfaces airport-search failures via the shared quick-search hook", () => {
+    // Fetch failures, cancellation, and the loading flag are handled inside
+    // useLocationQuickSearch (which clears loading in finally); this picker
+    // only maps the hook's error flag to its message.
+    expect(plannerSrc).toContain("useLocationQuickSearch({ limit: 8, minLength: 2 })");
     expect(plannerSrc).toContain("searchError");
-    // The search callback must clear loading in finally after catching.
-    expect(plannerSrc).toContain("finally { setLoading(false); }");
   });
 });
 

--- a/src/app/history/HistoryDashboard.tsx
+++ b/src/app/history/HistoryDashboard.tsx
@@ -18,7 +18,6 @@ import { ThunderstormChart } from "@/components/weather/charts/ThunderstormChart
 import { GDDChart } from "@/components/weather/charts/GDDChart";
 import { ChartSkeleton } from "@/components/ui/skeleton";
 import { HistoryAnalysis } from "@/components/weather/HistoryAnalysis";
-import type { WeatherLocation } from "@/lib/locations";
 import { useAppStore } from "@/lib/store";
 import { weatherCodeToInfo, windDirection, uvLevel } from "@/lib/weather";
 import type { WeatherInsights } from "@/lib/weather";
@@ -31,6 +30,7 @@ import {
   uvConcernLabel,
 } from "@/components/weather/ActivityInsights";
 import { Spinner } from "@/components/ui/spinner";
+import { useLocationQuickSearch } from "@/lib/use-location-quick-search";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -38,6 +38,10 @@ import { Spinner } from "@/components/ui/spinner";
 
 type DayRange = 7 | 14 | 30 | 90 | 180 | 365;
 type ViewTab = "weather" | "insights";
+
+/** The slice of a location this dashboard needs — satisfied by both the
+ *  quick-search results and the full location doc from /api/py/locations. */
+type SelectedHistoryLocation = { slug: string; name: string; province?: string };
 
 interface HistoryRecord {
   date: string;
@@ -367,8 +371,12 @@ export function suitabilityColors(level: "excellent" | "good" | "fair" | "poor")
 
 export function HistoryDashboard() {
   const globalSlug = useAppStore((s) => s.selectedLocation);
-  const [query, setQuery] = useState("");
-  const [selectedLocation, setSelectedLocation] = useState<WeatherLocation | null>(null);
+  // Shared debounced /api/py/search hook — same debounce + AbortController
+  // cancellation as every other quick location search in the app. Replaces a
+  // hand-rolled setTimeout debounce with NO cancellation, where a fast retype
+  // could let a stale slower response overwrite newer results (issue #103).
+  const { query, setQuery, results: quickResults, loading: searchLoading } = useLocationQuickSearch();
+  const [selectedLocation, setSelectedLocation] = useState<SelectedHistoryLocation | null>(null);
   const [days, setDays] = useState<DayRange>(30);
   const [records, setRecords] = useState<HistoryRecord[]>([]);
   const [insightsRecords, setInsightsRecords] = useState<InsightsRecord[]>([]);
@@ -380,13 +388,9 @@ export function HistoryDashboard() {
   const [activeTab, setActiveTab] = useState<ViewTab>("weather");
   const [categoryFilter, setCategoryFilter] = useState<ActivityCategory | "all">("all");
   const tableEndRef = useRef<HTMLDivElement>(null);
-  // Search-driven location results (replaces loading all locations)
-  const [searchResults, setSearchResults] = useState<WeatherLocation[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
   // Seed with static CATEGORIES for instant filter rendering, then upgrade from MongoDB.
   const [activityCategories, setActivityCategories] = useState<ActivityCategoryDoc[]>(CATEGORIES);
   const didAutoSelect = useRef(false);
-  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Build category filter options and styles from API data
   const categoryFilterOptions = useMemo(() => {
@@ -453,29 +457,10 @@ export function HistoryDashboard() {
       .finally(() => setLoading(false));
   }, [globalSlug]);
 
-  // Debounced search — fetch results from API instead of filtering a full list
-  useEffect(() => {
-    if (searchTimer.current) clearTimeout(searchTimer.current);
-
-    const q = query.trim();
-    if (!q || selectedLocation?.name === query) {
-      setSearchResults([]);
-      return;
-    }
-
-    searchTimer.current = setTimeout(() => {
-      setSearchLoading(true);
-      fetch(`/api/py/search?q=${encodeURIComponent(q)}&limit=10`)
-        .then((res) => (res.ok ? res.json() : null))
-        .then((data) => setSearchResults(data?.locations ?? []))
-        .catch(() => setSearchResults([]))
-        .finally(() => setSearchLoading(false));
-    }, 250);
-
-    return () => { if (searchTimer.current) clearTimeout(searchTimer.current); };
-  }, [query, selectedLocation?.name]);
-
-  const results = searchResults;
+  // Hide quick matches when the input just shows the picked location's name
+  // (the hook still fetched for it, but re-opening the dropdown for the
+  // selection you just made is noise, matching the previous behavior).
+  const results = selectedLocation?.name === query ? [] : quickResults;
 
   // ── Infinite scroll for table rows (TikTok-style) ───────────────────────
   useEffect(() => {
@@ -497,7 +482,7 @@ export function HistoryDashboard() {
   }, [records.length, visibleRowCount]);
 
   const fetchHistory = useCallback(
-    async (location: WeatherLocation, dayCount: DayRange) => {
+    async (location: SelectedHistoryLocation, dayCount: DayRange) => {
       setLoading(true);
       setError(null);
       setFetched(true);
@@ -522,7 +507,7 @@ export function HistoryDashboard() {
     [],
   );
 
-  const handleSelectLocation = (loc: WeatherLocation) => {
+  const handleSelectLocation = (loc: SelectedHistoryLocation) => {
     setSelectedLocation(loc);
     setQuery(loc.name);
     setShowDropdown(false);

--- a/src/lib/use-location-quick-search.test.ts
+++ b/src/lib/use-location-quick-search.test.ts
@@ -55,12 +55,13 @@ describe("useLocationQuickSearch — module structure", () => {
   });
 
   it("clears results for an empty query without a network request", () => {
-    expect(source).toContain("if (!q) {");
+    expect(source).toContain("if (!q || q.length < minLength) {");
     expect(source).toContain("setResults([])");
   });
 
   it("defers the empty-query clear via requestAnimationFrame (avoids sync setState in effect)", () => {
-    expect(source).toContain("requestAnimationFrame(() => setResults([]))");
+    expect(source).toContain("const raf = requestAnimationFrame(() => {");
+    expect(source).toContain("setResults([]);");
     expect(source).toContain("cancelAnimationFrame(raf)");
   });
 
@@ -69,5 +70,31 @@ describe("useLocationQuickSearch — module structure", () => {
     // guarding a fetch — trips the same lint rule as the empty-query case.
     expect(source).toContain("const raf = requestAnimationFrame(() => {");
     expect(source).toContain("setLoading(true);");
+  });
+});
+
+describe("useLocationQuickSearch — minLength + error surfacing (issue #103)", () => {
+  it("supports a minLength option so short queries never fire a request", () => {
+    expect(source).toContain("minLength = 1");
+    expect(source).toContain("q.length < minLength");
+  });
+
+  it("exposes an error flag: set on failure, cleared on success/empty/reset", () => {
+    expect(source).toContain("error: boolean");
+    expect(source).toContain("setError(true)");
+    // Cleared in the empty-query branch, on success, and in reset().
+    expect(source.split("setError(false)").length - 1).toBeGreaterThanOrEqual(3);
+  });
+
+  it("backs HistoryDashboard and AviationPlanner (no hand-rolled search remains)", () => {
+    const history = readFileSync(resolve(__dirname, "../app/history/HistoryDashboard.tsx"), "utf-8");
+    const aviation = readFileSync(resolve(__dirname, "../app/aviation/AviationPlanner.tsx"), "utf-8");
+    for (const src of [history, aviation]) {
+      expect(src).toContain("useLocationQuickSearch");
+      expect(src).not.toContain("/api/py/search?q=");
+    }
+    // The old HistoryDashboard debounce had no AbortController — a stale slow
+    // response could overwrite newer results. The hook owns cancellation now.
+    expect(history).not.toContain("searchTimer");
   });
 });

--- a/src/lib/use-location-quick-search.ts
+++ b/src/lib/use-location-quick-search.ts
@@ -15,6 +15,8 @@ export interface UseLocationQuickSearchOptions {
   debounceMs?: number;
   /** Max results requested from /api/py/search. Default 10. */
   limit?: number;
+  /** Minimum trimmed query length before a request fires. Default 1. */
+  minLength?: number;
 }
 
 export interface UseLocationQuickSearchResult {
@@ -22,6 +24,13 @@ export interface UseLocationQuickSearchResult {
   setQuery: (query: string) => void;
   results: QuickSearchLocation[];
   loading: boolean;
+  /**
+   * True when the most recent search request failed (network error or non-OK
+   * response). Cleared on the next successful search, empty query, or reset.
+   * Callers that surface search failures (e.g. the aviation airport picker)
+   * read this; others can ignore it.
+   */
+  error: boolean;
   /**
    * Synchronously clears both query and results — for "done with this
    * search" moments (a result was picked, or the user cancelled). Clearing
@@ -45,19 +54,24 @@ export interface UseLocationQuickSearchResult {
 export function useLocationQuickSearch({
   debounceMs = 300,
   limit = 10,
+  minLength = 1,
 }: UseLocationQuickSearchOptions = {}): UseLocationQuickSearchResult {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<QuickSearchLocation[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
   const debouncedQuery = useDebounce(query, debounceMs);
 
   useEffect(() => {
     const q = debouncedQuery.trim();
-    if (!q) {
+    if (!q || q.length < minLength) {
       // Deferred via rAF — calling setState synchronously in an effect body
       // trips react-hooks/set-state-in-effect (same pattern used elsewhere,
       // e.g. HomeLanding's auto-GPS effect).
-      const raf = requestAnimationFrame(() => setResults([]));
+      const raf = requestAnimationFrame(() => {
+        setResults([]);
+        setError(false);
+      });
       return () => cancelAnimationFrame(raf);
     }
 
@@ -70,12 +84,19 @@ export function useLocationQuickSearch({
       if (disposed) return;
       setLoading(true);
       fetch(`/api/py/search?q=${encodeURIComponent(q)}&limit=${limit}`, { signal: controller.signal })
-        .then((res) => (res.ok ? res.json() : null))
-        .then((data) => {
-          if (!disposed) setResults(data?.locations ?? []);
+        .then(async (res) => {
+          if (!res.ok) throw new Error(`Search failed (${res.status})`);
+          const data = await res.json();
+          if (!disposed) {
+            setResults(data?.locations ?? []);
+            setError(false);
+          }
         })
         .catch(() => {
-          if (!disposed && !controller.signal.aborted) setResults([]);
+          if (!disposed && !controller.signal.aborted) {
+            setResults([]);
+            setError(true);
+          }
         })
         .finally(() => {
           if (!disposed && !controller.signal.aborted) setLoading(false);
@@ -87,12 +108,13 @@ export function useLocationQuickSearch({
       controller.abort();
       cancelAnimationFrame(raf);
     };
-  }, [debouncedQuery, limit]);
+  }, [debouncedQuery, limit, minLength]);
 
   const reset = useCallback(() => {
     setQuery("");
     setResults([]);
+    setError(false);
   }, []);
 
-  return { query, setQuery, results, loading, reset };
+  return { query, setQuery, results, loading, error, reset };
 }


### PR DESCRIPTION
## Summary
- **HistoryDashboard** — replaced the hand-rolled `setTimeout` debounce with `useLocationQuickSearch`. The old implementation had **no `AbortController`**, so a fast retype could let a stale, slower response resolve after a newer one and overwrite the dropdown with outdated results — that race is fixed by construction now. The "don't reopen the dropdown for the location you just picked" behavior is preserved via a display-side guard. The selection state is typed by what the dashboard actually uses (`{slug, name, province?}`), satisfied by both quick-search results and the full location doc.
- **AviationPlanner (`AirportSearch`)** — migrated its separate hand-rolled implementation to the same hook. To do that without behavior loss, the hook gains two additive options/fields: `minLength` (the airport picker only searches from 2 characters) and an `error` flag (the picker surfaces search failures with an inline message — previously local state). Existing consumers are unaffected.

All four quick-search surfaces (MyWeatherModal, ExploreSearch, HistoryDashboard, AviationPlanner) now share one debounce/cancellation/result-shape implementation.

Fixes #103.

## Test plan
- [x] New hook tests: `minLength` gating, error flag set/cleared paths, both migrated consumers use the hook with no hand-rolled `/api/py/search` fetch or `searchTimer` remaining
- [x] Updated structural tests that asserted the old implementations (aviation's `finally { setLoading(false) }`, hook's empty-query branch shape)
- [x] `npm test` — 2005 passed; `python -m pytest tests/py/` — 957 passed
- [x] `npm run lint` — 0 errors; `npx tsc --noEmit` — clean; `npm run build` — clean; prettier (CLAUDE.md) — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_