### PR TITLE
Add My Location GPS action to the mobile bottom nav centre slot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1070,13 +1070,14 @@ The header also renders `WeatherReportModal` (lazy-loaded, only mounts when `rep
 
 The header takes no props — location context comes from the URL path.
 
-**Mobile Bottom Navigation** (visible `sm:hidden`): Fixed bottom nav with 4 always-on items, plus a 5th (Shamwari) gated behind `FLAGS.shamwari_chat` (currently paused, see Feature Flags):
+**Mobile Bottom Navigation** (visible `sm:hidden`): Fixed floating-pill bottom nav with 5 always-on items, plus a 6th (Shamwari) gated behind `FLAGS.shamwari_chat` (currently paused, see Feature Flags):
 
 1. **Weather** (home icon) → `/`
 2. **Explore** (compass icon) → `/explore`
-3. **Shamwari** (sparkles icon) → `/shamwari` — center position when the flag is on; hidden entirely while paused
-4. **History** (clock icon) → `/history`
-5. **My Weather** (map-pin button) → opens modal
+3. **Shamwari** (sparkles icon) → `/shamwari` — hidden entirely while paused
+4. **My Location** (navigation-arrow button, centre slot) — GPS action, not a route: runs the shared `detectUserLocation({ autoCreate: true })` flow (via deferred `import("@/lib/geolocation")` so the header bundle stays lean), then navigates to the detected location and syncs `selectedLocation`. Shows a `Spinner` while locating (double-tap guarded, `aria-busy`). On denial/unavailability/error it opens the My Weather modal instead — its Location tab has search plus a geolocation retry with proper error copy. Fires `geolocation_result` and, on success, `location_changed` (`method: "geolocation"`) analytics events
+5. **History** (clock icon) → `/history`
+6. **My Weather** (map-pin button) → opens modal
 
 **My Weather Modal** (`src/components/weather/MyWeatherModal.tsx`): A centralized preferences modal (shadcn Dialog + Tabs) with three tabs:
 

--- a/src/components/layout/Header.test.ts
+++ b/src/components/layout/Header.test.ts
@@ -51,8 +51,8 @@ describe("Header — mobile nav floating pill", () => {
 });
 
 describe("Header — mobile nav preserved behaviour", () => {
-  it("keeps the 4 always-on nav items and their labels", () => {
-    for (const label of ["Weather", "Explore", "History", "My Weather"]) {
+  it("keeps the 5 always-on nav items and their labels", () => {
+    for (const label of ["Weather", "Explore", "My Location", "History", "My Weather"]) {
       expect(source).toContain(`>${label}</span>`);
     }
   });
@@ -82,6 +82,44 @@ describe("Header — mobile nav preserved behaviour", () => {
 
   it("keeps the Mobile navigation aria-label landmark", () => {
     expect(source).toContain('aria-label="Mobile navigation"');
+  });
+});
+
+describe("Header — My Location centre action", () => {
+  it("renders a My Location button with the navigation arrow icon", () => {
+    expect(source).toContain(">My Location</span>");
+    expect(source).toContain('aria-label="Use my current location"');
+    expect(source).toContain("<NavigationIcon size={22} />");
+  });
+
+  it("uses the shared geolocation flow with auto-create (same as My Weather modal)", () => {
+    // Deferred import keeps geolocation out of the initial header bundle
+    expect(source).toContain('await import("@/lib/geolocation")');
+    expect(source).toContain("detectUserLocation({ autoCreate: true })");
+  });
+
+  it("navigates to the detected location and syncs the store", () => {
+    expect(source).toContain("setSelectedLocation(result.location.slug)");
+    expect(source).toContain("router.push(`/${result.location.slug}`)");
+  });
+
+  it("falls back to the My Weather modal on denial or failure", () => {
+    // The modal's Location tab has search + a geolocation retry with error
+    // copy — the user is never stranded on a silent failure.
+    expect(source).toMatch(/} else \{\s*openMyWeather\(\);/);
+  });
+
+  it("shows a spinner and guards against double-taps while locating", () => {
+    expect(source).toContain("if (locating) return;");
+    expect(source).toContain("aria-busy={locating}");
+    expect(source).toContain("disabled={locating}");
+    expect(source).toContain("<Spinner");
+  });
+
+  it("tracks geolocation_result and location_changed analytics events", () => {
+    expect(source).toContain('trackEvent("geolocation_result"');
+    expect(source).toContain('trackEvent("location_changed"');
+    expect(source).toContain('method: "geolocation"');
   });
 });
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,12 +2,14 @@
 
 import { lazy, Suspense, useState, useEffect, useRef } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { MukokoLogo } from "@/components/brand/MukokoLogo";
-import { MapPinIcon, ClockIcon, SparklesIcon, LayersIcon, BellIcon, UserIcon } from "@/lib/weather-icons";
+import { MapPinIcon, ClockIcon, SparklesIcon, LayersIcon, BellIcon, UserIcon, NavigationIcon } from "@/lib/weather-icons";
+import { Spinner } from "@/components/ui/spinner";
 import { useAppStore } from "@/lib/store";
 import { isFeatureEnabled } from "@/lib/feature-flags";
+import { trackEvent } from "@/lib/analytics";
 import { initialsFor, type PublicUser } from "@/lib/user-display";
 
 // Code-split: MyWeatherModal imports LOCATIONS (154 items), ACTIVITIES (20 items),
@@ -47,9 +49,12 @@ export function Header() {
   const openMyWeather = useAppStore((s) => s.openMyWeather);
   const myWeatherOpen = useAppStore((s) => s.myWeatherOpen);
   const selectedLocation = useAppStore((s) => s.selectedLocation);
+  const setSelectedLocation = useAppStore((s) => s.setSelectedLocation);
   const reportModalOpen = useAppStore((s) => s.reportModalOpen);
   const pathname = usePathname();
+  const router = useRouter();
   const [isScrolled, setIsScrolled] = useState(false);
+  const [locating, setLocating] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
   const notificationsRef = useRef<HTMLDivElement>(null);
   const bellButtonRef = useRef<HTMLButtonElement>(null);
@@ -91,6 +96,39 @@ export function Header() {
       document.removeEventListener("keydown", handleKeydown);
     };
   }, [notificationsOpen]);
+
+  // Center mobile-nav action: jump straight to the weather for wherever the
+  // user is right now (same GPS → /api/py/geo flow as My Weather's "Use
+  // current location" button, autoCreate included). On denial or failure the
+  // My Weather modal opens instead — its Location tab has search plus a
+  // geolocation retry with proper error copy, so the user is never stranded.
+  const handleMyLocation = async () => {
+    if (locating) return;
+    setLocating(true);
+    try {
+      // Deferred import — keeps geolocation out of the initial header bundle
+      // (same reasoning as the lazy MyWeatherModal above).
+      const { detectUserLocation } = await import("@/lib/geolocation");
+      const result = await detectUserLocation({ autoCreate: true });
+      trackEvent("geolocation_result", {
+        status: result.status,
+        location: result.location?.slug,
+      });
+      if ((result.status === "success" || result.status === "created") && result.location) {
+        trackEvent("location_changed", {
+          from: selectedLocation,
+          to: result.location.slug,
+          method: "geolocation",
+        });
+        setSelectedLocation(result.location.slug);
+        router.push(`/${result.location.slug}`);
+      } else {
+        openMyWeather();
+      }
+    } finally {
+      setLocating(false);
+    }
+  };
 
   // Determine which mobile nav item is active based on pathname
   const isExplore = pathname === "/explore" || pathname.startsWith("/explore/");
@@ -226,7 +264,8 @@ export function Header() {
         </nav>
       </header>
 
-      {/* Mobile bottom navigation — floating glass pill, 4 items */}
+      {/* Mobile bottom navigation — floating glass pill, 5 items with the */}
+      {/* My Location GPS action in the centre slot. */}
       {/* (Shamwari paused as a standalone destination — see FLAGS.shamwari_chat) */}
       {/* Detached from the edges (floats above the safe-area) so mobile browser */}
       {/* chrome never obscures it; stays put on scroll because it's fixed. */}
@@ -276,6 +315,21 @@ export function Header() {
               {pathname === "/shamwari" && <span className="absolute bottom-1 h-0.5 w-5 rounded-full bg-primary" aria-hidden="true" />}
             </Link>
           )}
+          <button
+            onClick={handleMyLocation}
+            disabled={locating}
+            aria-busy={locating}
+            className="relative flex flex-col items-center justify-center gap-0.5 px-2 py-2 rounded-xl transition-all min-w-[var(--touch-target-min)] min-h-[var(--touch-target-min)] text-text-tertiary hover:text-text-secondary active:scale-95"
+            aria-label="Use my current location"
+            type="button"
+          >
+            {locating ? (
+              <Spinner className="h-[22px] w-[22px]" />
+            ) : (
+              <NavigationIcon size={22} />
+            )}
+            <span className="text-[10px] leading-tight font-medium truncate max-w-[56px]">My Location</span>
+          </button>
           <Link
             href="/history"
             prefetch={false}


### PR DESCRIPTION
## Summary

With Shamwari paused, the mobile bottom nav dropped to 4 items and the layout looked off-balance. This adds a 5th always-on **My Location** action in the centre slot — the location-arrow pattern from Apple/Google Weather.

- **Centre button** (`NavigationIcon`, label "My Location") between Explore and History. Not a route — a GPS action.
- Tapping runs the shared `detectUserLocation({ autoCreate: true })` flow — the exact same GPS → `/api/py/geo` path as My Weather's "Use current location" button, so the two entry points can't drift. The geolocation module is imported on demand (`await import("@/lib/geolocation")`) to keep the initial header bundle lean.
- On success: syncs `selectedLocation` in the store and navigates to `/{slug}`.
- On denial/unavailability/error: opens the My Weather modal — its Location tab has search plus a geolocation retry with proper `geo.denied`/`geo.error` copy, so the user is never silently stranded.
- While locating: shared `Spinner` replaces the icon, `aria-busy` set, double-taps guarded.
- Analytics: fires `geolocation_result` (all outcomes) and `location_changed` with `method: "geolocation"` (success only).

## Validation

- `npm test` — 2006 passed (new structural tests for the centre action in `Header.test.ts`)
- `python -m pytest tests/py/` — 969 passed
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean
- `npm run build` — compiles, all pages generated
- CLAUDE.md mobile-nav section updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW

---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_