### PR TITLE
Restore left-aligned header wordmark on mobile

### DIFF
--- a/src/components/layout/Header.test.ts
+++ b/src/components/layout/Header.test.ts
@@ -103,3 +103,12 @@ describe("Header — notifications popover accessibility (issue #95)", () => {
     expect(source).toContain('document.removeEventListener("keydown", handleKeydown)');
   });
 });
+
+describe("Header — wordmark alignment", () => {
+  it("keeps the brand mark left-aligned at every breakpoint (no mx-auto centering)", () => {
+    // The mobile-centered "Netflix-style" treatment regressed the original
+    // left-aligned wordmark — the logo link must not center itself.
+    expect(source).not.toContain('className="mx-auto sm:mx-0 flex items-center"');
+    expect(source).toContain('aria-label="mukoko weather — return to home page"');
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -110,12 +110,13 @@ export function Header() {
         role="banner"
       >
         <nav aria-label="Primary navigation" className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-4 py-2.5 sm:px-6 md:px-8">
-          {/* Brand mark — icon + "weather" (Netflix-style icon recognition) */}
-          <div className="flex flex-1 min-w-0 items-center sm:flex-none">
+          {/* Brand mark — left-aligned at every breakpoint (the parent nav's
+              justify-between keeps the action pill on the right) */}
+          <div className="flex min-w-0 items-center">
             <Link
               href="/"
               aria-label="mukoko weather — return to home page"
-              className="mx-auto sm:mx-0 flex items-center"
+              className="flex items-center"
             >
               <MukokoLogo />
             </Link>


### PR DESCRIPTION
## Summary
The header restructure centered the brand mark on small screens (`mx-auto sm:mx-0` on the logo link). The wordmark should sit left at every breakpoint as it originally did — the parent nav's `justify-between` already keeps the action pill on the right, so the fix is dropping the centering classes (and the `flex-1`/`sm:flex-none` growth that only existed to give `mx-auto` room).

## Test plan
- [x] New structural test: the logo link no longer carries the mobile-centering classes
- [x] `npm test` — 2000 passed; `npx tsc --noEmit` — clean; `npm run lint` — 0 errors; `python -m pytest tests/py/` — 969 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_