### PR TITLE
Community weather stations: ingest API + station console app (monorepo)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,6 +390,7 @@ mukoko-weather/
 │       ├── _devices.py            # Device sync (preferences across devices)
 │       ├── _circuit_breaker.py    # Netflix Hystrix-inspired circuit breaker (per-provider resilience)
 │       ├── _embeddings.py         # Vector embedding endpoints
+│       ├── _stations.py           # Community station registration + WU/Ecowitt ingest + manual readings (StationKit writer)
 │       ├── _status.py             # System health checks
 │       └── _tiles.py              # Map tile proxy for Tomorrow.io
 ├── worker/                        # Cloudflare Workers edge API (optional)
@@ -521,6 +522,8 @@ All data handling, AI operations, database CRUD, and rule evaluation run in Pyth
 - `/api/py/devices` (create) — 20 req/hour, only when `deviceId` is omitted/fresh (unbounded doc creation); an existing/caller-supplied `deviceId` is idempotent and skips the limiter
 - `/api/py/reports` (submit) — 5 req/hour
 - `/api/py/reports/clarify` — 10 req/hour
+- `/api/py/stations/register` — 3 req/hour
+- `/api/py/stations/manual` — 12 req/hour (ingest endpoints authenticate by station key instead)
 
 **Resilience:** Module-level Anthropic client singletons with key-rotation detection (hash-based invalidation). Graceful degradation — AI endpoints return basic summaries when Anthropic is unavailable. Weather endpoints fall back through Tomorrow.io → Open-Meteo → seasonal estimates.
 
@@ -616,6 +619,10 @@ All data handling, AI operations, database CRUD, and rule evaluation run in Pyth
 - `/api/py/embeddings/status` — GET, vector search infrastructure status (stub)
 - `/api/py/airquality` — GET, EPA-standard Air Quality Index (0-500) + 7-pollutant breakdown (PM2.5, PM10, O3, NO2, SO2, CO, NH3) for `lat`/`lon`. Sourced from Open-Meteo Air Quality (free, no key) via `open_meteo_breaker`. Cached 1 h in `weather.air_quality_cache` with deterministic `_id` (`{lat:.4f}_{lon:.4f}`) so duplicate requests upsert one row, never two
 - `/api/py/airports/nearest` — GET, N nearest ICAO airports to `lat`/`lon` (query: `lat`, `lon`, optional `count` default 5 / max 20, optional `maxDistanceKm` default 500) via MongoDB `$geoNear` on the seeded `weather.airports` collection. Each result carries `icao` + `name` + `distanceKm`, sorted closest-first. Returns an empty list on any DB error so the TS client falls back to the static haversine scan
+- `/api/py/stations/register` — POST, register a community weather station (digital or manual/analog). Rate-limited 3/hour/IP. Returns `stationId` + `ingestKey` ONCE (SHA-256 hash at rest) with custom-server setup instructions
+- `/api/py/stations/ingest` — GET (Wunderground protocol, `ID`/`PASSWORD` query params) and POST (Ecowitt protocol, form fields with `PASSKEY=<stationId>:<ingestKey>`) — consumer station consoles push readings directly here via their "customized upload" setting. Imperial→metric conversion, inline QC range checks; raw payloads archived in `weather.stationObservations`, passing readings become validated `weather.observations` docs that `/api/py/weather` blends into current conditions (StationKit flow). Responds with the literal body `success` (WU protocol requirement)
+- `/api/py/stations/manual` — POST, manual reading from an analog station (farmers/schools: rain gauge + thermometer, no digital infrastructure). Requires `stationId` + `key`; Pydantic range validation + same QC/observation flow. Rate-limited 12/hour/IP
+- `/api/py/stations/status` — GET (`id`, `key`), last-seen + latest metrics for the owner's console
 - `/api/py/health` — GET, basic health check (MongoDB + Anthropic availability)
 
 ### Error Handling
@@ -1401,6 +1408,7 @@ _Python backend tests (pytest):_
 - `tests/py/test_ai_prompts.py` — AI prompts: single/all prompts, suggested rules, module-level caching, DB error graceful degradation
 - `tests/py/test_index.py` — FastAPI app: CORS origins, health endpoint, ConnectionFailure handler, all 16 routers mounted
 - `tests/py/test_tiles.py` — Map tiles: Tomorrow.io weather overlay proxy (layer validation, zoom range, timestamp validation, SSRF protection, proxy behavior, cache headers) + Mapbox base tile proxy (style validation, zoom range, URL construction, dark mode)
+- `tests/py/test_stations.py` — Station ingest: unit conversions (°F/mph/inHg/inches), QC range filter, hashed-key auth, registration (key never stored raw, GeoJSON location), manual readings (validated observation writes, 401/400 paths)
 - `tests/py/test_status.py` — System health: MongoDB/Tomorrow.io/Open-Meteo/Anthropic/cache checks, overall status aggregation
 - `tests/py/test_embeddings.py` — Embeddings stub: status endpoint shape
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,6 +393,9 @@ mukoko-weather/
 │       ├── _stations.py           # Community station registration + WU/Ecowitt ingest + manual readings (StationKit writer)
 │       ├── _status.py             # System health checks
 │       └── _tiles.py              # Map tile proxy for Tomorrow.io
+├── station-console/               # Station console app (MONOREPO sub-app — separate Vercel project at weatherstations.nyuchi.com)
+│   ├── package.json               # Own Next.js app: web-only, NO PWA/offline; WorkOS AuthKit with the SAME credentials as the main app (register the /callback redirect URI in WorkOS)
+│   └── src/                       # Auth-gated console: register stations, one-time credentials + WU/Ecowitt setup instructions, manual readings, status. Calls the /api/py/stations/* endpoints (CORS-allowed origin); station keys live in the owner's browser localStorage
 ├── worker/                        # Cloudflare Workers edge API (optional)
 │   ├── src/
 │   │   ├── index.ts               # Hono app, route mounting, CORS

--- a/api/py/_stations.py
+++ b/api/py/_stations.py
@@ -25,6 +25,7 @@ conditions for every visitor within 50 km.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import re
 import secrets
 from datetime import datetime, timezone
@@ -61,19 +62,35 @@ QC_RANGES = {
 }
 
 
-def _hash_key(key: str) -> str:
-    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+# Ingest keys are 192-bit random tokens (secrets.token_urlsafe(24)), not
+# human passwords — but they're still stored only as salted PBKDF2-HMAC-SHA256
+# hashes. Iterations are modest because the input is high-entropy (a slow KDF
+# guards low-entropy passwords; here it just bounds per-ingest CPU, and
+# stations report every 16-60s).
+_KDF_ITERATIONS = 60_000
+
+
+def _hash_key(key: str, salt: str) -> str:
+    return hashlib.pbkdf2_hmac(
+        "sha256", key.encode("utf-8"), salt.encode("utf-8"), _KDF_ITERATIONS
+    ).hex()
 
 
 def _find_station(station_id: str, key: str) -> dict | None:
-    """Resolve a station by id + ingest key (hash compared). None on any miss."""
+    """Resolve a station by id + ingest key (salted KDF compared). None on any miss."""
     if not station_id or not key or not STATION_ID_RE.match(station_id):
         return None
     try:
         doc = stations_collection().find_one({"stationId": station_id})
     except Exception:
         return None
-    if not doc or doc.get("ingestKeyHash") != _hash_key(key):
+    if not doc:
+        return None
+    salt = doc.get("ingestKeySalt") or ""
+    expected = doc.get("ingestKeyHash") or ""
+    if not salt or not expected:
+        return None
+    if not hmac.compare_digest(_hash_key(key, salt), expected):
         return None
     return doc
 
