### PR TITLE
Current location precedes saved; full-page weather backdrop; hourly outlook sentence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ mukoko-weather/
 │   ├── app/                          # Next.js App Router
 │   │   ├── layout.tsx                # Root layout, metadata, JSON-LD schemas
 │   │   ├── page.tsx                  # Home — server: resolves lastLocation cookie / IP-geo, hands off to HomeLanding
-│   │   ├── HomeLanding.tsx           # Client: GPS-first landing (auto-GPS first visit, silent travel recheck for returning visitors)
+│   │   ├── HomeLanding.tsx           # Client: GPS-first landing (auto-GPS first visit; returning visitors' redirect GATED on a current-location recheck — current location precedes saved)
 │   │   ├── HomeLanding.test.ts       # HomeLanding + page.tsx + proxy.ts tests (structure, travel recheck, edge routing)
 │   │   ├── globals.css               # Brand System v6 CSS custom properties
 │   │   ├── loading.tsx               # Root loading skeleton
@@ -211,7 +211,11 @@ mukoko-weather/
 │   │   │   ├── Breadcrumb.test.ts
 │   │   │   └── Footer.tsx            # Footer with site stats, copyright, links, Ubuntu philosophy
 │   │   ├── weather/
-│   │   │   ├── CurrentConditions.tsx  # Large temp display, feels-like, daily high/low
+│   │   │   ├── CurrentConditions.tsx  # De-carded hero: large temp display, feels-like, daily high/low — reads directly over WeatherBackdrop
+│   │   │   ├── WeatherBackdrop.tsx    # Fixed full-viewport condition-aware Three.js sky behind the whole location page (Apple Weather style)
+│   │   │   ├── WeatherBackdrop.test.ts
+│   │   │   ├── HourlyScrollCards.tsx  # Horizontal hour-by-hour strip + deterministic one-sentence outlook (hourly-summary.ts)
+│   │   │   ├── HourlyScrollCards.test.ts
 │   │   │   ├── HourlyForecast.tsx     # 24-hour hourly forecast
 │   │   │   ├── HourlyChart.tsx        # Canvas chart: temperature + rain over 24h
 │   │   │   ├── DailyForecast.tsx      # 7-day forecast cards
@@ -309,6 +313,8 @@ mukoko-weather/
 │   │   ├── suitability-cache.test.ts # Suitability cache tests
 │   │   ├── weather.ts             # Open-Meteo client, frost detection, weather utils, synthesizeOpenMeteoInsights
 │   │   ├── weather.test.ts
+│   │   ├── hourly-summary.ts      # Deterministic one-sentence hourly outlook (Apple-style, no AI): first condition-group change + peak gusts
+│   │   ├── hourly-summary.test.ts
 │   │   ├── weather-labels.ts      # Contextual label helpers (humidityLabel, pressureLabel, cloudLabel, feelsLikeContext)
 │   │   ├── weather-labels.test.ts
 │   │   ├── api-keys.ts            # Developer API keys — mk_live_ generation (CSPRNG), SHA-256 hashing, masking, owner-scoped CRUD in platform.apiKeys
@@ -556,7 +562,7 @@ All data handling, AI operations, database CRUD, and rule evaluation run in Pyth
 
 **Sub-route back-navigation:** `/[location]/atmosphere`, `/[location]/forecast`, and `/[location]/map` all render the shared `Breadcrumb` component (`src/components/layout/Breadcrumb.tsx` — `Home / {location.name} / {current page}`) instead of each hand-rolling its own trail. `/[location]/map` previously used a floating "← Back to weather" pill overlay on the map; it now uses the same breadcrumb bar as the other two sub-routes for a consistent back-navigation pattern across all three.
 
-- `/` — GPS-first landing via `HomeLanding` (see "HomeLanding (Smart Home Page)" below): first-time visitors get a full auto-GPS prompt; returning visitors see their cached location immediately with a silent background GPS recheck for travel detection
+- `/` — GPS-first landing via `HomeLanding` (see "HomeLanding (Smart Home Page)" below): first-time visitors get a full auto-GPS prompt; returning visitors see their cached location's countdown immediately, but the redirect is gated on a current-location GPS recheck — current location always takes precedence over the saved one
 - `/[location]` — dynamic weather pages — overview: current conditions, AI summary, activity insights, atmospheric metric cards
 - `/[location]/atmosphere` — 24-hour atmospheric detail charts (humidity, wind, pressure, UV) for a location
 - `/[location]/forecast` — hourly (24h) + daily (7-day) forecast charts + sunrise/sunset for a location