@@ -191,6 +208,7 @@ async def register_station(body: StationRegisterRequest, request: Request = None
 
     station_id = f"mws-{secrets.token_hex(4)}"
     ingest_key = secrets.token_urlsafe(24)
+    ingest_salt = secrets.token_hex(16)
 
     doc = stamp_platform_fields(
         {
@@ -203,7 +221,8 @@ async def register_station(body: StationRegisterRequest, request: Request = None
             "stationType": body.stationType,
             "hardware": (body.hardware or "").strip() or None,
             "status": "active",
-            "ingestKeyHash": _hash_key(ingest_key),
+            "ingestKeyHash": _hash_key(ingest_key, ingest_salt),
+            "ingestKeySalt": ingest_salt,
             "lastObservationAt": None,
         },
         country_code=(body.country or "ZW").upper(),

--- a/api/py/_stations.py
+++ b/api/py/_stations.py
@@ -1,0 +1,364 @@
+"""
+Community weather stations — registration, data ingest, manual readings.
+
+Consumer weather stations (Ecowitt/Fine Offset families, Ambient-style
+consoles, Davis bridges) support a "custom server" upload: the console POSTs
+its readings to any host on a schedule. This router gives those stations a
+first-party destination — no Weather Underground middleman — plus a manual
+path for analog stations (farmers/schools with rain gauges and min/max
+thermometers but no digital infrastructure).
+
+Endpoints:
+  POST /api/py/stations/register      — create a station, ingest key shown ONCE
+  GET  /api/py/stations/ingest        — Wunderground-protocol upload (query params)
+  POST /api/py/stations/ingest        — Ecowitt-protocol upload (form fields)
+  POST /api/py/stations/manual        — manual reading from an analog station
+  GET  /api/py/stations/status        — last-seen + latest reading (owner console)
+
+Data flow matches StationKit (Phase 0D): every accepted payload is stored
+raw in weather.stationObservations; readings that pass the inline QC range
+checks also become a validated weather.observations doc, which
+/api/py/weather's nearest_station_observation() blends into current
+conditions for every visitor within 50 km.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
+from pydantic import BaseModel, Field
+
+from ._db import (
+    check_rate_limit,
+    get_client_ip,
+    stamp_platform_fields,
+    stations_collection,
+    observations_collection,
+    station_observations_collection,
+)
+
+router = APIRouter()
+
+STATION_ID_RE = re.compile(r"^mws-[a-f0-9]{8}$")
+
+# Inline QC — physically plausible ranges. Values outside stay in the raw
+# stationObservations record but never become a validated observation.
+QC_RANGES = {
+    "airTemperatureCelsius": (-50.0, 60.0),
+    "relativeHumidityPercent": (0.0, 100.0),
+    "atmosphericPressureMillibar": (800.0, 1100.0),
+    "windSpeedKph": (0.0, 250.0),
+    "windGustKph": (0.0, 300.0),
+    "windDirectionDegrees": (0.0, 360.0),
+    "precipitationMillimeters": (0.0, 500.0),
+    "uvIndex": (0.0, 20.0),
+    "solarRadiationWm2": (0.0, 1500.0),
+}
+
+
+def _hash_key(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+def _find_station(station_id: str, key: str) -> dict | None:
+    """Resolve a station by id + ingest key (hash compared). None on any miss."""
+    if not station_id or not key or not STATION_ID_RE.match(station_id):
+        return None
+    try:
+        doc = stations_collection().find_one({"stationId": station_id})
+    except Exception:
+        return None
+    if not doc or doc.get("ingestKeyHash") != _hash_key(key):
+        return None
+    return doc
+
+
+def _qc_filter(metrics: dict) -> dict:
+    """Keep only metrics inside their plausible physical range."""
+    passed = {}
+    for field, value in metrics.items():
+        if value is None:
+            continue
+        lo_hi = QC_RANGES.get(field)
+        if lo_hi is None:
+            continue
+        lo, hi = lo_hi
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            continue
+        if lo <= v <= hi:
+            passed[field] = round(v, 2)
+    return passed
+
+
+def _store_observation(station: dict, metrics: dict, raw: dict, source: str) -> dict:
+    """
+    Store the raw payload, and — when at least one metric passes QC — a
+    validated observation the weather endpoint can blend. Returns a summary.
+    """
+    now = datetime.now(timezone.utc)
+    country = ((station.get("bundu") or {}).get("countryCode")) or "ZW"
+
+    raw_doc = stamp_platform_fields(
+        {
+            "stationId": station["stationId"],
+            "receivedAt": now,
+            "sourceType": source,
+            "payload": {k: str(v)[:120] for k, v in list(raw.items())[:60]},
+        },
+        country_code=country,
+    )
+    try:
+        station_observations_collection().insert_one(raw_doc)
+    except Exception:
+        pass  # Raw archive is best-effort — a validated observation still counts.
+
+    validated = _qc_filter(metrics)
+    if not validated:
+        return {"accepted": 0, "qcStatus": "rejected"}
+
+    obs_doc = stamp_platform_fields(
+        {
+            "stationId": station["stationId"],
+            "location": station.get("location")
+            or {"type": "Point", "coordinates": [station.get("lon"), station.get("lat")]},
+            "observedAt": now,
+            "qcStatus": "validated",
+            "sourceType": source,
+            "metrics": validated,
+        },
+        country_code=country,
+    )
+    observations_collection().insert_one(obs_doc)
+    try:
+        stations_collection().update_one(
+            {"stationId": station["stationId"]},
+            {"$set": {"lastObservationAt": now, "updatedAt": now}},
+        )
+    except Exception:
+        pass
+    return {"accepted": len(validated), "qcStatus": "validated"}
+
+
+# ── Unit conversions (consoles speak imperial) ──────────────────────────────
+
+def f_to_c(v):  # °F → °C
+    return None if v is None else (float(v) - 32.0) * 5.0 / 9.0
+
+def mph_to_kph(v):
+    return None if v is None else float(v) * 1.609344
+
+def inhg_to_hpa(v):
+    return None if v is None else float(v) * 33.8639
+
+def inch_to_mm(v):
+    return None if v is None else float(v) * 25.4
+
+def _num(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+# ── Registration ─────────────────────────────────────────────────────────────
+
+
+class StationRegisterRequest(BaseModel):
+    name: str = Field(min_length=2, max_length=80)
+    lat: float = Field(ge=-90, le=90)
+    lon: float = Field(ge=-180, le=180)
+    elevation: float | None = Field(default=None, ge=-430, le=9000)
+    stationType: str = Field(default="digital", pattern="^(digital|manual)$")
+    hardware: str | None = Field(default=None, max_length=80)
+    country: str | None = Field(default=None, max_length=2)
+
+
+@router.post("/api/py/stations/register")
+async def register_station(body: StationRegisterRequest, request: Request = None):
+    ip = get_client_ip(request) if request is not None else None
+    if not ip:
+        raise HTTPException(status_code=400, detail="Could not determine client IP")
+    rate = check_rate_limit(ip, "station-register", 3, 3600)
+    if not rate["allowed"]:
+        raise HTTPException(status_code=429, detail="Too many station registrations — try again later")
+
+    station_id = f"mws-{secrets.token_hex(4)}"
+    ingest_key = secrets.token_urlsafe(24)
+
+    doc = stamp_platform_fields(
+        {
+            "stationId": station_id,
+            "name": body.name.strip(),
+            "location": {"type": "Point", "coordinates": [body.lon, body.lat]},
+            "lat": body.lat,
+            "lon": body.lon,
+            "elevation": body.elevation,
+            "stationType": body.stationType,
+            "hardware": (body.hardware or "").strip() or None,
+            "status": "active",
+            "ingestKeyHash": _hash_key(ingest_key),
+            "lastObservationAt": None,
+        },
+        country_code=(body.country or "ZW").upper(),
+    )
+    stations_collection().insert_one(doc)
+
+    # The full key is returned exactly ONCE — only its hash is stored.
+    return {
+        "stationId": station_id,
+        "ingestKey": ingest_key,
+        "stationType": body.stationType,
+        "ingest": {
+            "wunderground": {
+                "server": "weather.mukoko.com",
+                "path": "/api/py/stations/ingest",
+                "params": "ID=<stationId>&PASSWORD=<ingestKey>",
+            },
+            "ecowitt": {
+                "server": "weather.mukoko.com",
+                "path": "/api/py/stations/ingest",
+                "note": "Set the customized upload PASSKEY to <stationId>:<ingestKey>",
+            },
+        },
+    }
+
+
+# ── Ingest — Wunderground protocol (GET) ─────────────────────────────────────
+
+
+@router.get("/api/py/stations/ingest")
+async def ingest_wunderground(request: Request):
+    q = request.query_params
+    station = _find_station(q.get("ID", ""), q.get("PASSWORD", ""))
+    if not station:
+        return PlainTextResponse("unauthorized", status_code=401)
+
+    metrics = {
+        "airTemperatureCelsius": f_to_c(_num(q.get("tempf"))),
+        "relativeHumidityPercent": _num(q.get("humidity")),
+        "atmosphericPressureMillibar": inhg_to_hpa(_num(q.get("baromin"))),
+        "windSpeedKph": mph_to_kph(_num(q.get("windspeedmph"))),
+        "windGustKph": mph_to_kph(_num(q.get("windgustmph"))),
+        "windDirectionDegrees": _num(q.get("winddir")),
+        "precipitationMillimeters": inch_to_mm(_num(q.get("rainin"))),
+        "uvIndex": _num(q.get("UV")),
+        "solarRadiationWm2": _num(q.get("solarradiation")),
+    }
+    _store_observation(station, metrics, dict(q), source="wunderground")
+    # The WU protocol expects the literal body "success".
+    return PlainTextResponse("success")
+
+
+# ── Ingest — Ecowitt protocol (POST form) ────────────────────────────────────
+
+
+@router.post("/api/py/stations/ingest")
+async def ingest_ecowitt(request: Request):
+    try:
+        form = await request.form()
+    except Exception:
+        return PlainTextResponse("bad request", status_code=400)
+    passkey = str(form.get("PASSKEY", ""))
+    station_id, _, key = passkey.partition(":")
+    station = _find_station(station_id, key)
+    if not station:
+        return PlainTextResponse("unauthorized", status_code=401)
+
+    g = lambda k: _num(form.get(k))  # noqa: E731
+    metrics = {
+        "airTemperatureCelsius": f_to_c(g("tempf")),
+        "relativeHumidityPercent": g("humidity"),
+        "atmosphericPressureMillibar": inhg_to_hpa(g("baromrelin") if form.get("baromrelin") else g("baromabsin")),
+        "windSpeedKph": mph_to_kph(g("windspeedmph")),
+        "windGustKph": mph_to_kph(g("windgustmph")),
+        "windDirectionDegrees": g("winddir"),
+        "precipitationMillimeters": inch_to_mm(g("rainratein")),
+        "uvIndex": g("uv"),
+        "solarRadiationWm2": g("solarradiation"),
+    }
+    _store_observation(station, metrics, dict(form), source="ecowitt")
+    return PlainTextResponse("success")
+
+
+# ── Manual readings (analog stations) ────────────────────────────────────────
+
+
+class ManualReadingRequest(BaseModel):
+    stationId: str
+    key: str = Field(max_length=64)
+    temperatureC: float | None = Field(default=None, ge=-50, le=60)
+    humidityPercent: float | None = Field(default=None, ge=0, le=100)
+    pressureHpa: float | None = Field(default=None, ge=800, le=1100)
+    windKph: float | None = Field(default=None, ge=0, le=250)
+    windDirectionDegrees: float | None = Field(default=None, ge=0, le=360)
+    rainfallMm: float | None = Field(default=None, ge=0, le=500)
+    notes: str | None = Field(default=None, max_length=280)
+
+
+@router.post("/api/py/stations/manual")
+async def manual_reading(body: ManualReadingRequest, request: Request = None):
+    ip = get_client_ip(request) if request is not None else None
+    if not ip:
+        raise HTTPException(status_code=400, detail="Could not determine client IP")
+    rate = check_rate_limit(ip, "station-manual", 12, 3600)
+    if not rate["allowed"]:
+        raise HTTPException(status_code=429, detail="Too many readings — try again later")
+
+    station = _find_station(body.stationId, body.key)
+    if not station:
+        raise HTTPException(status_code=401, detail="Unknown station or key")
+
+    metrics = {
+        "airTemperatureCelsius": body.temperatureC,
+        "relativeHumidityPercent": body.humidityPercent,
+        "atmosphericPressureMillibar": body.pressureHpa,
+        "windSpeedKph": body.windKph,
+        "windDirectionDegrees": body.windDirectionDegrees,
+        "precipitationMillimeters": body.rainfallMm,
+    }
+    raw = {k: v for k, v in metrics.items() if v is not None}
+    if body.notes:
+        raw["notes"] = body.notes
+    if not raw:
+        raise HTTPException(status_code=400, detail="At least one measurement is required")
+
+    result = _store_observation(station, metrics, raw, source="manual")
+    return JSONResponse(content=result)
+
+
+# ── Owner console status ─────────────────────────────────────────────────────
+
+
+@router.get("/api/py/stations/status")
+async def station_status(id: str = "", key: str = ""):
+    station = _find_station(id, key)
+    if not station:
+        raise HTTPException(status_code=401, detail="Unknown station or key")
+
+    latest = None
+    try:
+        latest = observations_collection().find_one(
+            {"stationId": station["stationId"]},
+            sort=[("observedAt", -1)],
+        )
+    except Exception:
+        pass
+
+    last_at = station.get("lastObservationAt")
+    return JSONResponse(
+        content={
+            "stationId": station["stationId"],
+            "name": station.get("name"),
+            "stationType": station.get("stationType", "digital"),
+            "status": station.get("status", "active"),
+            "lastObservationAt": last_at.isoformat() if isinstance(last_at, datetime) else last_at,
+            "latestMetrics": (latest or {}).get("metrics"),
+        }
+    )

--- a/api/py/index.py
+++ b/api/py/index.py
@@ -28,6 +28,7 @@ from ._data import router as data_router
 from ._history import router as history_router
 from ._status import router as status_router
 from ._tiles import router as tiles_router
+from ._stations import router as stations_router
 from ._ai_prompts import router as ai_prompts_router
 from ._ai_followup import router as ai_followup_router
 from ._history_analyze import router as history_analyze_router
@@ -92,6 +93,7 @@ app.add_middleware(
 # Mount routers
 # ---------------------------------------------------------------------------
 
+app.include_router(stations_router)
 app.include_router(devices_router)
 app.include_router(chat_router)
 app.include_router(suitability_router)

--- a/api/py/index.py
+++ b/api/py/index.py
@@ -62,7 +62,9 @@ app = FastAPI(
 
 _ALLOWED_ORIGINS = [
     "https://weather.mukoko.com",
+    "https://weatherstations.nyuchi.com",  # station console (monorepo: station-console/, separate Vercel project)
     "http://localhost:3000",   # web dev (Next.js)
+    "http://localhost:3001",   # station console dev
     "http://localhost:8081",   # Expo Metro web bundler
     "http://localhost:8082",   # Expo web dev server
     "http://localhost:19006",  # legacy Expo web port

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,9 @@ const eslintConfig = defineConfig([
     // Serwist service worker build artifact
     "public/sw.js",
     "public/sw.js.map",
+    // Monorepo sub-apps with their own toolchains (own tsconfig/lint)
+    "station-console/**",
+    "worker/**",
   ]),
 ]);
 

--- a/station-console/next.config.ts
+++ b/station-console/next.config.ts
@@ -1,0 +1,6 @@
+import type { NextConfig } from "next";
+
+// Web-only console — deliberately NO PWA, service worker, or offline support.
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/station-console/package.json
+++ b/station-console/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mukoko-station-console",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev -p 3001",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@workos-inc/authkit-nextjs": "^2.6.0",
+    "next": "^16.1.6",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.16",
+    "@types/node": "^24.9.2",
+    "@types/react": "^19.2.6",
+    "tailwindcss": "^4.1.16",
+    "typescript": "^5.9.3"
+  }
+}

--- a/station-console/postcss.config.mjs
+++ b/station-console/postcss.config.mjs
@@ -1,0 +1,2 @@
+const config = { plugins: { "@tailwindcss/postcss": {} } };
+export default config;

--- a/station-console/src/app/auth/signin/route.ts
+++ b/station-console/src/app/auth/signin/route.ts
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+import { getSignInUrl } from "@workos-inc/authkit-nextjs";
+
+export async function GET() {
+  redirect(await getSignInUrl());
+}

--- a/station-console/src/app/auth/signout/route.ts
+++ b/station-console/src/app/auth/signout/route.ts
@@ -1,0 +1,5 @@
+import { signOut } from "@workos-inc/authkit-nextjs";
+
+export async function GET() {
+  await signOut({ returnTo: "/" });
+}

--- a/station-console/src/app/callback/route.ts
+++ b/station-console/src/app/callback/route.ts
@@ -1,0 +1,6 @@
+import { handleAuth } from "@workos-inc/authkit-nextjs";
+
+// Same WorkOS environment as weather.mukoko.com — register
+// https://weatherstations.nyuchi.com/callback as an additional redirect URI
+// in the WorkOS dashboard.
+export const GET = handleAuth();

--- a/station-console/src/app/globals.css
+++ b/station-console/src/app/globals.css
@@ -1,0 +1,104 @@
+@import "tailwindcss";
+
+/* Mzizi / Mukoko Brand System — token subset mirrored from
+   mukoko-weather's globals.css (Brand System v6, brand kit doctrine
+   v4.1.0). Keep values in sync with the main app. */
+:root {
+  --color-primary: #0047ab; /* cobalt */
+  --color-primary-foreground: #ffffff;
+  --mineral-malachite: #0bda51;
+  --mineral-gold: #d4a017;
+  --mineral-terracotta: #c1440e;
+  --color-surface-base: #faf8f5;
+  --color-surface-card: #ffffff;
+  --color-text-primary: #1a1a1a;
+  --color-text-secondary: #4a4a4a;
+  --color-text-tertiary: #757575;
+  --color-border: #e5e0d8;
+  --color-severity-severe: #b3261e;
+  --color-severity-low: #0b6e4f;
+  --touch-target-min: 48px;
+  --radius-card: 16px;
+  --radius-button: 9999px;
+  --radius-input: 10px;
+}
+[data-theme="dark"] {
+  --color-primary: #4d8dff;
+  --color-primary-foreground: #0a0a0a;
+  --color-surface-base: #121212;
+  --color-surface-card: #1c1c1e;
+  --color-text-primary: #f5f5f5;
+  --color-text-secondary: #c7c7c7;
+  --color-text-tertiary: #8e8e93;
+  --color-border: #2c2c2e;
+  --color-severity-severe: #ff6b60;
+  --color-severity-low: #4cd58c;
+}
+@theme inline {
+  --color-primary: var(--color-primary);
+  --color-primary-foreground: var(--color-primary-foreground);
+  --color-surface-base: var(--color-surface-base);
+  --color-surface-card: var(--color-surface-card);
+  --color-text-primary: var(--color-text-primary);
+  --color-text-secondary: var(--color-text-secondary);
+  --color-text-tertiary: var(--color-text-tertiary);
+  --color-border: var(--color-border);
+  --color-severity-severe: var(--color-severity-severe);
+  --color-severity-low: var(--color-severity-low);
+}
+
+body {
+  background: var(--color-surface-base);
+  color: var(--color-text-primary);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}
+
+/* Fauna classes (Mzizi component naming) — subset used by the console */
+.kudu {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: var(--touch-target-min);
+  border-radius: var(--radius-button);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+}
+.impala {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: var(--touch-target-min);
+  border-radius: var(--radius-button);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  padding: 0.75rem 1.25rem;
+  font-weight: 500;
+}
+.baobab {
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-card);
+  padding: 1.25rem;
+}
+.giraffe {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.dove {
+  font-size: 0.875rem;
+  color: var(--color-text-tertiary);
+}
+.field {
+  width: 100%;
+  min-height: var(--touch-target-min);
+  border-radius: var(--radius-input);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-card);
+  color: var(--color-text-primary);
+  padding: 0.5rem 0.75rem;
+}

--- a/station-console/src/app/layout.tsx
+++ b/station-console/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Mukoko Weather Stations — Console",
+  description:
+    "Register community weather stations, connect station hardware, and log manual readings for the mukoko weather network.",
+  robots: { index: false },
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <AuthKitProvider>{children}</AuthKitProvider>
+      </body>
+    </html>
+  );
+}

--- a/station-console/src/app/layout.tsx
+++ b/station-console/src/app/layout.tsx
@@ -9,7 +9,11 @@ export const metadata: Metadata = {
   robots: { index: false },
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en">
       <body>

--- a/station-console/src/app/page.tsx
+++ b/station-console/src/app/page.tsx
@@ -1,0 +1,17 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { Console } from "@/components/Console";
+
+/**
+ * The whole console is auth-gated (authkitMiddleware enforces sign-in on
+ * every path) — station owners sign in with the same Nyuchi identity used
+ * on weather.mukoko.com.
+ */
+export default async function Home() {
+  const { user } = await withAuth({ ensureSignedIn: true });
+  return (
+    <Console
+      userEmail={user.email ?? ""}
+      userId={user.id}
+    />
+  );
+}

--- a/station-console/src/app/page.tsx
+++ b/station-console/src/app/page.tsx
@@ -8,10 +8,5 @@ import { Console } from "@/components/Console";
  */
 export default async function Home() {
   const { user } = await withAuth({ ensureSignedIn: true });
-  return (
-    <Console
-      userEmail={user.email ?? ""}
-      userId={user.id}
-    />
-  );
+  return <Console userEmail={user.email ?? ""} userId={user.id} />;
 }

--- a/station-console/src/components/Console.tsx
+++ b/station-console/src/components/Console.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  API_BASE,
+  loadStations,
+  saveStations,
+  registerStation,
+  fetchStatus,
+  submitManualReading,
+  type RegisteredStation,
+  type StationStatus,
+} from "@/lib/api";
+
+interface Credentials {
+  stationId: string;
+  ingestKey: string;
+}
+
+export function Console({ userEmail, userId }: { userEmail: string; userId: string }) {
+  const [stations, setStations] = useState<RegisteredStation[]>([]);
+  const [statuses, setStatuses] = useState<Record<string, StationStatus>>({});
+  const [creds, setCreds] = useState<Credentials | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Register form state
+  const [name, setName] = useState("");
+  const [lat, setLat] = useState("");
+  const [lon, setLon] = useState("");
+  const [stationType, setStationType] = useState<"digital" | "manual">("digital");
+  const [hardware, setHardware] = useState("");
+
+  useEffect(() => {
+    const list = loadStations();
+    setStations(list);
+    list.forEach((s) =>
+      fetchStatus(s)
+        .then((st) => setStatuses((prev) => ({ ...prev, [s.stationId]: st })))
+        .catch(() => undefined),
+    );
+  }, []);
+
+  const useGps = () => {
+    navigator.geolocation?.getCurrentPosition(
+      (pos) => {
+        setLat(pos.coords.latitude.toFixed(5));
+        setLon(pos.coords.longitude.toFixed(5));
+      },
+      () => setError("Could not read GPS — enter coordinates manually."),
+    );
+  };
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      const result = await registerStation({
+        name,
+        lat: parseFloat(lat),
+        lon: parseFloat(lon),
+        stationType,
+        hardware: hardware || undefined,
+      });
+      const entry: RegisteredStation = {
+        stationId: result.stationId,
+        key: result.ingestKey,
+        name,
+        stationType,
+      };
+      const next = [...stations, entry];
+      setStations(next);
+      saveStations(next);
+      setCreds({ stationId: result.stationId, ingestKey: result.ingestKey });
+      setName(""); setLat(""); setLon(""); setHardware("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Registration failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 p-4 sm:p-8">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold">Mukoko Weather Stations</h1>
+          <p className="dove">Signed in as {userEmail}</p>
+        </div>
+        <a href="/auth/signout" className="impala">Sign out</a>
+      </header>
+
+      {error && (
+        <p role="alert" className="baobab" style={undefined}>
+          <span className="text-[var(--color-severity-severe)]">{error}</span>
+        </p>
+      )}
+
+      {/* One-time credentials after registration */}
+      {creds && (
+        <section className="baobab space-y-2" aria-label="Station credentials">
+          <h2 className="giraffe">Save these credentials — the key is shown ONCE</h2>
+          <p className="dove">Station ID: <code>{creds.stationId}</code></p>
+          <p className="dove break-all">Ingest key: <code>{creds.ingestKey}</code></p>
+          <div className="space-y-1 text-sm">
+            <p className="giraffe">Point your station console at:</p>
+            <p className="dove">Wunderground protocol — server <code>weather.mukoko.com</code>, path <code>/api/py/stations/ingest</code>, ID = station ID, PASSWORD = ingest key</p>
+            <p className="dove">Ecowitt protocol — server <code>weather.mukoko.com</code>, path <code>/api/py/stations/ingest</code>, PASSKEY = <code>{creds.stationId}:{"<key>"}</code></p>
+          </div>
+          <button className="impala" onClick={() => setCreds(null)}>I have saved them</button>
+        </section>
+      )}
+
+      {/* Register */}
+      <section className="baobab space-y-3" aria-label="Register a station">
+        <h2 className="giraffe">Register a station</h2>
+        <form onSubmit={handleRegister} className="space-y-3">
+          <input className="field" required minLength={2} placeholder="Station name (e.g. Marondera High School)" value={name} onChange={(e) => setName(e.target.value)} />
+          <div className="flex gap-2">
+            <input className="field" required placeholder="Latitude" inputMode="decimal" value={lat} onChange={(e) => setLat(e.target.value)} />
+            <input className="field" required placeholder="Longitude" inputMode="decimal" value={lon} onChange={(e) => setLon(e.target.value)} />
+            <button type="button" className="impala shrink-0" onClick={useGps}>Use GPS</button>
+          </div>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-2">
+              <input type="radio" checked={stationType === "digital"} onChange={() => setStationType("digital")} />
+              Digital (uploads automatically)
+            </label>
+            <label className="flex items-center gap-2">
+              <input type="radio" checked={stationType === "manual"} onChange={() => setStationType("manual")} />
+              Analog (manual readings)
+            </label>
+          </div>
+          <input className="field" placeholder="Hardware (optional, e.g. Ecowitt WS2910)" value={hardware} onChange={(e) => setHardware(e.target.value)} />
+          <button type="submit" className="kudu w-full" disabled={busy}>
+            {busy ? "Registering…" : "Register station"}
+          </button>
+        </form>
+      </section>
+
+      {/* My stations */}
+      <section className="space-y-3" aria-label="My stations">
+        <h2 className="giraffe">My stations</h2>
+        {stations.length === 0 && <p className="dove">No stations on this device yet.</p>}
+        {stations.map((s) => (
+          <StationCard
+            key={s.stationId}
+            station={s}
+            status={statuses[s.stationId]}
+            onRemove={() => {
+              const next = stations.filter((x) => x.stationId !== s.stationId);
+              setStations(next);
+              saveStations(next);
+            }}
+          />
+        ))}
+      </section>
+
+      <footer className="dove">
+        API: {API_BASE} · Owner: {userId}
+      </footer>
+    </main>
+  );
+}
+
+function StationCard({
+  station,
+  status,
+  onRemove,
+}: {
+  station: RegisteredStation;
+  status?: StationStatus;
+  onRemove: () => void;
+}) {
+  const [reading, setReading] = useState<Record<string, string>>({});
+  const [result, setResult] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setBusy(true);
+    setResult(null);
+    try {
+      const payload: Record<string, number> = {};
+      for (const [k, v] of Object.entries(reading)) {
+        if (v !== "") payload[k] = parseFloat(v);
+      }
+      const res = await submitManualReading(station, payload);
+      setResult(res.qcStatus === "validated" ? `Saved — ${res.accepted} measurement(s) accepted` : "Rejected by quality checks");
+      setReading({});
+    } catch (err) {
+      setResult(err instanceof Error ? err.message : "Submit failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const set = (k: string) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setReading((prev) => ({ ...prev, [k]: e.target.value }));
+
+  return (
+    <article className="baobab space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <h3 className="giraffe">{station.name}</h3>
+          <p className="dove">
+            {station.stationId} · {station.stationType === "manual" ? "Analog" : "Digital"} ·{" "}
+            {status?.lastObservationAt
+              ? `Last reading ${new Date(status.lastObservationAt).toLocaleString()}`
+              : "No readings yet"}
+          </p>
+        </div>
+        <button className="impala" onClick={onRemove}>Remove</button>
+      </div>
+
+      {status?.latestMetrics && (
+        <p className="dove">
+          {Object.entries(status.latestMetrics)
+            .map(([k, v]) => `${k.replace(/([A-Z])/g, " $1").toLowerCase()}: ${v}`)
+            .join(" · ")}
+        </p>
+      )}
+
+      <form onSubmit={submit} className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        <input className="field" placeholder="Temp °C" inputMode="decimal" value={reading.temperatureC ?? ""} onChange={set("temperatureC")} />
+        <input className="field" placeholder="Rain mm" inputMode="decimal" value={reading.rainfallMm ?? ""} onChange={set("rainfallMm")} />
+        <input className="field" placeholder="Humidity %" inputMode="decimal" value={reading.humidityPercent ?? ""} onChange={set("humidityPercent")} />
+        <input className="field" placeholder="Pressure hPa" inputMode="decimal" value={reading.pressureHpa ?? ""} onChange={set("pressureHpa")} />
+        <input className="field" placeholder="Wind km/h" inputMode="decimal" value={reading.windKph ?? ""} onChange={set("windKph")} />
+        <button type="submit" className="kudu" disabled={busy}>
+          {busy ? "Saving…" : "Log reading"}
+        </button>
+      </form>
+      {result && <p className="dove" role="status">{result}</p>}
+    </article>
+  );
+}

--- a/station-console/src/components/Console.tsx
+++ b/station-console/src/components/Console.tsx
@@ -17,7 +17,13 @@ interface Credentials {
   ingestKey: string;
 }
 
-export function Console({ userEmail, userId }: { userEmail: string; userId: string }) {
+export function Console({
+  userEmail,
+  userId,
+}: {
+  userEmail: string;
+  userId: string;
+}) {
   const [stations, setStations] = useState<RegisteredStation[]>([]);
   const [statuses, setStatuses] = useState<Record<string, StationStatus>>({});
   const [creds, setCreds] = useState<Credentials | null>(null);
@@ -28,7 +34,9 @@ export function Console({ userEmail, userId }: { userEmail: string; userId: stri
   const [name, setName] = useState("");
   const [lat, setLat] = useState("");
   const [lon, setLon] = useState("");
-  const [stationType, setStationType] = useState<"digital" | "manual">("digital");
+  const [stationType, setStationType] = useState<"digital" | "manual">(
+    "digital",
+  );
   const [hardware, setHardware] = useState("");
 
   useEffect(() => {
@@ -73,7 +81,10 @@ export function Console({ userEmail, userId }: { userEmail: string; userId: stri
       setStations(next);
       saveStations(next);
       setCreds({ stationId: result.stationId, ingestKey: result.ingestKey });
-      setName(""); setLat(""); setLon(""); setHardware("");
+      setName("");
+      setLat("");
+      setLon("");
+      setHardware("");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Registration failed");
     } finally {
@@ -88,7 +99,9 @@ export function Console({ userEmail, userId }: { userEmail: string; userId: stri
           <h1 className="text-xl font-semibold">Mukoko Weather Stations</h1>
           <p className="dove">Signed in as {userEmail}</p>
         </div>
-        <a href="/auth/signout" className="impala">Sign out</a>
+        <a href="/auth/signout" className="impala">
+          Sign out
+        </a>
       </header>
 
       {error && (
@@ -100,15 +113,33 @@ export function Console({ userEmail, userId }: { userEmail: string; userId: stri
       {/* One-time credentials after registration */}
       {creds && (
         <section className="baobab space-y-2" aria-label="Station credentials">
-          <h2 className="giraffe">Save these credentials — the key is shown ONCE</h2>
-          <p className="dove">Station ID: <code>{creds.stationId}</code></p>
-          <p className="dove break-all">Ingest key: <code>{creds.ingestKey}</code></p>
+          <h2 className="giraffe">
+            Save these credentials — the key is shown ONCE
+          </h2>
+          <p className="dove">
+            Station ID: <code>{creds.stationId}</code>
+          </p>
+          <p className="dove break-all">
+            Ingest key: <code>{creds.ingestKey}</code>
+          </p>
           <div className="space-y-1 text-sm">
             <p className="giraffe">Point your station console at:</p>
-            <p className="dove">Wunderground protocol — server <code>weather.mukoko.com</code>, path <code>/api/py/stations/ingest</code>, ID = station ID, PASSWORD = ingest key</p>
-            <p className="dove">Ecowitt protocol — server <code>weather.mukoko.com</code>, path <code>/api/py/stations/ingest</code>, PASSKEY = <code>{creds.stationId}:{"<key>"}</code></p>
+            <p className="dove">
+              Wunderground protocol — server <code>weather.mukoko.com</code>,
+              path <code>/api/py/stations/ingest</code>, ID = station ID,
+              PASSWORD = ingest key
+            </p>
+            <p className="dove">
+              Ecowitt protocol — server <code>weather.mukoko.com</code>, path{" "}
+              <code>/api/py/stations/ingest</code>, PASSKEY ={" "}
+              <code>
+                {creds.stationId}:{"<key>"}
+              </code>
+            </p>
           </div>
-          <button className="impala" onClick={() => setCreds(null)}>I have saved them</button>
+          <button className="impala" onClick={() => setCreds(null)}>
+            I have saved them
+          </button>
         </section>
       )}
 
@@ -116,23 +147,59 @@ export function Console({ userEmail, userId }: { userEmail: string; userId: stri
       <section className="baobab space-y-3" aria-label="Register a station">
         <h2 className="giraffe">Register a station</h2>
         <form onSubmit={handleRegister} className="space-y-3">
-          <input className="field" required minLength={2} placeholder="Station name (e.g. Marondera High School)" value={name} onChange={(e) => setName(e.target.value)} />
+          <input
+            className="field"
+            required
+            minLength={2}
+            placeholder="Station name (e.g. Marondera High School)"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
           <div className="flex gap-2">
-            <input className="field" required placeholder="Latitude" inputMode="decimal" value={lat} onChange={(e) => setLat(e.target.value)} />
-            <input className="field" required placeholder="Longitude" inputMode="decimal" value={lon} onChange={(e) => setLon(e.target.value)} />
-            <button type="button" className="impala shrink-0" onClick={useGps}>Use GPS</button>
+            <input
+              className="field"
+              required
+              placeholder="Latitude"
+              inputMode="decimal"
+              value={lat}
+              onChange={(e) => setLat(e.target.value)}
+            />
+            <input
+              className="field"
+              required
+              placeholder="Longitude"
+              inputMode="decimal"
+              value={lon}
+              onChange={(e) => setLon(e.target.value)}
+            />
+            <button type="button" className="impala shrink-0" onClick={useGps}>
+              Use GPS
+            </button>
           </div>
           <div className="flex gap-4">
             <label className="flex items-center gap-2">
-              <input type="radio" checked={stationType === "digital"} onChange={() => setStationType("digital")} />
+              <input
+                type="radio"
+                checked={stationType === "digital"}
+                onChange={() => setStationType("digital")}
+              />
               Digital (uploads automatically)
             </label>
             <label className="flex items-center gap-2">
-              <input type="radio" checked={stationType === "manual"} onChange={() => setStationType("manual")} />
+              <input
+                type="radio"
+                checked={stationType === "manual"}
+                onChange={() => setStationType("manual")}
+              />
               Analog (manual readings)
             </label>
           </div>
-          <input className="field" placeholder="Hardware (optional, e.g. Ecowitt WS2910)" value={hardware} onChange={(e) => setHardware(e.target.value)} />
+          <input
+            className="field"
+            placeholder="Hardware (optional, e.g. Ecowitt WS2910)"
+            value={hardware}
+            onChange={(e) => setHardware(e.target.value)}
+          />
           <button type="submit" className="kudu w-full" disabled={busy}>
             {busy ? "Registering…" : "Register station"}
           </button>
@@ -142,7 +209,9 @@ export function Console({ userEmail, userId }: { userEmail: string; userId: stri
       {/* My stations */}
       <section className="space-y-3" aria-label="My stations">
         <h2 className="giraffe">My stations</h2>
-        {stations.length === 0 && <p className="dove">No stations on this device yet.</p>}
+        {stations.length === 0 && (
+          <p className="dove">No stations on this device yet.</p>
+        )}
         {stations.map((s) => (
           <StationCard
             key={s.stationId}
@@ -187,7 +256,11 @@ function StationCard({
         if (v !== "") payload[k] = parseFloat(v);
       }
       const res = await submitManualReading(station, payload);
-      setResult(res.qcStatus === "validated" ? `Saved — ${res.accepted} measurement(s) accepted` : "Rejected by quality checks");
+      setResult(
+        res.qcStatus === "validated"
+          ? `Saved — ${res.accepted} measurement(s) accepted`
+          : "Rejected by quality checks",
+      );
       setReading({});
     } catch (err) {
       setResult(err instanceof Error ? err.message : "Submit failed");
@@ -205,34 +278,73 @@ function StationCard({
         <div>
           <h3 className="giraffe">{station.name}</h3>
           <p className="dove">
-            {station.stationId} · {station.stationType === "manual" ? "Analog" : "Digital"} ·{" "}
+            {station.stationId} ·{" "}
+            {station.stationType === "manual" ? "Analog" : "Digital"} ·{" "}
             {status?.lastObservationAt
               ? `Last reading ${new Date(status.lastObservationAt).toLocaleString()}`
               : "No readings yet"}
           </p>
         </div>
-        <button className="impala" onClick={onRemove}>Remove</button>
+        <button className="impala" onClick={onRemove}>
+          Remove
+        </button>
       </div>
 
       {status?.latestMetrics && (
         <p className="dove">
           {Object.entries(status.latestMetrics)
-            .map(([k, v]) => `${k.replace(/([A-Z])/g, " $1").toLowerCase()}: ${v}`)
+            .map(
+              ([k, v]) => `${k.replace(/([A-Z])/g, " $1").toLowerCase()}: ${v}`,
+            )
             .join(" · ")}
         </p>
       )}
 
       <form onSubmit={submit} className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-        <input className="field" placeholder="Temp °C" inputMode="decimal" value={reading.temperatureC ?? ""} onChange={set("temperatureC")} />
-        <input className="field" placeholder="Rain mm" inputMode="decimal" value={reading.rainfallMm ?? ""} onChange={set("rainfallMm")} />
-        <input className="field" placeholder="Humidity %" inputMode="decimal" value={reading.humidityPercent ?? ""} onChange={set("humidityPercent")} />
-        <input className="field" placeholder="Pressure hPa" inputMode="decimal" value={reading.pressureHpa ?? ""} onChange={set("pressureHpa")} />
-        <input className="field" placeholder="Wind km/h" inputMode="decimal" value={reading.windKph ?? ""} onChange={set("windKph")} />
+        <input
+          className="field"
+          placeholder="Temp °C"
+          inputMode="decimal"
+          value={reading.temperatureC ?? ""}
+          onChange={set("temperatureC")}
+        />
+        <input
+          className="field"
+          placeholder="Rain mm"
+          inputMode="decimal"
+          value={reading.rainfallMm ?? ""}
+          onChange={set("rainfallMm")}
+        />
+        <input
+          className="field"
+          placeholder="Humidity %"
+          inputMode="decimal"
+          value={reading.humidityPercent ?? ""}
+          onChange={set("humidityPercent")}
+        />
+        <input
+          className="field"
+          placeholder="Pressure hPa"
+          inputMode="decimal"
+          value={reading.pressureHpa ?? ""}
+          onChange={set("pressureHpa")}
+        />
+        <input
+          className="field"
+          placeholder="Wind km/h"
+          inputMode="decimal"
+          value={reading.windKph ?? ""}
+          onChange={set("windKph")}
+        />
         <button type="submit" className="kudu" disabled={busy}>
           {busy ? "Saving…" : "Log reading"}
         </button>
       </form>
-      {result && <p className="dove" role="status">{result}</p>}
+      {result && (
+        <p className="dove" role="status">
+          {result}
+        </p>
+      )}
     </article>
   );
 }

--- a/station-console/src/lib/api.ts
+++ b/station-console/src/lib/api.ts
@@ -1,0 +1,77 @@
+/**
+ * Typed client for the station endpoints served by the mukoko-weather
+ * Python backend (the stable ingest/API layer — see api/py/_stations.py in
+ * this monorepo). The console is UI only; all writes go through that API.
+ */
+
+export const API_BASE =
+  process.env.NEXT_PUBLIC_WEATHER_API_BASE ?? "https://weather.mukoko.com";
+
+export interface RegisteredStation {
+  stationId: string;
+  key: string;
+  name: string;
+  stationType: "digital" | "manual";
+}
+
+export interface StationStatus {
+  stationId: string;
+  name: string;
+  stationType: string;
+  status: string;
+  lastObservationAt: string | null;
+  latestMetrics: Record<string, number> | null;
+}
+
+const STORE_KEY = "mws-console-stations";
+
+/** Local registry — station credentials live in the OWNER's browser only. */
+export function loadStations(): RegisteredStation[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORE_KEY) ?? "[]");
+  } catch {
+    return [];
+  }
+}
+
+export function saveStations(stations: RegisteredStation[]): void {
+  localStorage.setItem(STORE_KEY, JSON.stringify(stations));
+}
+
+export async function registerStation(body: {
+  name: string;
+  lat: number;
+  lon: number;
+  stationType: "digital" | "manual";
+  hardware?: string;
+  country?: string;
+}) {
+  const res = await fetch(`${API_BASE}/api/py/stations/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error((await res.json().catch(() => null))?.detail ?? `Registration failed (${res.status})`);
+  return res.json();
+}
+
+export async function fetchStatus(station: RegisteredStation): Promise<StationStatus> {
+  const res = await fetch(
+    `${API_BASE}/api/py/stations/status?id=${encodeURIComponent(station.stationId)}&key=${encodeURIComponent(station.key)}`,
+  );
+  if (!res.ok) throw new Error(`Status failed (${res.status})`);
+  return res.json();
+}
+
+export async function submitManualReading(
+  station: RegisteredStation,
+  reading: Record<string, number | string | undefined>,
+) {
+  const res = await fetch(`${API_BASE}/api/py/stations/manual`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ stationId: station.stationId, key: station.key, ...reading }),
+  });
+  if (!res.ok) throw new Error((await res.json().catch(() => null))?.detail ?? `Submit failed (${res.status})`);
+  return res.json();
+}

--- a/station-console/src/lib/api.ts
+++ b/station-console/src/lib/api.ts
@@ -51,11 +51,17 @@ export async function registerStation(body: {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error((await res.json().catch(() => null))?.detail ?? `Registration failed (${res.status})`);
+  if (!res.ok)
+    throw new Error(
+      (await res.json().catch(() => null))?.detail ??
+        `Registration failed (${res.status})`,
+    );
   return res.json();
 }
 
-export async function fetchStatus(station: RegisteredStation): Promise<StationStatus> {
+export async function fetchStatus(
+  station: RegisteredStation,
+): Promise<StationStatus> {
   const res = await fetch(
     `${API_BASE}/api/py/stations/status?id=${encodeURIComponent(station.stationId)}&key=${encodeURIComponent(station.key)}`,
   );
@@ -70,8 +76,16 @@ export async function submitManualReading(
   const res = await fetch(`${API_BASE}/api/py/stations/manual`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ stationId: station.stationId, key: station.key, ...reading }),
+    body: JSON.stringify({
+      stationId: station.stationId,
+      key: station.key,
+      ...reading,
+    }),
   });
-  if (!res.ok) throw new Error((await res.json().catch(() => null))?.detail ?? `Submit failed (${res.status})`);
+  if (!res.ok)
+    throw new Error(
+      (await res.json().catch(() => null))?.detail ??
+        `Submit failed (${res.status})`,
+    );
   return res.json();
 }

--- a/station-console/src/middleware.ts
+++ b/station-console/src/middleware.ts
@@ -1,0 +1,15 @@
+import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
+
+// Same WorkOS credentials as weather.mukoko.com (shared Nyuchi identity) —
+// only the redirect URI differs (this app's /callback must be registered in
+// the WorkOS dashboard).
+export default authkitMiddleware({
+  middlewareAuth: {
+    enabled: true,
+    unauthenticatedPaths: [],
+  },
+});
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/station-console/tsconfig.json
+++ b/station-console/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tests/py/test_index.py
+++ b/tests/py/test_index.py
@@ -244,3 +244,23 @@ class TestRouterMounting:
     def test_health_endpoint_mounted(self):
         paths = self._get_route_paths()
         assert "/api/py/health" in paths
+
+
+class TestStationsRouterMounted:
+    def test_stations_router_mounted(self):
+        paths = set()
+
+        def collect(routes):
+            for route in routes:
+                if hasattr(route, "path"):
+                    paths.add(route.path)
+                if hasattr(route, "original_router") and route.original_router:
+                    collect(route.original_router.routes)
+                elif hasattr(route, "routes"):
+                    collect(route.routes)
+
+        collect(app.routes)
+        assert "/api/py/stations/register" in paths
+        assert "/api/py/stations/ingest" in paths
+        assert "/api/py/stations/manual" in paths
+        assert "/api/py/stations/status" in paths

--- a/tests/py/test_stations.py
+++ b/tests/py/test_stations.py
@@ -1,0 +1,221 @@
+"""Tests for _stations.py — registration, WU/Ecowitt ingest, manual readings, QC."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from py._stations import (
+    _hash_key,
+    _qc_filter,
+    _find_station,
+    f_to_c,
+    mph_to_kph,
+    inhg_to_hpa,
+    inch_to_mm,
+    register_station,
+    manual_reading,
+    StationRegisterRequest,
+    ManualReadingRequest,
+    QC_RANGES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit conversions
+# ---------------------------------------------------------------------------
+
+
+class TestConversions:
+    def test_fahrenheit_to_celsius(self):
+        assert f_to_c(32) == 0
+        assert round(f_to_c(95), 1) == 35.0
+        assert f_to_c(None) is None
+
+    def test_mph_to_kph(self):
+        assert round(mph_to_kph(10), 2) == 16.09
+        assert mph_to_kph(None) is None
+
+    def test_inhg_to_hpa(self):
+        assert round(inhg_to_hpa(29.92), 0) == 1013
+        assert inhg_to_hpa(None) is None
+
+    def test_inches_to_mm(self):
+        assert inch_to_mm(1) == 25.4
+        assert inch_to_mm(None) is None
+
+
+# ---------------------------------------------------------------------------
+# QC range filter
+# ---------------------------------------------------------------------------
+
+
+class TestQcFilter:
+    def test_keeps_plausible_values(self):
+        out = _qc_filter({"airTemperatureCelsius": 25.5, "relativeHumidityPercent": 60})
+        assert out == {"airTemperatureCelsius": 25.5, "relativeHumidityPercent": 60.0}
+
+    def test_rejects_out_of_range(self):
+        out = _qc_filter({"airTemperatureCelsius": 95, "relativeHumidityPercent": 130})
+        assert out == {}
+
+    def test_drops_unknown_fields_and_nones(self):
+        out = _qc_filter({"hackField": 1, "airTemperatureCelsius": None})
+        assert out == {}
+
+    def test_every_range_has_sane_bounds(self):
+        for field, (lo, hi) in QC_RANGES.items():
+            assert lo < hi, field
+
+
+# ---------------------------------------------------------------------------
+# Station auth
+# ---------------------------------------------------------------------------
+
+
+class TestFindStation:
+    @patch("py._stations.stations_collection")
+    def test_matches_hashed_key(self, mock_coll):
+        mock_coll.return_value.find_one.return_value = {
+            "stationId": "mws-abcd1234",
+            "ingestKeyHash": _hash_key("secret"),
+        }
+        assert _find_station("mws-abcd1234", "secret") is not None
+
+    @patch("py._stations.stations_collection")
+    def test_rejects_wrong_key(self, mock_coll):
+        mock_coll.return_value.find_one.return_value = {
+            "stationId": "mws-abcd1234",
+            "ingestKeyHash": _hash_key("secret"),
+        }
+        assert _find_station("mws-abcd1234", "wrong") is None
+
+    def test_rejects_malformed_station_id(self):
+        assert _find_station("not-a-station", "key") is None
+        assert _find_station("", "") is None
+
+    @patch("py._stations.stations_collection")
+    def test_returns_none_on_db_error(self, mock_coll):
+        mock_coll.return_value.find_one.side_effect = Exception("db down")
+        assert _find_station("mws-abcd1234", "secret") is None
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def _make_request():
+    from fastapi import Request
+    req = MagicMock(spec=Request)
+    req.headers = {"x-forwarded-for": "1.2.3.4"}
+    req.client = MagicMock()
+    req.client.host = "1.2.3.4"
+    return req
+
+
+class TestRegister:
+    @pytest.mark.asyncio
+    @patch("py._stations.check_rate_limit", return_value={"allowed": True, "remaining": 2})
+    @patch("py._stations.stations_collection")
+    @patch("py._stations.get_client_ip", return_value="1.2.3.4")
+    async def test_registers_and_returns_key_once(self, _ip, mock_coll, _rate):
+        req = _make_request()
+        result = await register_station(
+            StationRegisterRequest(name="School Station", lat=-17.8, lon=31.0, stationType="manual"),
+            request=req,
+        )
+        assert result["stationId"].startswith("mws-")
+        assert len(result["ingestKey"]) >= 24
+        inserted = mock_coll.return_value.insert_one.call_args[0][0]
+        # Only the SHA-256 hash is persisted — never the raw key
+        assert inserted["ingestKeyHash"] == _hash_key(result["ingestKey"])
+        assert result["ingestKey"] not in str({k: v for k, v in inserted.items() if k != "ingestKeyHash"})
+        # GeoJSON point for the 2dsphere blend query
+        assert inserted["location"] == {"type": "Point", "coordinates": [31.0, -17.8]}
+        # Platform stamps present
+        assert inserted["_schemaVersion"]
+        assert inserted["bundu"]["countryCode"] == "ZW"
+
+    @pytest.mark.asyncio
+    @patch("py._stations.check_rate_limit", return_value={"allowed": False, "remaining": 0})
+    @patch("py._stations.get_client_ip", return_value="1.2.3.4")
+    async def test_rate_limited(self, _ip, _rate):
+        with pytest.raises(HTTPException) as exc:
+            await register_station(
+                StationRegisterRequest(name="Spam", lat=0, lon=0), request=_make_request()
+            )
+        assert exc.value.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# Manual readings
+# ---------------------------------------------------------------------------
+
+
+def _station_doc():
+    return {
+        "stationId": "mws-abcd1234",
+        "ingestKeyHash": _hash_key("secret"),
+        "location": {"type": "Point", "coordinates": [31.0, -17.8]},
+        "bundu": {"countryCode": "ZW"},
+    }
+
+
+class TestManualReading:
+    @pytest.mark.asyncio
+    @patch("py._stations.check_rate_limit", return_value={"allowed": True, "remaining": 11})
+    @patch("py._stations.observations_collection")
+    @patch("py._stations.station_observations_collection")
+    @patch("py._stations.stations_collection")
+    @patch("py._stations.get_client_ip", return_value="1.2.3.4")
+    async def test_valid_reading_becomes_validated_observation(
+        self, _ip, mock_stations, _mock_raw, mock_obs, _rate
+    ):
+        mock_stations.return_value.find_one.return_value = _station_doc()
+        result = await manual_reading(
+            ManualReadingRequest(stationId="mws-abcd1234", key="secret", temperatureC=21.5, rainfallMm=12),
+            request=_make_request(),
+        )
+        import json
+
+        body = json.loads(result.body)
+        assert body["qcStatus"] == "validated"
+        assert body["accepted"] == 2
+        obs = mock_obs.return_value.insert_one.call_args[0][0]
+        assert obs["qcStatus"] == "validated"
+        assert obs["sourceType"] == "manual"
+        assert obs["metrics"]["airTemperatureCelsius"] == 21.5
+        assert obs["location"]["type"] == "Point"
+
+    @pytest.mark.asyncio
+    @patch("py._stations.check_rate_limit", return_value={"allowed": True, "remaining": 11})
+    @patch("py._stations.stations_collection")
+    @patch("py._stations.get_client_ip", return_value="1.2.3.4")
+    async def test_wrong_key_is_401(self, _ip, mock_stations, _rate):
+        mock_stations.return_value.find_one.return_value = _station_doc()
+        with pytest.raises(HTTPException) as exc:
+            await manual_reading(
+                ManualReadingRequest(stationId="mws-abcd1234", key="nope", temperatureC=20),
+                request=_make_request(),
+            )
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    @patch("py._stations.check_rate_limit", return_value={"allowed": True, "remaining": 11})
+    @patch("py._stations.stations_collection")
+    @patch("py._stations.get_client_ip", return_value="1.2.3.4")
+    async def test_empty_reading_is_400(self, _ip, mock_stations, _rate):
+        mock_stations.return_value.find_one.return_value = _station_doc()
+        with pytest.raises(HTTPException) as exc:
+            await manual_reading(
+                ManualReadingRequest(stationId="mws-abcd1234", key="secret"),
+                request=_make_request(),
+            )
+        assert exc.value.status_code == 400
+
+    def test_pydantic_rejects_impossible_values(self):
+        with pytest.raises(Exception):
+            ManualReadingRequest(stationId="mws-abcd1234", key="k", temperatureC=99)

--- a/tests/py/test_stations.py
+++ b/tests/py/test_stations.py
@@ -80,7 +80,8 @@ class TestFindStation:
     def test_matches_hashed_key(self, mock_coll):
         mock_coll.return_value.find_one.return_value = {
             "stationId": "mws-abcd1234",
-            "ingestKeyHash": _hash_key("secret"),
+            "ingestKeySalt": "aa" * 16,
+            "ingestKeyHash": _hash_key("secret", "aa" * 16),
         }
         assert _find_station("mws-abcd1234", "secret") is not None
 
@@ -88,9 +89,15 @@ class TestFindStation:
     def test_rejects_wrong_key(self, mock_coll):
         mock_coll.return_value.find_one.return_value = {
             "stationId": "mws-abcd1234",
-            "ingestKeyHash": _hash_key("secret"),
+            "ingestKeySalt": "aa" * 16,
+            "ingestKeyHash": _hash_key("secret", "aa" * 16),
         }
         assert _find_station("mws-abcd1234", "wrong") is None
+
+    @patch("py._stations.stations_collection")
+    def test_rejects_doc_missing_salt_or_hash(self, mock_coll):
+        mock_coll.return_value.find_one.return_value = {"stationId": "mws-abcd1234"}
+        assert _find_station("mws-abcd1234", "secret") is None
 
     def test_rejects_malformed_station_id(self):
         assert _find_station("not-a-station", "key") is None
@@ -130,8 +137,8 @@ class TestRegister:
         assert result["stationId"].startswith("mws-")
         assert len(result["ingestKey"]) >= 24
         inserted = mock_coll.return_value.insert_one.call_args[0][0]
-        # Only the SHA-256 hash is persisted — never the raw key
-        assert inserted["ingestKeyHash"] == _hash_key(result["ingestKey"])
+        # Only the salted PBKDF2 hash is persisted — never the raw key
+        assert inserted["ingestKeyHash"] == _hash_key(result["ingestKey"], inserted["ingestKeySalt"])
         assert result["ingestKey"] not in str({k: v for k, v in inserted.items() if k != "ingestKeyHash"})
         # GeoJSON point for the 2dsphere blend query
         assert inserted["location"] == {"type": "Point", "coordinates": [31.0, -17.8]}
@@ -158,7 +165,8 @@ class TestRegister:
 def _station_doc():
     return {
         "stationId": "mws-abcd1234",
-        "ingestKeyHash": _hash_key("secret"),
+        "ingestKeySalt": "aa" * 16,
+        "ingestKeyHash": _hash_key("secret", "aa" * 16),
         "location": {"type": "Point", "coordinates": [31.0, -17.8]},
         "bundu": {"countryCode": "ZW"},
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -30,5 +36,9 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "worker"]
+  "exclude": [
+    "node_modules",
+    "worker",
+    "station-console"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": [
@@ -36,9 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": [
-    "node_modules",
-    "worker",
-    "station-console"
-  ]
+  "exclude": ["node_modules", "worker", "station-console"]
 }


### PR DESCRIPTION
## Summary

The backend half of the community weather-station plan. Consumer stations (Ecowitt/Fine Offset families, Ambient-style consoles) support a "customized upload" server setting — this PR gives them a **first-party destination**: stations push straight to `weather.mukoko.com`, no Weather Underground middleman, and readings flow into the existing StationKit blend (`/api/py/weather` already serves any validated observation within 50 km as `X-Current-Source: stationkit`).

- **`POST /api/py/stations/register`** — creates a station (`digital` or `manual`/analog). The ingest key is returned exactly once (SHA-256 at rest); response includes per-protocol custom-server setup instructions. 3/hour/IP.
- **`GET|POST /api/py/stations/ingest`** — one path, two de-facto protocols: Wunderground (GET query params, responds with the literal `success` body the protocol requires) and Ecowitt (POST form, `PASSKEY=<stationId>:<ingestKey>`). Imperial→metric conversion (°F, mph, inHg, inches), inline QC range checks; raw payloads archived in `weather.stationObservations`, passing metrics become validated `weather.observations` docs with GeoJSON locations.
- **`POST /api/py/stations/manual`** — the analog path for farmers and schools with rain gauges and min/max thermometers but no digital infrastructure. Station-key auth, Pydantic range validation, same QC/observation flow. 12/hour/IP.
- **`GET /api/py/stations/status`** — last-seen + latest metrics for the owner's console.

**Deliberately no console UI in this app** — per the architecture decision, mukoko-weather stays the read-only weather surface; the station console ships as a separate web-only app (no PWA/offline) consuming these APIs.

## Tests

- `tests/py/test_stations.py` — 18 tests: unit conversions, QC filter (plausible ranges, unknown-field/None rejection), hashed-key auth (wrong key, malformed id, DB-error safety), registration (key never persisted raw, GeoJSON point, platform stamps, rate limit), manual readings (validated observation write, 401/400 paths, Pydantic bounds)
- Full suite: 998 Python + 2078 TS passing; lint 0 errors; tsc clean; build green
- CLAUDE.md: routing entries, rate-limit list, structure tree, test list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW

---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_