@@ -1169,10 +1175,10 @@ The home page (`/`) is a server/client split, designed around one hard constrain
 - `src/app/page.tsx` — server component. Resolves the `lastLocation` cookie to a real `WeatherLocation` via `getLocationFromDb()` (only trusts a slug that both looks valid AND actually resolves — an unresolvable/deleted slug falls through to fresh detection instead of looping). If resolved, passes it to `HomeLanding` as `detectedLocation` with `isReturningUser={true}`. Otherwise falls back to server-side IP geo (Vercel's `x-vercel-ip-latitude`/`longitude` headers, find-only, `autoCreate=false`) as a rough hint for first-time visitors.
 - `src/app/HomeLanding.tsx` — client component, GPS-first pipeline (mirrors Apple/Google Weather):
   1. **First-time visitor** (`isReturningUser` false, no prior local state) → auto-triggers full browser GPS on mount (`detectUserLocation({ autoCreate: true })`), showing "Finding your location…" while it runs. Success/created → redirect there. Denied/unavailable/error → fall back to the IP-geo countdown if present, else the city chooser. A one-time `mukoko-gps-autoprompted` localStorage flag (independent of Zustand) ensures this only ever runs once per visitor.
-  2. **Returning visitor** (cached `lastLocation`) → shows that location's "Taking you to {city}…" countdown **immediately**, no wait. Concurrently, a **silent travel recheck** runs in the background: a fast-timeout (3s), cache-friendly (5 min `maximumAge`) GPS check via the same `detectUserLocation()`, now accepting optional `timeoutMs`/`maximumAgeMs` overrides. If it resolves to a _different_ location before the countdown fires, the redirect target swaps to the new city — the traveling case. GPS denial, failure, timeout, or a match with the cached location leaves the countdown completely untouched, so the common (non-traveling) case has zero added latency or friction.
+  2. **Returning visitor** (cached `lastLocation`) → shows that location's "Taking you to {city}…" countdown **immediately** — but the redirect is **gated on a current-location recheck settling** (`recheckSettled`): **current location takes precedence over saved locations** (the Apple Weather rule), so the cached city can never win a race against a GPS check that is still running. The recheck is a fast-timeout (4s), cache-friendly (5 min `maximumAge`) GPS check via `detectUserLocation()`; an absolute 8s settle cap (`RECHECK_SETTLE_CAP_MS`) guarantees the redirect never hangs. GPS resolving somewhere new swaps the redirect target; when the nearest KNOWN location is > 25 km from the fix (`FAR_NEAREST_KM` — rural travel), a create-on-demand lookup (`autoCreate: true`) resolves the user's actual place instead of a far-away catalog entry. Denial/failure/timeout lets the cached location proceed.
   3. "Use my current location" button / "Browse all locations" link — unchanged manual escape hatches.
 
-**Why this fixes the "stuck on my home city while traveling" bug:** previously, both the edge middleware and the server page instantly redirected any returning visitor straight to their cached `lastLocation` cookie, and the client-side auto-GPS effect explicitly skipped re-running for anyone who'd already onboarded — so GPS was only ever consulted on a visitor's very first-ever visit. A user who onboarded in Harare and later opened the app in Cape Town would land straight back on Harare's weather. The silent recheck above restores GPS as the authority on every app open, without sacrificing the instant feel of the common case.
+**Why this fixes the "stuck on my home city while traveling" bug:** previously, both the edge middleware and the server page instantly redirected any returning visitor straight to their cached `lastLocation` cookie, and the client-side auto-GPS effect explicitly skipped re-running for anyone who'd already onboarded — so GPS was only ever consulted on a visitor's very first-ever visit. A user who onboarded in Harare and later opened the app in Cape Town would land straight back on Harare's weather. The gated recheck above makes GPS the authority on every app open — the redirect waits for it to settle rather than racing it.
 
 ### Lazy Loading & Mobile Performance (TikTok-Style)
 
@@ -1397,7 +1403,7 @@ _Python backend tests (pytest):_
 _Page/component tests:_
 
 - `src/app/seo.test.ts` — metadata generation, schema validation, canonical URL coverage (layout bleed guard, per-page canonical presence)
-- `src/app/HomeLanding.test.ts` — HomeLanding structure, auto-GPS on first visit, silent travel recheck for returning visitors, page.tsx server logic, proxy.ts edge routing
+- `src/app/HomeLanding.test.ts` — HomeLanding structure, auto-GPS on first visit, gated current-location recheck (settle cap, far-nearest escalation), page.tsx server logic, proxy.ts edge routing
 - `src/app/explore/explore.test.ts` — explore page tests (browse-only, Shamwari CTA link)
 - `src/app/shamwari/shamwari.test.ts` — Shamwari page structure, full-viewport layout, loading skeleton
 - `src/app/[location]/FrostAlertBanner.test.ts` — banner rendering, severity styling

--- a/src/app/HomeLanding.test.ts
+++ b/src/app/HomeLanding.test.ts
@@ -132,10 +132,25 @@ describe("HomeLanding — silent travel recheck for returning visitors", () => {
     expect(source).toContain("setEffectiveLocation(result.location)");
   });
 
-  it("never blocks or delays the visible countdown — failures are silent", () => {
-    // The recheck's .catch() is a no-op: GPS denial/failure/timeout must
-    // leave the cached-location countdown completely untouched.
-    expect(source).toContain(".catch(() => {");
+  it("gates the redirect on the recheck settling — current location takes precedence", () => {
+    expect(source).toContain("recheckSettled");
+    expect(source).toContain("!recheckSettled) return;");
+    expect(source).toContain("RECHECK_SETTLE_CAP_MS");
+    expect(source).toContain("setRecheckSettled(true)");
+  });
+
+  it("escalates to create-on-demand when the nearest known location is far", () => {
+    expect(source).toContain("FAR_NEAREST_KM");
+    expect(source).toContain("result.distanceKm != null && result.distanceKm > FAR_NEAREST_KM");
+    expect(source).toContain("detectUserLocation({ autoCreate: true })");
+  });
+
+  it("failures leave the cached-location countdown untouched but still open the gate", () => {
+    // GPS denial/failure/timeout must leave the cached-location countdown
+    // target untouched — and the finally block must ALWAYS open the
+    // redirect gate so the flow can never hang.
+    expect(source).toContain("} finally {");
+    expect(source).toContain("if (!disposed) setRecheckSettled(true);");
   });
 
   it("uses effectiveLocation (not the raw prop) as the redirect/render target", () => {

--- a/src/app/HomeLanding.tsx
+++ b/src/app/HomeLanding.tsx
@@ -35,12 +35,23 @@ const REDIRECT_DELAY_MS = 2000;
  */
 const GPS_AUTOPROMPT_KEY = "mukoko-gps-autoprompted";
 
-// Silent travel recheck: a short timeout (never meaningfully delays the
-// visible countdown) paired with a generous cache window (a returning
-// visitor's device likely already has a recent-enough GPS fix), so this is
-// fast in the common case and never blocks the redirect if GPS is slow.
-const SILENT_RECHECK_TIMEOUT_MS = 3000;
+// Current-location recheck for returning visitors. CURRENT LOCATION TAKES
+// PRECEDENCE over the saved/cached one (the Apple Weather rule) — the
+// redirect WAITS for this check to settle instead of racing it, so a
+// traveling user can never be redirected to their old city just because
+// GPS took a moment. A short GPS timeout + generous cache window keep the
+// common case fast (a device usually has a recent fix), and the absolute
+// settle cap below guarantees the redirect never hangs on a slow stack.
+const SILENT_RECHECK_TIMEOUT_MS = 4000;
 const SILENT_RECHECK_MAX_AGE_MS = 300000;
+// Hard ceiling on how long the redirect can wait for the recheck (GPS +
+// geo API round-trip). Past this, the cached location wins — never hang.
+const RECHECK_SETTLE_CAP_MS = 8000;
+// When the find-only recheck's nearest KNOWN location is further than this,
+// the user's actual spot isn't represented in the catalog (rural travel) —
+// escalate to a create-on-demand lookup so they land on their real place,
+// not a far-away city that happens to be the nearest database entry.
+const FAR_NEAREST_KM = 25;
 
 /**
  * True when client-side state — independent of the server's lastLocation
@@ -69,11 +80,14 @@ function isKnownReturningVisitor(): boolean {
  *      • denied / unavailable / error → gracefully fall back to the IP-detected
  *        location countdown (if any), else the city chooser. Never hangs.
  * 2. Returning visitor (cached lastLocation) → show that location's "Taking
- *    you to [City]…" countdown immediately (no wait), while a SILENT,
- *    fast-timeout GPS recheck races in the background. If it resolves to a
- *    *different* location before the countdown fires — the traveling case —
- *    the redirect target swaps to the new city. GPS denial/failure/timeout,
- *    or a match with the cached location, leaves the countdown untouched.
+ *    you to [City]…" countdown immediately, while a fast, cache-friendly GPS
+ *    recheck runs. CURRENT LOCATION TAKES PRECEDENCE (the Apple Weather
+ *    rule): the redirect is GATED on the recheck settling — it cannot fire
+ *    while GPS is still deciding, so the cached city never wins a race. GPS
+ *    resolving somewhere new swaps the redirect target (with create-on-demand
+ *    escalation when the nearest known location is >25 km from the fix);
+ *    denial/failure/timeout (or the 8s settle cap) lets the cached location
+ *    proceed.
  * 3. IP geo detected (server-side, no prompt) with no cached location either:
  *    same countdown UI, used as the fallback for a first-time visitor whose
  *    GPS attempt failed.
@@ -92,6 +106,11 @@ export function HomeLanding({ detectedLocation, isReturningUser }: Props) {
   // `autoDetecting` is true while the first-visit auto-GPS attempt is in flight,
   // so we render the "Finding your location…" scene instead of the IP countdown.
   const [autoDetecting, setAutoDetecting] = useState(false);
+  // The redirect is GATED on the current-location recheck settling (success,
+  // denial, failure, or the settle cap) — current location takes precedence
+  // over the cached one, so the cached redirect must never win a race
+  // against a GPS check that's still running.
+  const [recheckSettled, setRecheckSettled] = useState(false);
 
   // ── Auto-GPS on first visit ──────────────────────────────────────────────
   useEffect(() => {
@@ -151,48 +170,80 @@ export function HomeLanding({ detectedLocation, isReturningUser }: Props) {
     };
   }, [router, detectedLocation, isReturningUser]);
 
-  // ── Silent travel recheck for returning visitors ─────────────────────────
+  // ── Current-location recheck for returning visitors ──────────────────────
   // Returning visitors skip the auto-GPS-prompt flow above and see their
-  // cached location's countdown immediately. This silently re-confirms via a
-  // fast, cache-friendly GPS check in the background — if the visitor has
-  // travelled somewhere new since their last visit, the redirect target
-  // swaps before the countdown fires. Compares against the original cached
+  // cached location's countdown immediately — but the REDIRECT waits for
+  // this check to settle (see `recheckSettled`): current location takes
+  // precedence over the saved one, always. If GPS resolves somewhere new,
+  // the redirect target swaps; only on denial/failure/timeout does the
+  // cached location win. When the nearest KNOWN location is far from the
+  // user's actual position (rural travel), a create-on-demand lookup
+  // resolves their real place instead. Compares against the original cached
   // `detectedLocation` (not `effectiveLocation`) so this only ever runs once
   // per mount, never re-triggering itself after it swaps the target.
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (!isReturningUser && !isKnownReturningVisitor()) return;
-    if (!detectedLocation) return;
+    if ((!isReturningUser && !isKnownReturningVisitor()) || !detectedLocation) {
+      // No recheck applies (first-time visitor, or nothing to redirect to) —
+      // open the redirect gate immediately. Deferred via rAF: setState
+      // synchronously in an effect body trips react-hooks/set-state-in-effect.
+      const raf = requestAnimationFrame(() => setRecheckSettled(true));
+      return () => cancelAnimationFrame(raf);
+    }
 
     let disposed = false;
-    detectUserLocation({
-      autoCreate: false,
-      timeoutMs: SILENT_RECHECK_TIMEOUT_MS,
-      maximumAgeMs: SILENT_RECHECK_MAX_AGE_MS,
-    })
-      .then((result) => {
+
+    // Absolute cap — whatever happens in the GPS/geo stack, the redirect
+    // gate opens by RECHECK_SETTLE_CAP_MS.
+    const settleCap = setTimeout(() => setRecheckSettled(true), RECHECK_SETTLE_CAP_MS);
+
+    void (async () => {
+      try {
+        const result = await detectUserLocation({
+          autoCreate: false,
+          timeoutMs: SILENT_RECHECK_TIMEOUT_MS,
+          maximumAgeMs: SILENT_RECHECK_MAX_AGE_MS,
+        });
         if (disposed) return;
-        if (
-          (result.status === "success" || result.status === "created") &&
-          result.location &&
-          result.location.slug !== detectedLocation.slug
-        ) {
-          setEffectiveLocation(result.location);
+        if ((result.status === "success" || result.status === "created") && result.location) {
+          if (result.distanceKm != null && result.distanceKm > FAR_NEAREST_KM) {
+            // Nearest catalog entry is far from the actual GPS position —
+            // create-on-demand resolves the user's real place (the browser
+            // already has a fresh fix, so this is a network hop, not a
+            // second GPS wait).
+            const precise = await detectUserLocation({ autoCreate: true });
+            if (disposed) return;
+            if ((precise.status === "success" || precise.status === "created") && precise.location) {
+              if (precise.location.slug !== detectedLocation.slug) setEffectiveLocation(precise.location);
+            } else if (result.location.slug !== detectedLocation.slug) {
+              setEffectiveLocation(result.location);
+            }
+          } else if (result.location.slug !== detectedLocation.slug) {
+            setEffectiveLocation(result.location);
+          }
         }
-      })
-      .catch(() => {
-        // Silent by design — GPS failure/denial/timeout leaves the cached
-        // location's countdown completely untouched.
-      });
+        // Denial/failure/timeout: cached location wins — nothing to swap.
+      } catch {
+        // Same: the cached location's countdown proceeds untouched.
+      } finally {
+        if (!disposed) setRecheckSettled(true);
+      }
+    })();
 
     return () => {
       disposed = true;
+      clearTimeout(settleCap);
     };
   }, [isReturningUser, detectedLocation]);
 
   // ── Location auto-redirect countdown (cached lastLocation or IP-geo) ──────
+  // For returning visitors the redirect additionally waits for the
+  // current-location recheck above (`recheckSettled`) — the countdown UI
+  // runs regardless, but navigation only fires once the recheck has had its
+  // say. First-time/IP-geo visitors have no recheck; their gate opens in
+  // the effect below.
   useEffect(() => {
-    if (!effectiveLocation || cancelled) return;
+    if (!effectiveLocation || cancelled || !recheckSettled) return;
 
     const redirectTimer = setTimeout(() => {
       router.replace(`/${effectiveLocation.slug}`);
@@ -206,7 +257,7 @@ export function HomeLanding({ detectedLocation, isReturningUser }: Props) {
       clearTimeout(redirectTimer);
       clearInterval(countdownInterval);
     };
-  }, [effectiveLocation, router, cancelled]);
+  }, [effectiveLocation, router, cancelled, recheckSettled]);
 
   const handleCancel = () => { setCancelled(true); };
 

--- a/src/app/[location]/WeatherDashboard.tsx
+++ b/src/app/[location]/WeatherDashboard.tsx
@@ -42,6 +42,7 @@ import { type Activity, ACTIVITIES } from "@/lib/activities";
 import { InfoRow } from "@/components/ui/info-row";
 import { SectionHeader } from "@/components/ui/section-header";
 import { SupportBanner } from "@/components/weather/SupportBanner";
+import { WeatherBackdrop } from "@/components/weather/WeatherBackdrop";
 import { DraggableSection } from "@/components/weather/DraggableSection";
 import { LiveClock } from "@/components/weather/LiveClock";
 import { getIcaoForSlug, getNearestIcao, getNearestIcaos, fetchNearestAirports, type AirportDistance } from "@/lib/icao-codes";
@@ -201,6 +202,15 @@ export function WeatherDashboard({
 
   return (
     <>
+      {/* Full-viewport condition-aware sky behind the whole page (Apple
+          Weather style) — strongest behind the de-carded hero at the top,
+          fading to the normal surface background further down. Fixed and
+          -z-10, so every card/section paints over it. */}
+      <WeatherBackdrop
+        weatherCode={weather.current.weather_code}
+        windSpeed={weather.current.wind_speed_10m}
+        isDay={weather.current.is_day === 1}
+      />
       <Header />
 
       {/* Breadcrumb navigation — always three layers: Country / Province / Location */}

--- a/src/components/weather/CurrentConditions.tsx
+++ b/src/components/weather/CurrentConditions.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from "react";
 import { WeatherIcon, ShareIcon } from "@/lib/weather-icons";
 import { weatherCodeToInfo, type CurrentWeather, type DailyWeather } from "@/lib/weather";
-import { HeroWeatherBackground } from "@/components/weather/HeroWeatherBackground";
 
 const BASE_URL = "https://weather.mukoko.com";
 
@@ -59,16 +58,12 @@ export function CurrentConditions({ current, locationName, daily, slug }: Props)
 
   return (
     <section aria-labelledby="current-conditions-heading">
-      {/* Hero card — the main current-conditions block sits at the very top of the
-          page and reads as the visual anchor: oversized temperature, extra padding.
-          It also hosts the condition-based animated background. */}
-      <div className="baobab relative isolate overflow-hidden p-5 sm:p-7">
-        {/* Condition-based animated background (decorative, self-isolating) */}
-        <HeroWeatherBackground
-          weatherCode={current.weather_code}
-          windSpeed={current.wind_speed_10m}
-          isDay={current.is_day === 1}
-        />
+      {/* Hero — the main current-conditions block sits at the very top of the
+          page as the visual anchor: oversized temperature, extra padding.
+          Deliberately NOT a card: it reads directly over the page-level
+          WeatherBackdrop sky (Apple Weather style) — the backdrop's scrim
+          keeps the text tokens readable. */}
+      <div className="relative p-5 sm:p-7">
         <h2 id="current-conditions-heading" className="sr-only">
           Current weather conditions in {locationName}
         </h2>

--- a/src/components/weather/HourlyScrollCards.test.ts
+++ b/src/components/weather/HourlyScrollCards.test.ts
@@ -92,3 +92,21 @@ describe("HourlyScrollCards — weather data", () => {
     expect(source).toContain("text-text-primary");
   });
 });
+
+describe("HourlyScrollCards — one-sentence outlook", () => {
+  it("renders the deterministic hourly summary above the strip", () => {
+    expect(source).toContain('from "@/lib/hourly-summary"');
+    expect(source).toContain("hourlySummary(hourly, start)");
+    expect(source).toContain("{summary}");
+  });
+
+  it("derives the summary from the same start index as the strip", () => {
+    // One `start` feeds both the sentence and the hour cards — they can
+    // never disagree about what "now" is.
+    expect(source).toMatch(/const summary = hydrated \? hourlySummary\(hourly, start\)/);
+  });
+
+  it("gates the summary on hydration (depends on the client wall clock)", () => {
+    expect(source).toContain("hydrated ? hourlySummary");
+  });
+});

--- a/src/components/weather/HourlyScrollCards.tsx
+++ b/src/components/weather/HourlyScrollCards.tsx
@@ -2,6 +2,7 @@
 
 import { WeatherIcon } from "@/lib/weather-icons";
 import { weatherCodeToInfo, type HourlyWeather } from "@/lib/weather";
+import { hourlySummary } from "@/lib/hourly-summary";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { useHydrated } from "@/lib/use-hydrated";
 
@@ -29,8 +30,18 @@ export function HourlyScrollCards({ hourly }: Props) {
   const start = startIndex >= 0 ? startIndex : 0;
   const hours = hourly.time.slice(start, start + 24);
 
+  // Deterministic one-sentence outlook (Apple Weather pattern) — derived from
+  // the same start index as the strip, no AI call. Hydration-gated like the
+  // strip itself: the sentence depends on the client's wall clock.
+  const summary = hydrated ? hourlySummary(hourly, start) : null;
+
   return (
     <div className="baobab overflow-hidden p-3">
+      {summary && (
+        <p className="border-b border-text-tertiary/10 px-1.5 pb-2.5 mb-1 text-base text-text-secondary leading-snug">
+          {summary}
+        </p>
+      )}
       <ScrollArea className="w-full" type="hover">
         <div className="flex gap-2.5 pb-2 [overscroll-behavior-x:contain]" role="list" aria-label="Hourly weather forecast">
           {hours.map((time, i) => {

--- a/src/components/weather/WeatherBackdrop.test.ts
+++ b/src/components/weather/WeatherBackdrop.test.ts
@@ -1,24 +1,25 @@
 /**
- * Tests for HeroWeatherBackground — validates the condition-based animated
- * background layer behind the CurrentConditions hero card. Source-based
- * structural testing (Vitest runs in Node without a DOM/WebGL context).
+ * Tests for WeatherBackdrop — validates the fixed, full-viewport
+ * condition-based animated sky behind the whole location page (Apple
+ * Weather style). Source-based structural testing (Vitest runs in Node
+ * without a DOM/WebGL context).
  */
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
 const source = readFileSync(
-  resolve(__dirname, "HeroWeatherBackground.tsx"),
+  resolve(__dirname, "WeatherBackdrop.tsx"),
   "utf-8",
 );
 
-describe("HeroWeatherBackground — component contract", () => {
+describe("WeatherBackdrop — component contract", () => {
   it("is a client component", () => {
     expect(source).toContain('"use client"');
   });
 
-  it("exports HeroWeatherBackground as a named function", () => {
-    expect(source).toContain("export function HeroWeatherBackground");
+  it("exports WeatherBackdrop as a named function", () => {
+    expect(source).toContain("export function WeatherBackdrop");
   });
 
   it("accepts weatherCode, windSpeed and isDay props", () => {
@@ -32,7 +33,7 @@ describe("HeroWeatherBackground — component contract", () => {
   });
 });
 
-describe("HeroWeatherBackground — performance discipline", () => {
+describe("WeatherBackdrop — performance discipline", () => {
   it("caps the renderer pixel ratio at 1", () => {
     expect(source).toContain("maxPixelRatio: 1");
   });
@@ -44,10 +45,17 @@ describe("HeroWeatherBackground — performance discipline", () => {
     expect(source).toContain("handle.resume()");
   });
 
-  it("pauses/resumes based on viewport intersection", () => {
-    expect(source).toContain("IntersectionObserver");
-    expect(source).toContain("isIntersecting");
-    expect(source).toContain("observer?.disconnect()");
+  it("is a fixed full-viewport backdrop behind all content (no IntersectionObserver needed)", () => {
+    expect(source).toContain('"pointer-events-none fixed inset-0 -z-10 overflow-hidden"');
+    // Always on-screen while the page is visible — tab visibility is the
+    // only pause signal, so no observer is constructed (the docstring may
+    // still mention the API by name when explaining why it's absent).
+    expect(source).not.toContain("new IntersectionObserver");
+  });
+
+  it("fades the sky into the surface background lower down the page", () => {
+    expect(source).toContain("from-transparent");
+    expect(source).toContain("to-surface-base");
   });
 
   it("disposes the scene on unmount", () => {
@@ -55,7 +63,7 @@ describe("HeroWeatherBackground — performance discipline", () => {
   });
 });
 
-describe("HeroWeatherBackground — reduced motion + resilience", () => {
+describe("WeatherBackdrop — reduced motion + resilience", () => {
   it("respects prefers-reduced-motion", () => {
     expect(source).toContain("prefers-reduced-motion: reduce");
   });
@@ -73,7 +81,7 @@ describe("HeroWeatherBackground — reduced motion + resilience", () => {
   });
 });
 
-describe("HeroWeatherBackground — accessibility + layout", () => {
+describe("WeatherBackdrop — accessibility + layout", () => {
   it("is decorative and hidden from assistive tech", () => {
     expect(source).toContain('aria-hidden="true"');
   });
@@ -93,7 +101,7 @@ describe("HeroWeatherBackground — accessibility + layout", () => {
   });
 });
 
-describe("HeroWeatherBackground — scene mapping", () => {
+describe("WeatherBackdrop — scene mapping", () => {
   const sceneClasses = [
     "weaver-sky-clear-day",
     "weaver-sky-clear-night",

--- a/src/components/weather/WeatherBackdrop.tsx
+++ b/src/components/weather/WeatherBackdrop.tsx
@@ -47,13 +47,18 @@ function skyClass(type: WeatherSceneType, isDay: boolean): string {
 }
 
 /**
- * Condition-aware animated background for the CurrentConditions hero card.
+ * Condition-aware animated backdrop for the WHOLE location page — a fixed,
+ * full-viewport sky behind all content (Apple Weather style), not confined
+ * to the hero card. The sky is strongest at the top (behind the de-carded
+ * CurrentConditions hero) and fades into the normal surface background
+ * further down so charts and cards keep their usual contrast.
  *
- * Performance discipline (the card stays mounted for the whole page life):
+ * Performance discipline (the backdrop stays mounted for the whole page life):
  * - Three.js renderer pixel ratio is capped at 1 (`maxPixelRatio`).
  * - The animation loop is PAUSED when the tab is hidden (`visibilitychange`)
- *   or the card scrolls off-screen (IntersectionObserver), and resumed when
- *   it returns — so the GPU idles whenever the hero is not visible.
+ *   and resumed when it returns — so the GPU idles in background tabs. (No
+ *   IntersectionObserver: a fixed, viewport-filling element is always
+ *   on-screen while the page is visible.)
  * - Everything is disposed on unmount.
  * - `prefers-reduced-motion` skips Three.js entirely and shows only the static
  *   mineral gradient.
@@ -62,7 +67,7 @@ function skyClass(type: WeatherSceneType, isDay: boolean): string {
  * the static gradient (createWeatherScene returns a no-op handle on failure),
  * and the whole card is additionally wrapped in ChartErrorBoundary upstream.
  */
-export function HeroWeatherBackground({ weatherCode, windSpeed, isDay = true }: Props) {
+export function WeatherBackdrop({ weatherCode, windSpeed, isDay = true }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Client-only media queries. Default to SSR-safe values, resolve on mount.
@@ -89,32 +94,20 @@ export function HeroWeatherBackground({ weatherCode, windSpeed, isDay = true }: 
 
     let disposed = false;
     let handle: WeatherSceneHandle | null = null;
-    let onScreen = true;
 
     const isVisible = () =>
       typeof document === "undefined" || document.visibilityState === "visible";
 
-    // Pause whenever hidden OR off-screen; resume only when both are true.
+    // A fixed, viewport-filling backdrop is always on-screen — the only
+    // pause signal that matters is tab visibility.
     const syncPlayback = () => {
       if (!handle) return;
-      if (onScreen && isVisible()) handle.resume();
+      if (isVisible()) handle.resume();
       else handle.pause();
     };
 
     const handleVisibility = () => syncPlayback();
     document.addEventListener("visibilitychange", handleVisibility);
-
-    let observer: IntersectionObserver | null = null;
-    if (typeof IntersectionObserver !== "undefined") {
-      observer = new IntersectionObserver(
-        (entries) => {
-          onScreen = entries[0]?.isIntersecting ?? true;
-          syncPlayback();
-        },
-        { threshold: 0 },
-      );
-      observer.observe(el);
-    }
 
     const config: WeatherSceneConfig = {
       type: sceneType,
@@ -141,7 +134,6 @@ export function HeroWeatherBackground({ weatherCode, windSpeed, isDay = true }: 
     return () => {
       disposed = true;
       document.removeEventListener("visibilitychange", handleVisibility);
-      observer?.disconnect();
       handle?.dispose();
     };
   }, [animate, isMobile, isDay, sceneType, windSpeed]);
@@ -149,7 +141,7 @@ export function HeroWeatherBackground({ weatherCode, windSpeed, isDay = true }: 
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none absolute inset-0 overflow-hidden rounded-[var(--radius-card)]"
+      className="pointer-events-none fixed inset-0 -z-10 overflow-hidden"
     >
       {/* Static mineral gradient — always painted; the reduced-motion fallback. */}
       <div className={`absolute inset-0 weaver-sky ${skyClass(sceneType, isDay)}`} />
@@ -157,6 +149,9 @@ export function HeroWeatherBackground({ weatherCode, windSpeed, isDay = true }: 
       {animate && <div ref={containerRef} className="absolute inset-0" />}
       {/* Readability scrim so hero text keeps contrast over the animation. */}
       <div className="absolute inset-0 weaver-scrim" />
+      {/* Fade the sky into the normal surface background further down the
+          page so cards, charts and body text keep their usual contrast. */}
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent from-25% via-surface-base/70 via-65% to-surface-base" />
     </div>
   );
 }

--- a/src/lib/hourly-summary.test.ts
+++ b/src/lib/hourly-summary.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  hourlySummary,
+  conditionGroup,
+  SUMMARY_LOOKAHEAD_HOURS,
+  GUST_MENTION_KMH,
+} from "./hourly-summary";
+import type { HourlyWeather } from "./weather";
+
+function makeHourly(codes: number[], gusts?: number[]): HourlyWeather {
+  const start = new Date();
+  start.setHours(8, 0, 0, 0); // deterministic hour labels
+  return {
+    time: codes.map((_, i) => new Date(start.getTime() + i * 3600_000).toISOString()),
+    weather_code: codes,
+    wind_gusts_10m: gusts ?? codes.map(() => 10),
+  } as unknown as HourlyWeather;
+}
+
+describe("conditionGroup", () => {
+  it("maps WMO codes to coarse groups", () => {
+    expect(conditionGroup(0)).toBe("clear");
+    expect(conditionGroup(2)).toBe("partly cloudy");
+    expect(conditionGroup(3)).toBe("cloudy");
+    expect(conditionGroup(45)).toBe("foggy");
+    expect(conditionGroup(53)).toBe("drizzly");
+    expect(conditionGroup(63)).toBe("rainy");
+    expect(conditionGroup(81)).toBe("rainy");
+    expect(conditionGroup(73)).toBe("snowy");
+    expect(conditionGroup(95)).toBe("stormy");
+  });
+});
+
+describe("hourlySummary", () => {
+  it("announces the first condition change with its hour", () => {
+    // clear now, rain arriving at index 3 (start hour 08:00 → 11:00)
+    const codes = [0, 0, 0, 63, 63, 63, 63, 63, 63, 63, 63, 63];
+    const summary = hourlySummary(makeHourly(codes), 0);
+    expect(summary).toContain("Rain expected around 11:00.");
+  });
+
+  it("reports continuation when nothing changes in the window", () => {
+    const codes = Array(14).fill(3);
+    const summary = hourlySummary(makeHourly(codes), 0);
+    expect(summary).toContain(`Cloudy conditions will continue for the next ${SUMMARY_LOOKAHEAD_HOURS} hours.`);
+  });
+
+  it("ignores fine-grained changes within the same group", () => {
+    // slight rain → moderate rain → heavy rain: all "rainy", no change reported
+    const codes = [61, 63, 65, 63, 61, 63, 65, 63, 61, 63, 65, 63];
+    const summary = hourlySummary(makeHourly(codes), 0);
+    expect(summary).toContain("will continue");
+  });
+
+  it("adds the gust clause when peak gusts reach the threshold", () => {
+    const codes = Array(12).fill(0);
+    const gusts = Array(12).fill(10);
+    gusts[4] = 26.4;
+    const summary = hourlySummary(makeHourly(codes, gusts), 0);
+    expect(summary).toContain("Wind gusts are up to 26 km/h.");
+  });
+
+  it("omits the gust clause below the threshold", () => {
+    const codes = Array(12).fill(0);
+    const gusts = Array(12).fill(GUST_MENTION_KMH - 1);
+    const summary = hourlySummary(makeHourly(codes, gusts), 0);
+    expect(summary).not.toContain("Wind gusts");
+  });
+
+  it("respects the start index (same slicing as the strip)", () => {
+    // change is at absolute index 6; starting at 5 it's 1 hour ahead (13:00 for 08:00 base)
+    const codes = [0, 0, 0, 0, 0, 0, 95, 95, 95, 95, 95, 95, 95, 95, 95, 95, 95, 95];
+    const summary = hourlySummary(makeHourly(codes), 5);
+    expect(summary).toContain("Thunderstorms expected around 14:00.");
+  });
+
+  it("returns null on missing or insufficient data", () => {
+    expect(hourlySummary(makeHourly([]), 0)).toBeNull();
+    expect(hourlySummary(makeHourly([0]), 0)).toBeNull();
+    expect(hourlySummary(makeHourly(Array(12).fill(0)), -1)).toBeNull();
+    expect(hourlySummary(makeHourly(Array(12).fill(0)), 99)).toBeNull();
+  });
+});

--- a/src/lib/hourly-summary.ts
+++ b/src/lib/hourly-summary.ts
@@ -1,0 +1,113 @@
+/**
+ * Deterministic one-sentence summary for the hourly forecast strip — the
+ * Apple Weather pattern ("Hazy conditions expected around 19:00. Wind gusts
+ * are up to 26 km/h."). Pure function over the hourly arrays: no AI call,
+ * no network, renders instantly with the card and never hallucinates.
+ */
+
+import type { HourlyWeather } from "./weather";
+
+/** Hours of forecast the summary looks ahead. */
+export const SUMMARY_LOOKAHEAD_HOURS = 12;
+
+/** Gust threshold (km/h) above which the wind clause is added. */
+export const GUST_MENTION_KMH = 25;
+
+/**
+ * Coarse condition groups — transitions between groups are what the sentence
+ * reports. Finer changes (e.g. slight → moderate rain) stay silent.
+ */
+type ConditionGroup =
+  | "clear"
+  | "partly cloudy"
+  | "cloudy"
+  | "foggy"
+  | "drizzly"
+  | "rainy"
+  | "snowy"
+  | "stormy";
+
+export function conditionGroup(code: number): ConditionGroup {
+  if (code >= 95) return "stormy";
+  if ((code >= 71 && code <= 77) || code === 85 || code === 86) return "snowy";
+  if ((code >= 61 && code <= 67) || (code >= 80 && code <= 82)) return "rainy";
+  if (code >= 51 && code <= 57) return "drizzly";
+  if (code === 45 || code === 48) return "foggy";
+  if (code === 3) return "cloudy";
+  if (code === 1 || code === 2) return "partly cloudy";
+  return "clear";
+}
+
+/** Phrase used when a group ARRIVES ("X expected around 14:00"). */
+const ARRIVAL_PHRASE: Record<ConditionGroup, string> = {
+  clear: "Clear conditions",
+  "partly cloudy": "Partly cloudy conditions",
+  cloudy: "Cloudy conditions",
+  foggy: "Foggy conditions",
+  drizzly: "Drizzle",
+  rainy: "Rain",
+  snowy: "Snow",
+  stormy: "Thunderstorms",
+};
+
+/** Phrase used when a group PERSISTS ("X will continue…"). */
+const CONTINUE_PHRASE: Record<ConditionGroup, string> = {
+  clear: "Clear conditions",
+  "partly cloudy": "Partly cloudy conditions",
+  cloudy: "Cloudy conditions",
+  foggy: "Foggy conditions",
+  drizzly: "Drizzle",
+  rainy: "Rain",
+  snowy: "Snow",
+  stormy: "Thunderstorms",
+};
+
+function hourLabel(iso: string): string {
+  return `${String(new Date(iso).getHours()).padStart(2, "0")}:00`;
+}
+
+/**
+ * Build the summary from the hourly arrays, starting at `start` (the same
+ * current-hour index the hourly strip itself uses — callers pass it so the
+ * sentence and the strip can't disagree about what "now" is).
+ *
+ * Returns null when there isn't enough data to say anything meaningful.
+ */
+export function hourlySummary(hourly: HourlyWeather, start: number): string | null {
+  const codes = hourly.weather_code;
+  const times = hourly.time;
+  if (!codes?.length || !times?.length || start < 0 || start >= codes.length) return null;
+
+  const end = Math.min(start + SUMMARY_LOOKAHEAD_HOURS, codes.length);
+  if (end - start < 2) return null;
+
+  const nowGroup = conditionGroup(codes[start]);
+
+  // First hour whose coarse condition group differs from now
+  let changeIdx = -1;
+  for (let i = start + 1; i < end; i++) {
+    if (conditionGroup(codes[i]) !== nowGroup) {
+      changeIdx = i;
+      break;
+    }
+  }
+
+  let sentence: string;
+  if (changeIdx > 0) {
+    sentence = `${ARRIVAL_PHRASE[conditionGroup(codes[changeIdx])]} expected around ${hourLabel(times[changeIdx])}.`;
+  } else {
+    sentence = `${CONTINUE_PHRASE[nowGroup]} will continue for the next ${end - start} hours.`;
+  }
+
+  // Wind clause — peak gusts over the same window
+  const gusts = hourly.wind_gusts_10m ?? [];
+  let maxGust = 0;
+  for (let i = start; i < end; i++) {
+    if ((gusts[i] ?? 0) > maxGust) maxGust = gusts[i];
+  }
+  if (maxGust >= GUST_MENTION_KMH) {
+    sentence += ` Wind gusts are up to ${Math.round(maxGust)} km/h.`;
+  }
+
+  return sentence;
+}


### PR DESCRIPTION
## Summary

Three Apple Weather-parity changes from the screenshot report:

### 1. Current location takes precedence over saved locations
The home redirect raced a **2s countdown** against a **3s-timeout GPS recheck** — the cached/saved city nearly always won, which is exactly the "stuck on that URL" behavior. Now:
- The redirect is **gated on the current-location recheck settling** (`recheckSettled`): the cached city can never win a race against a GPS check that's still deciding. Denial/failure/timeout (or an absolute 8s settle cap) lets the cached location proceed — the flow can never hang.
- **Far-nearest escalation**: when the nearest *known* location is >25 km from the GPS fix (rural travel), a create-on-demand lookup resolves the user's actual place instead of redirecting to a distant catalog entry.
- Not the PWA/service-worker: documents aren't runtime-cached — the race was the whole story.

### 2. The weather animation spans the entire location page
`HeroWeatherBackground` (card-embedded) becomes **`WeatherBackdrop`** — a fixed, full-viewport, condition-aware Three.js sky behind all content. The `CurrentConditions` hero is **de-carded** (no opaque container) so it reads directly over the sky, Apple-style; a gradient fades the backdrop into the normal surface background further down so cards/charts keep contrast. All performance guards retained: DPR capped at 1, pause on `visibilitychange`, full dispose on unmount, `prefers-reduced-motion` gets the static gradient only. The IntersectionObserver is dropped (a fixed viewport-filling element is always on-screen).

### 3. One-sentence hourly outlook — no AI
`src/lib/hourly-summary.ts`: a pure function scanning the next 12 hours for the first coarse condition-group change ("Rain expected around 19:00.") plus peak gusts ("Wind gusts are up to 26 km/h."). Rendered at the top of the hourly strip, derived from the same start index as the strip so they can't disagree, hydration-gated (depends on the client wall clock). Deterministic — instant, free, never hallucinates.

## Validation

- `npm test` — 2100 tests passing (new: `hourly-summary.test.ts`, gating/escalation tests in `HomeLanding.test.ts`, `WeatherBackdrop.test.ts` rewritten for fixed positioning)
- `python -m pytest tests/py/` — 979 passing
- lint 0 errors; `tsc --noEmit` clean; build green
- CLAUDE.md updated (HomeLanding pipeline, component tree, hourly-summary lib)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW

---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_