### PR TITLE
Station console: Nyuchi Design system rebrand + footer outbound-link fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ next-env.d.ts
 .worktrees/
 .venv/
 .env*.local
+
+# station-console sub-app (own Vercel project)
+station-console/node_modules
+station-console/.next

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,7 @@
+{
+  // markdownlint-cli2 settings (rule config stays in .markdownlint.jsonc).
+  // The Nyuchi Design agent skills are fetched verbatim from the registry
+  // (design.nyuchi.com, versions pinned in .nyuchi-design.json) — linting
+  // them locally would force edits that drift from upstream.
+  "ignores": ["**/node_modules/**", "station-console/.claude/skills/**"]
+}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,5 +3,5 @@
   // The Nyuchi Design agent skills are fetched verbatim from the registry
   // (design.nyuchi.com, versions pinned in .nyuchi-design.json) — linting
   // them locally would force edits that drift from upstream.
-  "ignores": ["**/node_modules/**", "station-console/.claude/skills/**"]
+  "ignores": ["**/node_modules/**", "station-console/.claude/skills/**"],
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,7 @@ CODEOWNERS.example
 *-lock.yaml
 package-lock.json
 pnpm-lock.yaml
+
+# Nyuchi Design registry artifacts — fetched verbatim from design.nyuchi.com
+# (versions pinned in .nyuchi-design.json); reformatting would drift from upstream
+station-console/.claude/skills/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,10 @@ mukoko-weather/
 │       └── _tiles.py              # Map tile proxy for Tomorrow.io
 ├── station-console/               # Station console app (MONOREPO sub-app — separate Vercel project at weatherstations.nyuchi.com)
 │   ├── package.json               # Own Next.js app: web-only, NO PWA/offline; WorkOS AuthKit with the SAME credentials as the main app (register the /callback redirect URI in WorkOS)
-│   └── src/                       # Auth-gated console: register stations, one-time credentials + WU/Ecowitt setup instructions, manual readings, status. Calls the /api/py/stations/* endpoints (CORS-allowed origin); station keys live in the owner's browser localStorage
+│   ├── components.json            # Nyuchi Design registry config — bootstrapped via `npx @nyuchi/design-cli init`, components installed from the registry (design.nyuchi.com → mzizi.dev) via the shadcn CLI
+│   ├── .claude/skills/            # Nyuchi Design agent skills (`npx @nyuchi/design-cli skills install`; versions pinned in .nyuchi-design.json)
+│   └── src/                       # Auth-gated console: register stations, one-time credentials + WU/Ecowitt setup instructions, manual readings, status. Calls the /api/py/stations/* endpoints (CORS-allowed origin); station keys live in the owner's browser localStorage.
+│                                  # Styling per Mzizi doctrine: canonical Nyuchi L1 tokens in src/app/globals.css + registry L2 primitives in src/components/ui/ (Button, Input, Label, Card, Badge, Alert, RadioGroup) — pages are pure composition, no hand-rolled CSS classes or inline styles; theme via next-themes (class-based dark mode); fonts Noto Sans/Serif + JetBrains Mono via next/font
 ├── worker/                        # Cloudflare Workers edge API (optional)
 │   ├── src/
 │   │   ├── index.ts               # Hono app, route mounting, CORS

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -16,173 +16,316 @@ export default function TermsPage() {
   return (
     <>
       <Header />
-      <main id="main-content" className="mx-auto max-w-3xl px-4 py-10 pb-24 sm:pb-10 sm:px-6 md:px-8">
-        <h1 className="font-display text-3xl font-bold text-text-primary sm:text-4xl">Terms of Service</h1>
-        <p className="mt-2 text-base text-text-tertiary">Last updated: June 2026</p>
+      <main
+        id="main-content"
+        className="mx-auto max-w-3xl px-4 py-10 pb-24 sm:pb-10 sm:px-6 md:px-8"
+      >
+        <h1 className="font-display text-3xl font-bold text-text-primary sm:text-4xl">
+          Terms of Service
+        </h1>
+        <p className="mt-2 text-base text-text-tertiary">
+          Last updated: June 2026
+        </p>
 
         <div className="mt-8 space-y-8 text-text-secondary leading-relaxed">
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">1. Agreement</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              1. Agreement
+            </h2>
             <p className="mt-3">
-              These Terms of Service (&quot;Terms&quot;) govern your use of mukoko weather
-              (&quot;the Service&quot;), operated by <strong className="text-text-primary">Mukoko Africa</strong>,
-              a division of <strong className="text-text-primary">Nyuchi Africa (PVT) Ltd</strong>
-              (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;). The Service is developed by
-              Nyuchi Web Services.
+              These Terms of Service (&quot;Terms&quot;) govern your use of
+              mukoko weather (&quot;the Service&quot;), operated by{" "}
+              <strong className="text-text-primary">Mukoko Africa</strong>, a
+              division of{" "}
+              <strong className="text-text-primary">
+                Nyuchi Africa (PVT) Ltd
+              </strong>
+              (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;). The Service is
+              developed by Nyuchi Web Services.
             </p>
             <p className="mt-3">
               By accessing or using the Service at{" "}
-              <a href="https://weather.mukoko.com" className="text-primary underline">weather.mukoko.com</a>,
-              you agree to be bound by these Terms. If you do not agree, please do not use the Service.
+              <a
+                href="https://weather.mukoko.com"
+                className="text-primary underline"
+              >
+                weather.mukoko.com
+              </a>
+              , you agree to be bound by these Terms. If you do not agree,
+              please do not use the Service.
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">2. Description of Service</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              2. Description of Service
+            </h2>
             <p className="mt-3">
-              mukoko weather provides weather forecasts, current conditions, AI-generated weather summaries,
-              frost alerts, aviation weather briefings (METAR/TAF), interactive weather maps, and community
-              weather reporting for locations globally. The core Service is provided free of charge.
+              mukoko weather provides weather forecasts, current conditions,
+              AI-generated weather summaries, frost alerts, aviation weather
+              briefings (METAR/TAF), interactive weather maps, and community
+              weather reporting for locations globally. The core Service is
+              provided free of charge.
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">3. Weather data disclaimer</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              3. Weather data disclaimer
+            </h2>
             <p className="mt-3">
-              Weather information provided by the Service is sourced from third-party data providers
-              (Tomorrow.io, Open-Meteo) and AI models (Anthropic Claude). While we strive for accuracy:
+              Weather information provided by the Service is sourced from
+              third-party data providers (Tomorrow.io, Open-Meteo) and AI models
+              (Anthropic Claude). While we strive for accuracy:
             </p>
             <ul className="mt-2 list-disc pl-6 space-y-1">
-              <li>Weather forecasts are inherently uncertain and should be used as guidance, not guarantees</li>
-              <li>AI-generated summaries are informational and should not be the sole basis for critical decisions</li>
-              <li>Frost alerts are automated estimates and do not replace professional agricultural advice</li>
-              <li>Community weather reports are user-submitted and unverified — they should be treated as anecdotal observations only</li>
-              <li>We do not guarantee the accuracy, completeness, or timeliness of any weather data</li>
+              <li>
+                Weather forecasts are inherently uncertain and should be used as
+                guidance, not guarantees
+              </li>
+              <li>
+                AI-generated summaries are informational and should not be the
+                sole basis for critical decisions
+              </li>
+              <li>
+                Frost alerts are automated estimates and do not replace
+                professional agricultural advice
+              </li>
+              <li>
+                Community weather reports are user-submitted and unverified —
+                they should be treated as anecdotal observations only
+              </li>
+              <li>
+                We do not guarantee the accuracy, completeness, or timeliness of
+                any weather data
+              </li>
             </ul>
             <p className="mt-3">
-              For critical decisions affecting life, property, or agriculture, always consult your
-              local meteorological service and relevant professional advisors.
+              For critical decisions affecting life, property, or agriculture,
+              always consult your local meteorological service and relevant
+              professional advisors.
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">4. Aviation weather disclaimer</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              4. Aviation weather disclaimer
+            </h2>
             <p className="mt-3">
-              The aviation weather features (METAR observations, TAF forecasts, and pre-flight weather
-              briefings including PDF exports) are provided for <strong className="text-text-primary">planning and informational purposes only</strong>.
+              The aviation weather features (METAR observations, TAF forecasts,
+              and pre-flight weather briefings including PDF exports) are
+              provided for{" "}
+              <strong className="text-text-primary">
+                planning and informational purposes only
+              </strong>
+              .
             </p>
             <ul className="mt-2 list-disc pl-6 space-y-1">
-              <li>Aviation weather data is sourced from the Aviation Weather Center (NOAA) and may be delayed, incomplete, or unavailable</li>
-              <li>PDF briefings generated by the Service do not constitute an official pre-flight weather briefing</li>
-              <li>Pilots must obtain an official briefing from their national civil aviation authority (e.g. CAA Zimbabwe) or authorised aeronautical information service before flight</li>
-              <li>Always verify NOTAMs, airspace restrictions, and current conditions with official sources</li>
-              <li>Do not make flight decisions based solely on information from this Service</li>
+              <li>
+                Aviation weather data is sourced from the Aviation Weather
+                Center (NOAA) and may be delayed, incomplete, or unavailable
+              </li>
+              <li>
+                PDF briefings generated by the Service do not constitute an
+                official pre-flight weather briefing
+              </li>
+              <li>
+                Pilots must obtain an official briefing from their national
+                civil aviation authority (e.g. CAA Zimbabwe) or authorised
+                aeronautical information service before flight
+              </li>
+              <li>
+                Always verify NOTAMs, airspace restrictions, and current
+                conditions with official sources
+              </li>
+              <li>
+                Do not make flight decisions based solely on information from
+                this Service
+              </li>
             </ul>
             <p className="mt-3">
-              <strong className="text-text-primary">We expressly disclaim all liability for any aviation incidents, accidents, or losses arising from reliance on aviation weather information provided by this Service.</strong>
+              <strong className="text-text-primary">
+                We expressly disclaim all liability for any aviation incidents,
+                accidents, or losses arising from reliance on aviation weather
+                information provided by this Service.
+              </strong>
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">5. Community weather reports</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              5. Community weather reports
+            </h2>
             <p className="mt-3">
               By submitting a community weather report, you:
             </p>
             <ul className="mt-2 list-disc pl-6 space-y-1">
-              <li>Confirm that the report reflects your genuine current observation</li>
-              <li>Grant us a non-exclusive licence to display and use the report within the Service</li>
-              <li>Acknowledge that reports are publicly visible to other users of the Service</li>
+              <li>
+                Confirm that the report reflects your genuine current
+                observation
+              </li>
+              <li>
+                Grant us a non-exclusive licence to display and use the report
+                within the Service
+              </li>
+              <li>
+                Acknowledge that reports are publicly visible to other users of
+                the Service
+              </li>
               <li>Agree not to submit false, misleading, or harmful reports</li>
             </ul>
             <p className="mt-3">
-              Reports are automatically removed after 24–72 hours. We reserve the right to remove any
-              report that violates these Terms or our community standards.
+              Reports are automatically removed after 24–72 hours. We reserve
+              the right to remove any report that violates these Terms or our
+              community standards.
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">6. Acceptable use</h2>
-            <p className="mt-3">You may use the Service for personal, educational, and commercial purposes. You may not:</p>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              6. Acceptable use
+            </h2>
+            <p className="mt-3">
+              You may use the Service for personal, educational, and commercial
+              purposes. You may not:
+            </p>
             <ul className="mt-2 list-disc pl-6 space-y-1">
-              <li>Attempt to disrupt, overload, or interfere with the Service&apos;s infrastructure</li>
-              <li>Use automated systems to scrape or harvest data at a rate that impacts other users</li>
-              <li>Misrepresent the Service as your own product or remove attribution</li>
-              <li>Submit false community weather reports or attempt to manipulate the reporting system</li>
+              <li>
+                Attempt to disrupt, overload, or interfere with the
+                Service&apos;s infrastructure
+              </li>
+              <li>
+                Use automated systems to scrape or harvest data at a rate that
+                impacts other users
+              </li>
+              <li>
+                Misrepresent the Service as your own product or remove
+                attribution
+              </li>
+              <li>
+                Submit false community weather reports or attempt to manipulate
+                the reporting system
+              </li>
               <li>Use the Service for any unlawful purpose</li>
             </ul>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">7. API and embed usage</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              7. API and embed usage
+            </h2>
             <p className="mt-3">
-              The Service provides API endpoints and an embeddable widget. These are provided for
-              reasonable use. We reserve the right to rate-limit or restrict access to API endpoints
-              if usage is excessive or impacts the Service for other users.
+              The Service provides API endpoints and an embeddable widget. These
+              are provided for reasonable use. We reserve the right to
+              rate-limit or restrict access to API endpoints if usage is
+              excessive or impacts the Service for other users.
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">8. Intellectual property</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              8. Intellectual property
+            </h2>
             <p className="mt-3">
-              The mukoko weather name, logo, and brand are trademarks of Mukoko Africa / Nyuchi Africa (PVT) Ltd.
-              The Service&apos;s source code is licensed under the{" "}
-              <a href="https://github.com/nyuchitech/mukoko-weather/blob/main/LICENSE" className="text-primary underline" rel="noopener noreferrer">
+              The mukoko weather name, logo, and brand are trademarks of Mukoko
+              Africa / Nyuchi Africa (PVT) Ltd. The Service&apos;s source code
+              is licensed under the{" "}
+              <a
+                href="https://github.com/nyuchi/mukoko-weather/blob/main/LICENSE"
+                className="text-primary underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 MIT License
               </a>
-              . Weather data is provided by Open-Meteo, Tomorrow.io, and the Aviation Weather Center
-              under their respective terms.
+              . Weather data is provided by Open-Meteo, Tomorrow.io, and the
+              Aviation Weather Center under their respective terms.
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">9. Limitation of liability</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              9. Limitation of liability
+            </h2>
             <p className="mt-3">
-              THE SERVICE IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTIES
-              OF ANY KIND, EITHER EXPRESS OR IMPLIED. TO THE FULLEST EXTENT PERMITTED BY LAW, NYUCHI
-              AFRICA (PVT) LTD AND ITS DIVISIONS SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
-              SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING FROM YOUR USE OF THE SERVICE.
+              THE SERVICE IS PROVIDED &quot;AS IS&quot; AND &quot;AS
+              AVAILABLE&quot; WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR
+              IMPLIED. TO THE FULLEST EXTENT PERMITTED BY LAW, NYUCHI AFRICA
+              (PVT) LTD AND ITS DIVISIONS SHALL NOT BE LIABLE FOR ANY INDIRECT,
+              INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING
+              FROM YOUR USE OF THE SERVICE.
             </p>
             <p className="mt-3">
-              This includes, without limitation, damages for loss of crops, business interruption,
-              travel disruption, aviation incidents, or any decisions made based on weather or aviation
-              information from the Service.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">10. Service availability</h2>
-            <p className="mt-3">
-              We aim to keep the Service available at all times but do not guarantee uninterrupted access.
-              The Service may be temporarily unavailable due to maintenance, updates, or circumstances
-              beyond our control. We reserve the right to modify or discontinue the Service at any time.
+              This includes, without limitation, damages for loss of crops,
+              business interruption, travel disruption, aviation incidents, or
+              any decisions made based on weather or aviation information from
+              the Service.
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">11. Changes to these Terms</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              10. Service availability
+            </h2>
             <p className="mt-3">
-              We may update these Terms from time to time. Changes will be posted on this page with an
-              updated date. Your continued use of the Service after changes constitutes acceptance of the
-              revised Terms.
+              We aim to keep the Service available at all times but do not
+              guarantee uninterrupted access. The Service may be temporarily
+              unavailable due to maintenance, updates, or circumstances beyond
+              our control. We reserve the right to modify or discontinue the
+              Service at any time.
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">12. Governing law</h2>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              11. Changes to these Terms
+            </h2>
             <p className="mt-3">
-              These Terms are governed by the laws of the Republic of Zimbabwe, where Nyuchi Africa (PVT)
-              Ltd is incorporated. Any disputes arising from these Terms or your use of the Service shall
-              be subject to the jurisdiction of the courts of Zimbabwe. If you access the Service from
-              outside Zimbabwe, you are responsible for compliance with your local laws.
+              We may update these Terms from time to time. Changes will be
+              posted on this page with an updated date. Your continued use of
+              the Service after changes constitutes acceptance of the revised
+              Terms.
             </p>
           </section>
 
           <section>
-            <h2 className="font-heading text-xl font-bold text-text-primary">13. Contact</h2>
-            <p className="mt-3">For questions about these Terms, contact us at:</p>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              12. Governing law
+            </h2>
+            <p className="mt-3">
+              These Terms are governed by the laws of the Republic of Zimbabwe,
+              where Nyuchi Africa (PVT) Ltd is incorporated. Any disputes
+              arising from these Terms or your use of the Service shall be
+              subject to the jurisdiction of the courts of Zimbabwe. If you
+              access the Service from outside Zimbabwe, you are responsible for
+              compliance with your local laws.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="font-heading text-xl font-bold text-text-primary">
+              13. Contact
+            </h2>
+            <p className="mt-3">
+              For questions about these Terms, contact us at:
+            </p>
             <ul className="mt-2 space-y-1">
-              <li><a href="mailto:legal@nyuchi.com" className="text-primary underline">legal@nyuchi.com</a></li>
-              <li><a href="mailto:support@mukoko.com" className="text-primary underline">support@mukoko.com</a></li>
+              <li>
+                <a
+                  href="mailto:legal@nyuchi.com"
+                  className="text-primary underline"
+                >
+                  legal@nyuchi.com
+                </a>
+              </li>
+              <li>
+                <a
+                  href="mailto:support@mukoko.com"
+                  className="text-primary underline"
+                >
+                  support@mukoko.com
+                </a>
+              </li>
             </ul>
             <p className="mt-3 text-base text-text-tertiary">
               Mukoko Africa, a division of Nyuchi Africa (PVT) Ltd
@@ -191,8 +334,18 @@ export default function TermsPage() {
         </div>
 
         <nav className="mt-10 flex gap-4 text-base" aria-label="Legal pages">
-          <Link href="/about" className="text-primary underline hover:text-primary/80 transition-colors">About</Link>
-          <Link href="/privacy" className="text-primary underline hover:text-primary/80 transition-colors">Privacy Policy</Link>
+          <Link
+            href="/about"
+            className="text-primary underline hover:text-primary/80 transition-colors"
+          >
+            About
+          </Link>
+          <Link
+            href="/privacy"
+            className="text-primary underline hover:text-primary/80 transition-colors"
+          >
+            Privacy Policy
+          </Link>
         </nav>
       </main>
       <Footer />

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -69,7 +69,7 @@ export function Footer() {
                 </svg>
               </a>
               <a
-                href="https://github.com/nyuchitech/mukoko-weather"
+                href="https://github.com/nyuchi/mukoko-weather"
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="GitHub"
@@ -134,7 +134,7 @@ export function Footer() {
               Contact
             </a>
             <a
-              href="https://github.com/nyuchitech/mukoko-weather/issues/new/choose"
+              href="https://github.com/nyuchi/mukoko-weather/issues/new/choose"
               target="_blank"
               rel="noopener noreferrer"
               className={link}
@@ -170,14 +170,6 @@ export function Footer() {
             >
               Barstool
             </a>
-            <a
-              href="https://travel.mukoko.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className={link}
-            >
-              Travel
-            </a>
           </div>
         </div>
 
@@ -187,8 +179,9 @@ export function Footer() {
             &copy; {year} Mukoko Africa — a division of{" "}
             <a
               href="https://nyuchi.com"
+              target="_blank"
+              rel="noopener noreferrer"
               className="transition-colors hover:text-text-secondary"
-              rel="noopener"
             >
               Nyuchi Africa (PVT) Ltd
             </a>
@@ -198,16 +191,18 @@ export function Footer() {
             Weather data:{" "}
             <a
               href="https://www.tomorrow.io"
-              className="hover:text-text-secondary transition-colors"
+              target="_blank"
               rel="noopener noreferrer"
+              className="hover:text-text-secondary transition-colors"
             >
               Tomorrow.io
             </a>
             {" & "}
             <a
               href="https://open-meteo.com"
-              className="hover:text-text-secondary transition-colors"
+              target="_blank"
               rel="noopener noreferrer"
+              className="hover:text-text-secondary transition-colors"
             >
               Open-Meteo
             </a>

--- a/src/lib/observability.test.ts
+++ b/src/lib/observability.test.ts
@@ -229,7 +229,9 @@ describe("sendAlert", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok"));
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok"));
     vi.stubEnv("ALERT_WEBHOOK_URL", "");
   });
 
@@ -304,7 +306,9 @@ describe("sendAlert", () => {
     });
 
     expect(fetchSpy).toHaveBeenCalledOnce();
-    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+    );
     expect(body.mukoko_alert.location).toBe("harare");
   });
 
@@ -332,7 +336,7 @@ describe("sendAlert", () => {
 describe("buildIssueUrl", () => {
   it("returns a GitHub issue URL with template and title", () => {
     const url = buildIssueUrl({ title: "Test error" });
-    expect(url).toContain("github.com/nyuchitech/mukoko-weather/issues/new");
+    expect(url).toContain("github.com/nyuchi/mukoko-weather/issues/new");
     expect(url).toContain("template=bug_report.yml");
     expect(url).toContain("title=%5BBug%5D+Test+error");
   });

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -159,9 +159,9 @@ function shouldAlert(key: string): boolean {
 }
 
 const SEVERITY_EMOJI: Record<ErrorSeverity, string> = {
-  low: "\u2139\uFE0F",      // ℹ️
-  medium: "\u26A0\uFE0F",   // ⚠️
-  high: "\uD83D\uDED1",     // 🛑
+  low: "\u2139\uFE0F", // ℹ️
+  medium: "\u26A0\uFE0F", // ⚠️
+  high: "\uD83D\uDED1", // 🛑
   critical: "\uD83D\uDD34", // 🔴
 };
 
@@ -200,7 +200,9 @@ export function sendAlert(ctx: ErrorContext): void {
         type: "context",
         elements: [
           { type: "mrkdwn", text: `*Time:* ${timestamp}` },
-          ...(ctx.meta ? [{ type: "mrkdwn", text: `*Meta:* ${JSON.stringify(ctx.meta)}` }] : []),
+          ...(ctx.meta
+            ? [{ type: "mrkdwn", text: `*Meta:* ${JSON.stringify(ctx.meta)}` }]
+            : []),
         ],
       },
     ],
@@ -258,9 +260,11 @@ export function buildIssueUrl(context: {
     "",
     "## Expected behaviour",
     "The page should load without errors.",
-  ].filter(Boolean).join("\n");
+  ]
+    .filter(Boolean)
+    .join("\n");
 
   params.set("body", body);
 
-  return `https://github.com/nyuchitech/mukoko-weather/issues/new?${params.toString()}`;
+  return `https://github.com/nyuchi/mukoko-weather/issues/new?${params.toString()}`;
 }

--- a/station-console/.claude/skills/bundu-design.md
+++ b/station-console/.claude/skills/bundu-design.md
@@ -1,0 +1,95 @@
+# Bundu — _The Ecosystem_
+
+**Bundu** (Shona: _wilderness_) is the parent identity of the Bundu ecosystem — the complete ecosystem
+built by Nyuchi Africa. Three pillars: **mukoko** (consumer super app), **nyuchi** (infrastructure &
+enterprise), and the **sister brands** (specialist verticals) — one identity, one design system, one
+open data commons.
+
+All values here are verified against `nyuchi_design_db → component_documents` (collections
+`styling-ecosystem`, `genetic-code-ubuntu-pillars`, `genetic-code-ubuntu-principles`), doctrine
+**v4.1.0**. **The database is the source of truth** — re-pull before assuming; doctrine evolves.
+(Notably: principles were renamed in v4.x — use the set below, not older Shona-named lists. One
+known DB error, corrected by the founder: the `styling-ecosystem → bundu` row carries `bundu.family`
+and family framing — the correct URL is **bundu.org** and the correct framing is **the Bundu
+ecosystem**. Trust this file over the DB for those two fields until the row is fixed.)
+
+## Bundu's own identity
+
+- **Mineral:** `copper` — `#BF5A36` light / `#FF8A65` dark · connection, foundation, stewardship
+- **Meaning:** Wilderness · **Language:** Shona · **URL:** <https://bundu.org>
+- **Voice:** visionary, grounded, inclusive
+- **Role:** the ecosystem — the layer that holds the whole, the commons, governance, philosophy
+- **Wordmark:** `bundu`, lowercase always, Noto Serif 600 (per ecosystem rule)
+- **No standalone Bundu logo mark is registered in the design DB yet** — that's an open identity
+  item. Until one exists, ecosystem-level materials use the wordmark in copper, optionally with
+  Mukoko's Swarm mark when the subject is the product family. Don't invent a Bundu mark ad hoc.
+
+## The brand constellation (verified, v4.1.0)
+
+Every brand owns a mineral and a voice. Theme each brand's surfaces and copy in **its own** mineral
+and register — never default everything to tanzanite.
+
+| Brand        | Role                        | Mineral    | Meaning    | Voice                                  |
+| ------------ | --------------------------- | ---------- | ---------- | -------------------------------------- |
+| **bundu**    | The ecosystem               | copper     | Wilderness | visionary, grounded, inclusive         |
+| **nyuchi**   | Infrastructure & enterprise | gold       | Bee        | technical, reliable, industrious       |
+| **mukoko**   | Africa's super app          | tanzanite  | Beehive    | welcoming, structured, protective      |
+| **shamwari** | Sovereign AI companion      | sodalite   | Friend     | helpful, warm, intelligent             |
+| nhimbe       | Events & gatherings         | malachite  | Gathering  | celebratory, communal, vibrant         |
+| bushtrade    | Marketplace                 | gold       | Bush trade | practical, trustworthy, local          |
+| lingo        | Language learning           | cobalt     | Language   | encouraging, cultural, playful         |
+| campfire     | Platform messaging anchor   | malachite  | Campfire   | direct, warm, always present           |
+| bytes        | Short-form creator video    | tanzanite  | Bytes      | energetic, creative, youthful          |
+| novels       | Publishing platform         | malachite  | Novels     | literary, thoughtful, immersive        |
+| places       | Geographic knowledge graph  | gold       | Places     | authoritative, helpful, discoverable   |
+| transport    | Public transit & booking    | gold       | Transport  | efficient, reliable, practical         |
+| planner      | Productivity hub            | cobalt     | Planner    | organised, clear, supportive           |
+| wallet       | Payments & tokens           | gold       | Wallet     | trustworthy, precise, secure           |
+| pulse        | Feed & Mukoko Home          | tanzanite  | Pulse      | personal, adaptive, ambient            |
+| health       | Wellness & telemedicine     | malachite  | Health     | caring, accurate, private              |
+| circles      | Community messaging         | terracotta | Circles    | inclusive, moderated, community-driven |
+
+The narrative spine: **nyuchi is the bee, mukoko is the hive, bundu is the wilderness the hive
+lives in.** Use this when explaining the ecosystem — it is the one-sentence architecture.
+
+## Ubuntu as identity (live doctrine)
+
+Bundu carries the philosophy. _Ndiri nekuti tiri_ — I am because we are.
+
+**Five Pillars** (spheres of belonging): **family** (the household and kin, the primary web of
+belonging) → **community** (neighbours, peers, chosen kin) → **society** (the broader human web —
+strangers, institutions, the polity) → **environment** (the natural world that holds all
+relationships; Ubuntu is ecological before it is social) → **spirituality** (the vertical axis —
+meaning, purpose, ancestry, the sacred).
+
+**Five Principles** (operating rules): **survival** (collective endurance — no one survives alone) ·
+**solidarity** (firm, persevering commitment to the common good) · **compassion** (active care shown
+through helping, sharing, welcoming) · **respect** (unprejudiced consideration of another's
+privileges, beliefs, norms — includes elder-respect) · **dignity** (inherent worth by virtue of
+existence, irrespective of status or background).
+
+In ecosystem materials, philosophy is **structural, not decorative**: name a pillar/principle only
+when the feature or message genuinely embodies it.
+
+## Rules for ecosystem-level work
+
+- **Lowercase wordmarks, always** — `bundu`, `nyuchi`, `mukoko`, `shamwari`, and every sister brand.
+- **Copper accents** signal "this is the ecosystem speaking" (parent-level pages, governance,
+  commons, manifesto-register material).
+- **Cross-brand layouts:** lead with the brand that owns the message; bring in the constellation
+  table's minerals when showing the family together (each brand in its own mineral — this is what
+  the Swarm mark's full palette expresses at logo scale).
+- **Voice shifts with the speaker.** A bundu page is visionary/grounded/inclusive; the same content
+  on mukoko.com becomes welcoming/structured/protective. Don't copy-paste tone across brands.
+- Cultural specificity is non-negotiable: Shona vocabulary and Zimbabwean grounding are structural.
+- All UI tokens (radius, type, spacing, surfaces, status colors) come from **nyuchi-design**;
+  Mukoko logo/assets come from **mukoko-design**. This skill governs _which brand speaks and how_.
+
+## If invoked with no other guidance
+
+Ask whether the work is (a) parent-brand material (bundu.org page, manifesto, investor/ecosystem
+deck), (b) a cross-brand piece (family overview, comparison, announcement spanning brands), or
+(c) a voice/mineral decision for a specific brand — then apply the constellation table and the
+voice rules, pulling tokens and assets from the sibling skills.
+
+_Bundu — the wilderness the hive lives in._

--- a/station-console/.claude/skills/cloudflare-worker-rust.md
+++ b/station-console/.claude/skills/cloudflare-worker-rust.md
@@ -1,0 +1,163 @@
+# Cloudflare Worker in Rust — Nyuchi Pattern
+
+## When to use this skill
+
+Every Nyuchi service that runs on Cloudflare Workers is built in Rust using the `workers-rs` crate, which compiles Rust to WebAssembly and deploys it to the Worker runtime. This covers: Fundi (fundi.nyuchi.dev), the MCP server (mcp.nyuchi.dev), and the core API (api.nyuchi.dev).
+
+## Project setup
+
+```bash
+# Install wrangler
+npm install -g wrangler
+
+# Create a new Worker project
+cargo generate cloudflare/workers-rs
+
+# Directory structure
+service-name/
+├── src/
+│   ├── lib.rs          # Worker entry point
+│   ├── router.rs       # Request routing
+│   ├── supabase.rs     # Supabase REST client
+│   ├── auth.rs         # WorkOS JWT validation
+│   └── handlers/       # One file per route
+├── wrangler.toml       # Cloudflare config
+└── Cargo.toml
+```
+
+## wrangler.toml pattern
+
+```toml
+name = "nyuchi-fundi"
+main = "build/worker/shim.mjs"
+compatibility_date = "2024-01-01"
+
+[build]
+command = "cargo install -q worker-build && worker-build --release"
+
+# Secrets (set via: wrangler secret put SUPABASE_URL)
+# SUPABASE_URL
+# SUPABASE_SERVICE_ROLE_KEY
+# WORKOS_API_KEY
+# GITHUB_TOKEN
+
+# Cron trigger (for Fundi polling)
+[[triggers.crons]]
+cron = "*/5 * * * *"
+
+# Queue binding (for event-driven N8 signals)
+[[queues.consumers]]
+queue = "nyuchi-fundi-signals"
+max_batch_size = 10
+```
+
+## Worker entry point pattern
+
+```rust
+// src/lib.rs
+use worker::*;
+mod router;
+mod supabase;
+mod auth;
+
+#[event(fetch)]
+pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+    router::handle(req, env).await
+}
+
+// For Cron Triggers (Fundi polling)
+#[event(scheduled)]
+pub async fn scheduled(_event: ScheduledEvent, env: Env, _ctx: ScheduleContext) {
+    if let Err(e) = fundi::run_healing_cycle(&env).await {
+        console_error!("[nyuchi:fundi] Healing cycle error: {:?}", e);
+    }
+}
+
+// For Queue consumers (N8 event-driven signals)
+#[event(queue)]
+pub async fn queue(batch: MessageBatch<String>, env: Env, _ctx: Context) -> Result<()> {
+    fundi::process_signals(batch, &env).await
+}
+```
+
+## Database connection: Hyperdrive (recommended)
+
+```rust
+// src/supabase.rs
+// Uses Cloudflare Hyperdrive for globally-pooled native Postgres access.
+// Hyperdrive maintains persistent connections to Supabase from every
+// Cloudflare edge node, eliminating TCP handshake overhead per request.
+// Full SQL function suite available — get_node_counts(), get_architecture(), etc.
+
+pub struct SupabaseClient {
+    url: String,
+    service_role_key: String,
+}
+
+impl SupabaseClient {
+    pub fn from_env(env: &Env) -> Result<Self> {
+        Ok(Self {
+            url: env.secret("SUPABASE_URL")?.to_string(),
+            service_role_key: env.secret("SUPABASE_SERVICE_ROLE_KEY")?.to_string(),
+        })
+    }
+
+    pub async fn get(&self, table: &str, query: &str) -> Result<String> {
+        let url = format!("{}/rest/v1/{}?{}", self.url, table, query);
+        let mut headers = Headers::new();
+        headers.set("apikey", &self.service_role_key)?;
+        headers.set("Authorization", &format!("Bearer {}", self.service_role_key))?;
+        headers.set("Content-Type", "application/json")?;
+
+        let req = Request::new_with_init(
+            &url,
+            RequestInit::new().with_headers(headers),
+        )?;
+        let mut resp = Fetch::Request(req).send().await?;
+        resp.text().await
+    }
+}
+```
+
+## WorkOS JWT validation pattern
+
+```rust
+// src/auth.rs
+// Validate WorkOS JWTs on write operations
+// Read endpoints skip auth — public access
+
+pub async fn validate_workos_jwt(req: &Request, env: &Env) -> Result<Option<Claims>> {
+    let auth_header = req.headers().get("Authorization")?;
+    let Some(header) = auth_header else {
+        return Ok(None); // No token — caller decides if this is allowed
+    };
+    let token = header.strip_prefix("Bearer ").unwrap_or(&header);
+    // Validate against WorkOS JWKS endpoint
+    // workos-rust crate handles this
+    todo!()
+}
+```
+
+## Naming conventions
+
+All console output uses the [nyuchi:service-name] prefix:
+```rust
+console_log!("[nyuchi:fundi] Healing cycle complete: {} issues processed", count);
+console_error!("[nyuchi:fundi] GitHub API error: {:?}", e);
+```
+
+## Deploy
+
+```bash
+# Development
+wrangler dev
+
+# Production
+wrangler deploy
+
+# Set secrets
+wrangler secret put SUPABASE_URL
+wrangler secret put SUPABASE_SERVICE_ROLE_KEY
+wrangler secret put WORKOS_API_KEY
+wrangler secret put GITHUB_TOKEN
+```

--- a/station-console/.claude/skills/ecosystem-app-setup.md
+++ b/station-console/.claude/skills/ecosystem-app-setup.md
@@ -1,0 +1,179 @@
+---
+name: ecosystem-app-setup
+version: 1.0.0
+description: End-to-end setup for a new Bundu/Mukoko ecosystem app
+agents: claude-code, cursor, copilot
+requires_mcp: false
+---
+
+# Setting Up a New Nyuchi-Ecosystem App
+
+Follow this skill when a user wants to start a new app that is part of the Nyuchi ecosystem (mukoko, nyuchi, shamwari, bundu, nhimbe) or an app that consumes the Nyuchi Design System.
+
+## Preferred path — one command
+
+Once @nyuchi/design-cli ships, bootstrapping is a single command:
+
+```bash
+npx @nyuchi/design-cli init
+```
+
+This scaffolds a Next.js 16 project (Turbopack, pnpm, Node 24) with:
+
+- globals.css pre-populated with the seven African minerals tokens (with role + family)
+- components.json pointing at https://mzizi.dev/api/v1/ui
+- lib/utils.ts with the cn() helper
+- app/layout.tsx wired with the nyuchi-theme-provider
+- .claude/skills/ populated with all published Nyuchi skills
+- package.json with the right scripts and dependencies
+
+Until @nyuchi/design-cli ships, follow the manual steps below.
+
+## Manual bootstrap (legacy — use until CLI lands)
+
+### 1. Create the Next.js project
+
+```bash
+pnpm create next-app@latest my-app --turbopack --typescript --tailwind --app --no-src-dir
+cd my-app
+```
+
+### 2. Install Nyuchi-compatible dependencies
+
+```bash
+pnpm add class-variance-authority clsx tailwind-merge
+pnpm add -D @tailwindcss/typography
+```
+
+### 3. Scaffold globals.css
+
+Add the seven African minerals tokens at the top of `app/globals.css`:
+
+```css
+@layer base {
+  :root {
+    /* Seven minerals (dark-theme values) — query styling-minerals for canonical light/dark, container, role, family */
+    /* deep-earth family */
+    --color-cobalt: 0 176 255;         /* Knowledge — Katanga, DRC & Zambia */
+    --color-sodalite: 61 90 254;       /* Intelligence — Kunene, Namibia & SA */
+    --color-tanzanite: 179 136 255;    /* Identity — Merelani Hills, Tanzania */
+    --color-malachite: 100 255 218;    /* Growth — Congo Copper Belt */
+    /* hand family */
+    --color-gold: 255 215 64;          /* Value — Ghana/SA/Mali/Zimbabwe */
+    --color-copper: 255 138 101;       /* Stewardship — Central African Copperbelt */
+    --color-terracotta: 225 176 126;   /* Community — Pan-African Sahel */
+    
+    /* Semantic — query styling-semantic-colors */
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --primary: var(--color-cobalt);
+    /* ... */
+  }
+  
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    /* ... */
+  }
+}
+```
+
+Note: these are seed values. Query the live styling-semantic-colors collection for the canonical definitions — the DB is the source of truth.
+
+### 4. Set up components.json
+
+```json
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui"
+  },
+  "registries": {
+    "nyuchi": {
+      "url": "https://mzizi.dev/api/v1/ui"
+    }
+  }
+}
+```
+
+### 5. Add a component to verify
+
+```bash
+pnpm dlx shadcn@latest add https://mzizi.dev/api/v1/ui/nyuchi-theme-provider
+pnpm dlx shadcn@latest add https://mzizi.dev/api/v1/ui/button
+```
+
+### 6. Wire the theme provider
+
+In `app/layout.tsx`:
+
+```tsx
+import { NyuchiThemeProvider } from "@/components/nyuchi-theme-provider"
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <NyuchiThemeProvider>
+          {children}
+        </NyuchiThemeProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+### 7. Install the Nyuchi skills
+
+```bash
+npx skills add nyuchi/design-agent-skills
+```
+
+This populates `./.claude/skills/` with `nyuchi-design-system.md`, `scaffold-component.md`, and `ecosystem-app-setup.md` — so any AI assistant working in this repo has the doctrine on hand.
+
+### 8. Verify everything works
+
+```bash
+pnpm dev
+```
+
+Open http://localhost:3000 and confirm the theme toggle works, the button renders with the mineral-based styling, and Tailwind picks up the CSS variables.
+
+## Ubuntu philosophy alignment
+
+Nyuchi is built on Ubuntu — "I am because we are." When you architect a new app:
+
+- Prefer open source over proprietary
+- Build for community, not extraction
+- Respect data sovereignty — African data stays on African infrastructure where possible
+- Accessibility is not an afterthought; it is the starting point
+- Every feature should contribute to collective wellbeing, not just individual efficiency
+
+These aren't marketing claims. They're architectural constraints. If you find yourself designing something that only benefits a small subset of users at others' expense, question whether it belongs in the ecosystem.
+
+## What goes in the ecosystem and what doesn't
+
+The ecosystem has two legal layers — the Bundu Foundation (research lab, standards body, open-source org, AI lab; owns the doctrine, architecture, and token palette) above Nyuchi Africa (the single operating company). Inside Nyuchi Africa sit three pillars and the platform:
+
+- Mukoko — the consumer pillar: the super-app (social, commerce, payments, identity)
+- Nyuchi — the commercial/infrastructure pillar and the platform (web services, developer tools, MCP, Honeycomb storage)
+- Shamwari AI — the intelligence pillar, sovereign by nature (on-device inference, pod-resident context, no third-party AI vendor)
+- Nhimbe — cooperative economic features
+
+Bundu is not an app and not a layer inside a stack; it is the Foundation that governs the ecosystem. Mukoko and Shamwari AI are pillars/products inside Nyuchi Africa, not separate companies.
+
+Not ecosystem apps:
+- Any app that extracts value without giving back
+- Any app that requires surveillance for its business model
+- Any app that centralises what should be federated
+
+If the app you're building doesn't fit the ecosystem, that's fine — use the Nyuchi Design System as a consumer, but don't brand it as ecosystem.

--- a/station-console/.claude/skills/mcp-server-cloudflare.md
+++ b/station-console/.claude/skills/mcp-server-cloudflare.md
@@ -1,0 +1,46 @@
+# MCP Server on Cloudflare Workers — Nyuchi Pattern
+
+## Domain structure
+
+All Nyuchi MCP servers live under mcp.nyuchi.dev:
+
+```
+mcp.nyuchi.dev/design    → Design system (components, tokens, docs)
+mcp.nyuchi.dev/data      → SiafuDB and NTL data layer (future)
+mcp.nyuchi.dev/payments  → ContiPay integration (future)
+mcp.nyuchi.dev/identity  → WorkOS identity (future)
+```
+
+Each path is a separate Cloudflare Worker or a separate route in a shared Worker depending on team preference.
+
+## MCP protocol basics
+
+MCP servers expose:
+- `tools/list` → returns available tools
+- `tools/call` → executes a specific tool
+- `resources/list` → optional: exposes resources
+- `prompts/list` → optional: exposes prompts
+
+All communication is JSON-RPC 2.0 over HTTP with Server-Sent Events (SSE) for streaming.
+
+## Tool naming convention
+
+All Nyuchi MCP tools follow snake_case and describe their action clearly:
+```
+get_design_tokens
+list_components
+get_component
+get_node_counts
+get_architecture
+get_install_command
+get_skill
+get_ai_instructions
+```
+
+## Auth pattern
+
+Public tools (no auth): get_design_tokens, list_components, get_component
+Authenticated tools (WorkOS JWT): create_component, update_component, log_release
+
+The Worker validates the WorkOS JWT before executing authenticated tools.
+Public tools run without any token.

--- a/station-console/.claude/skills/mukoko-design.md
+++ b/station-console/.claude/skills/mukoko-design.md
@@ -1,0 +1,76 @@
+# Mukoko — _The Swarm_
+
+The visual identity for **Mukoko**, the hive at the centre of the Nyuchi ecosystem. Every asset
+here is generated from the live tokens in `nyuchi_design_db → styling-minerals` (doctrine **v4.1.0**).
+**The database is the source of truth**, not this folder — if the palette shifts, re-pull and regenerate.
+
+## The idea (the meaning, say it right)
+
+The mark is the **Seed of Life** — one centre cell ringed by six, the first complete ring of the
+honeycomb — rendered in the **seven African Minerals**:
+
+> **Tanzanite at the core** (Mukoko, the brand), ringed by the six minerals of the ecosystem.
+> One hive holding the whole. **Ndiri nekuti tiri** — _I am because we are._
+
+It is a _known_ geometric figure (like the Audi or Olympic rings), made ours through the mineral
+palette and the meaning. Symmetry of form; distinctiveness through colour and story. **nyuchi is the
+bee; mukoko is the hive** — so Mukoko's hero mark is the hive/cluster, never a bee (that's Nyuchi's).
+
+## The seven minerals
+
+| Mineral       | Light     | Dark      | Meaning                 | Role                  |
+| ------------- | --------- | --------- | ----------------------- | --------------------- |
+| cobalt        | `#0047AB` | `#00B0FF` | digital future, trust   | CTAs, links           |
+| **tanzanite** | `#4B0082` | `#B388FF` | premium, connection     | **brand / core cell** |
+| malachite     | `#004D40` | `#64FFDA` | growth, success         | positive actions      |
+| gold          | `#5D4037` | `#FFD740` | honey, rewards          | achievements          |
+| terracotta    | `#A0522D` | `#E1B07E` | earth, community        | community             |
+| sodalite      | `#283593` | `#3D5AFE` | intelligence, depth     | AI / Shamwari         |
+| copper        | `#BF5A36` | `#FF8A65` | connection, stewardship | Bundu / commons       |
+
+Use `light` on light surfaces, `dark` on dark. Full machine-readable values (containers + on-containers)
+are in `tokens/minerals.json`; drop-in CSS custom properties are in `tokens/minerals.css`.
+
+**Ring order** (clockwise from top): `cobalt → gold → malachite → copper → sodalite → terracotta`,
+**tanzanite** in the centre. This alternates cool/warm for visual balance — a design decision, not a
+law. If positions are ever assigned meaning, regenerate from the geometry script.
+
+## Assets in this skill
+
+```
+logo/mark/        full-palette mark (light/dark, SVG + PNG) + mono/ (7 minerals × light|dark SVG)
+logo/lockup/      mark + lowercase `mukoko` serif wordmark (light/dark, SVG + PNG)
+app-icon/         primary (full palette on deep tanzanite), paper, mono-tanzanite knockout (SVG + 1024 PNG)
+favicon/          MONO tanzanite mark, legible small (SVG + 16/32/48/180 PNG)
+backgrounds/      honeycomb grain (paper), tanzanite header band, stone splash 1080×1920, full-mineral pattern
+tokens/           minerals.json (source for native tokens) + minerals.css (web, auto dark-mode)
+BRAND-GUIDE.md    the full written guide (meaning, manifest, usage, do/don't)
+```
+
+## Rules for using the mark
+
+- **Default to the full-palette mark at ≥32px** (headers, About screens, decks, profile images, merch).
+- **Below 32px use the mono favicon** — the seven hues fuse small; the single-mineral version stays crisp. This is why the favicon ships mono tanzanite.
+- **Mono variants** let one app/surface/sub-brand wear a single mineral (Shamwari→sodalite, community→terracotta, success→malachite). Shape constant; only colour changes.
+- **Clear space** = one cell-radius on all sides. **Min size:** 24px full mark, 16px mono favicon.
+- **App icon default** = `app-icon/mukoko-appicon-primary` (full palette on deep tanzanite `#1A0033`).
+- **Wordmark:** Noto Serif 600, **lowercase always** (`mukoko`, never `Mukoko`/`MUKOKO`). UI = Noto Sans; code/labels = JetBrains Mono.
+
+## Do / don't
+
+**Do** — use the supplied SVGs; flip light/dark mineral values to the surface; use mono variants to signal context; give the mark room.
+**Don't** — add gradients/shadows/glows/outlines; recolour petals off-palette or reorder the ring arbitrarily; rotate, stretch or rearrange cells; capitalise the wordmark; use the full-palette mark below 32px.
+
+## Regenerating
+
+All assets are deterministic from the minerals tokens. Re-pull `styling-minerals` from the DB and
+rebuild the cluster (core + six petals at edge-normal angles `30 + 60·i`, distance `√3·r + gap`,
+sharing true edges) so geometry, ring order and exports stay reproducible.
+
+## If invoked with no other guidance
+
+Ask what's needed (logo export? app icon? social/launch asset? splash? a new surface wearing a
+mineral?), confirm light vs dark surface, then produce the asset using the files here — or regenerate
+from tokens for a size/format not already exported.
+
+_Mukoko — the hive that holds the whole._

--- a/station-console/.claude/skills/nyuchi-design.md
+++ b/station-console/.claude/skills/nyuchi-design.md
@@ -1,0 +1,57 @@
+> **Doctrine v4.1.0.** The source of truth for all tokens is the live database
+> `nyuchi_design_db → component_documents` (and its mirror `globals.css` / `colors_and_type.css`).
+> Pull live before assuming — the palette and scales evolve faster than this file.
+> **Last verified (this revision):** minerals, heritage anchors, radius scale. Typography, spacing,
+> semantic colors, motion, shadow and z-index were **not** re-verified in this pass — confirm against the DB if precision matters.
+
+Read the `README.md` file within this skill, and explore the other available files. Key entry points:
+
+- `README.md` — brand context, content fundamentals, visual foundations, iconography.
+- `colors_and_type.css` — canonical CSS tokens (light + dark). Always `@import` this rather than hard-coding hex values. **Note:** refresh against the live DB for the two newest minerals (sodalite, copper) and the heritage anchors if the local file predates doctrine v4.1.0.
+- `assets/` — brand marks. **nyuchi** = the bee (worker / infrastructure). **mukoko** = the hive. Mukoko's current mark is **the Swarm** (seven-mineral Seed-of-Life cluster) — see the dedicated `mukoko-design` skill. Use the light mark on dark surfaces and vice versa.
+- `preview/` — reference cards for type, colors, spacing, components, brand.
+- `ui_kits/mukoko/` — React/JSX super-app UI kit with a working click-through prototype.
+
+## Rules that are non-negotiable
+
+- **Lowercase wordmarks** — `mukoko`, `nyuchi`, `bundu`, `shamwari`, `nhimbe`, `bushtrade` — always.
+- **Seven African Minerals** (geological, the core palette). Pull from `--color-<name>` / `--container-<mineral>` / `--on-container-<mineral>`:
+  - `cobalt` — primary blue, links, CTAs · digital future, trust
+  - `tanzanite` — **mukoko's brand mineral**, social features · premium, connection
+  - `malachite` — success states, positive actions · growth
+  - `gold` — achievements, rewards, highlights · honey, warmth
+  - `terracotta` — community features · earth, grounding
+  - `sodalite` — **AI / Shamwari surfaces, deep-reasoning states** · intelligence, depth _(added v4.1.0)_
+  - `copper` — **Bundu ecosystem identity, the commons** · connection, stewardship _(added v4.1.0)_
+- **Seven Heritage tones (indigo, savanna, baobab, sunset, river, hematite, kalahari) — legacy note superseded; see styling-heritage-colors. Former text: Two Heritage anchors** (atmospheric neutrals, mini-app surfaces & backgrounds): `hematite` (#546E7A / #90A4AE, neutral anchor) and `kalahari` (#C9B589 / #E8D9B5, warm light anchor). _(The earlier "Five Heritage / Ten Colors of Africa" framing is retired.)_
+- **Each brand owns a mineral** (`styling-ecosystem`, verified v4.1.0): bundu→**copper**, nyuchi→**gold**, mukoko→**tanzanite**, shamwari→**sodalite**, nhimbe/campfire/novels/health→malachite, lingo/planner→cobalt, bushtrade/places/transport/wallet→gold, bytes/pulse→tanzanite, circles→terracotta. Theme a surface in its brand's mineral — never default everything to tanzanite.
+- **Buttons are ALWAYS pill** (`rounded-full` → `--radius-full`, 9999px). Inputs match buttons visually.
+- **Button height 56px** (sm 48px). **Input height 48px** (sm 40px). Min touch target 48px. Badges are 20px tall.
+- **Radius scale is named** (px): `none` 0 · `xs` 4 · `sm` 7 · `md` 12 · `lg` 14 (**DEFAULT** cards/panels) · `xl` 17 · `2xl` 24 · `full` 9999 (pills). Checkboxes use `sm`(7), inputs/small cards `md`(12), cards/panels `lg`(14), modals/sheets/dialogs/tabs `xl`(17), hero cards `2xl`(24). Reference via `--radius-<name>`.
+- **H1–H3 are Noto Serif. H4+ and body are Noto Sans. Code is JetBrains Mono.**
+- **Rings over shadows.** Cards get `ring-1` of `--border`, not a drop shadow.
+- **No gradients, no glassmorphism** except sticky chrome (`backdrop-blur`).
+- **Emoji only as mini-app identifiers**, never as chrome or body decoration.
+- **Status colors are NOT minerals.** Use `--status-success` (#22C55E), `--status-warning` (#F59E0B), `--status-error` (#EF4444), `--status-info` (#3B82F6) — universal accessibility-first. Severity scale (`--severity-low/moderate/high/severe/extreme/cold`) and connection (`--connection-online/syncing/cached/offline`) follow the same logic. Verification tiers are the only place minerals carry status meaning (community→malachite, otp→cobalt, government→tanzanite, licensed→gold).
+- **Surfaces (April 2026 AAA refresh):** light mode — `--background` warm paper, `--card` pure white, `--muted` cream, `--overlay` white. Dark mode — `--background` warm stone L10%, `--card` L6% (darker than bg), `--muted` L2% (deepest), `--overlay` L14% (lighter than bg, scrim creates pop).
+- **Mukoko's mark is the Swarm** — a seven-mineral Seed-of-Life cluster (tanzanite core, six minerals ringed around it). Full-palette at ≥32px; mono single-mineral version below that. Full kit + rules live in the `mukoko-design` skill.
+- **Lucide React** for UI icons (or the Lucide CDN JS build for HTML prototypes).
+- **APCA 3.0 AAA contrast** on both primary and secondary text on every surface.
+
+## When creating visual artifacts
+
+Copy assets out of this skill and create static HTML files for the user to view. `@import` `colors_and_type.css` at the top of every HTML file. For phone prototypes copy the structure from `ui_kits/mukoko/index.html`. For slide decks use the MineralStrip accent and serif display type.
+
+## When working on production code
+
+Install upstream components with the shadcn CLI — never hand-roll copies:
+
+```bash
+npx shadcn@latest add https://design.nyuchi.com/api/v1/ui/<name>
+```
+
+Read the rules in `README.md` to become an expert in designing with this brand. Pull CSS variables from the upstream `globals.css` (mirrored in `colors_and_type.css`); refresh the mineral/heritage/radius tokens from the live DB if the mirror predates v4.1.0.
+
+## If invoked with no other guidance
+
+Ask what the user wants to build or design (marketing page? a new mini-app for mukoko? a deck? a component?), ask what surface (mobile / desktop / print / slide), ask which brand voice (bundu / nyuchi / mukoko / shamwari / nhimbe), then act as an expert designer who outputs HTML artifacts _or_ production code, depending on the need.

--- a/station-console/.claude/skills/scaffold-component.md
+++ b/station-console/.claude/skills/scaffold-component.md
@@ -1,0 +1,165 @@
+---
+name: scaffold-component
+version: 1.0.0
+description: How to scaffold a new Nyuchi component correctly
+agents: claude-code, cursor, copilot, cline
+requires_mcp: true
+---
+
+# Scaffolding a Nyuchi Component
+
+Follow this workflow whenever you are creating a new component in the Nyuchi Design System. The system is DB-first: production source lives in components.source_code, not in the file system. The frontend pulls from the DB at build time.
+
+## Step 1 — Decide the node
+
+Use the Node Decision Guide:
+
+- N1 Tokens — CSS value, spacing, colour, motion, radius (goes in a styling-* collection, not components)
+- N2 Primitive — generic UI (button, card, input, dialog, toolbar, bento-grid)
+- N3 Brand — Nyuchi-branded composition with mineral palette and harness integration
+- N4 Safety — conditional-rendering gate (permission, geo, rate limit)
+- N5 Resilience — error boundary, skeleton, offline banner, fallback chain
+- N6 Page — full-screen layout composition
+- N7 Shell — app container (navigation, routing, lifecycle)
+- N8 Assurance — instrumentation, a11y audit, RTL conformity, probes
+- N9 Fundi — automated healing
+- N10 Documentation — docs, AI instructions, docs infrastructure
+
+If you are unsure, query the MCP: `get_node_categories(N)` shows what lives in each node.
+
+## Step 2 — Register in component_documents with status=alpha
+
+`public.components` is a **read-only view** projected from the `component_documents` base table — you cannot INSERT or UPDATE it. Author by writing a row to `component_documents`; the view reflects it automatically.
+
+```sql
+INSERT INTO component_documents (collection, name, node, owner, document)
+VALUES (
+  'primitives',              -- collection: primitives | brand | pages | shell | safety | resilience | observability | fundi | documentation
+  'your-component-name',
+  2,                         -- ecosystem node (1-10); matches the collection
+  'mzizi',                   -- owner: mzizi | nyuchi | bundu | framework
+  jsonb_build_object(
+    'name',         'your-component-name',
+    'node',         2,
+    'collection',   'primitives',
+    'owner',        'mzizi',
+    'nodeLabel',    'primitive',     -- primitive/brand/safety/resilience/pages/shell/assurance/fundi/documentation
+    'category',     'layout',        -- e.g. layout, form, feedback, navigation, conformity
+    'status',       'alpha',         -- alpha until source is production-ready, then stable
+    'dnaRole',      'core',          -- core | shipped | swappable | genetic-code | machinery | documentation
+    'model',        'mzizi-dna-helix',
+    'framework',    'react',
+    'runtimeLang',  'typescript',
+    'platforms',    jsonb_build_array('web'),
+    'description',  'Short description of what it does',
+    'doctrineVersion','4.1.7',
+    'source_code',  '',              -- filled in Step 3
+    'urls', jsonb_build_object(
+      'portal',     'https://mzizi.dev/components/your-component-name',
+      'api',        'https://mzizi.dev/api/components/your-component-name',
+      'health',     'https://mzizi.dev/api/health/your-component-name',
+      'source',     'https://mzizi.dev/source/your-component-name',
+      'changelog',  'https://mzizi.dev/changelog/your-component-name',
+      'playground', 'https://mzizi.dev/playground/your-component-name'
+    )
+  )
+);
+```
+
+The composite primary key is `(collection, name)`. `dna_role` and `schema_version` are derived from the document's `dnaRole` / `_schemaVersion`. Portal URLs stay on `mzizi.dev` (the registry/portal host); the MCP endpoint is `mcp.mzizi.dev/mcp`.
+
+## Step 3 — Write the source
+
+Once registered, write the production source into the document's `source_code` field via SQL — never to the read-only `components` view. Follow the enterprise criteria for the chosen node:
+
+```sql
+UPDATE component_documents
+SET document = jsonb_set(document, '{source_code}', to_jsonb($$ ...your TSX source... $$::text), true)
+WHERE collection = 'primitives' AND name = 'your-component-name';
+```
+
+### N2 Primitive checklist
+
+- No useNyuchiHarness import
+- data-slot attribute on root element
+- data-portal attribute pointing to mzizi.dev/components/{name}
+- cn() for className composition
+- No raw Tailwind colours — use semantic tokens (bg-primary, text-foreground, etc.)
+- Icons from @/lib/icons, never lucide-react directly
+- Touch targets follow styling-touch-targets (48px minimum)
+- If pill-shaped category (button, input, avatar, badge, toggle), use borderRadius 9999
+
+### N3 Brand checklist
+
+- nyuchi- prefix on the name
+- useNyuchiHarness hook with full destructure { log, motion, LiveRegion }
+- animStyle with motion.prefersReduced check
+- ARIA role or aria-label
+- data-slot and data-portal attributes
+- focus-visible ring on interactive elements
+- min-h-[48px] touch targets on buttons (styling-touch-targets.comfortable)
+- I18N via Intl formatters for dates, numbers, currency
+- Semantic tokens for status-bearing colours
+
+### N6 Page checklist
+
+- Pure composition — no inline buttons, cards, or SVGs
+- Accept children/slots for content
+- Semantic CSS vars only (bg-card, text-foreground, bg-primary)
+- Loading state prop
+- role="main" and aria-label
+
+### N8 Assurance checklist
+
+- TypeScript module exporting typed functions and React hooks
+- Banner comment identifying node and purpose
+- Configurable rules array
+- Optional onViolation/onComplete callbacks
+- React hook variant for continuous monitoring
+
+## Step 4 — Add docs and demos
+
+Docs and demos are fields **inside** the same `component_documents` row — not separate tables. Merge them into the document:
+
+```sql
+UPDATE component_documents
+SET document = document || jsonb_build_object(
+  'use_cases', jsonb_build_array('Use case 1', 'Use case 2'),
+  'variants',  jsonb_build_array('default', 'sm', 'lg'),
+  'features',  jsonb_build_array('cn() for className composition', 'data-slot attribute'),
+  'a11y',      jsonb_build_array('Accessibility feature'),
+  'demo',      jsonb_build_object('has_demo', true, 'demo_type', 'interactive')
+)
+WHERE collection = 'primitives' AND name = 'your-component-name';
+```
+
+## Step 5 — Flip status to stable
+
+Once the source is production-ready and has been dogfooded somewhere:
+
+```sql
+UPDATE component_documents
+SET document = jsonb_set(document, '{status}', '"stable"')
+WHERE collection = 'primitives' AND name = 'your-component-name';
+
+SELECT log_version('your-component-name', 'promoted', 'Promoted from alpha to stable', 'your-handle');
+```
+
+## Step 6 — Validate accessibility
+
+If your component introduces a new colour pair, validate before shipping:
+
+```sql
+SELECT calculate_contrast_ratio('#FFFFFF', '#0047AB');
+-- Returns the WCAG 2.1 contrast ratio. AA 4.5, AAA 7.0.
+```
+
+For systematic pair tracking look at styling-accessibility-checks — critical pairs have a row with computed ratio and colour-blindness safety flags.
+
+## What to avoid
+
+- Never store component source in the file system if it's meant to be distributed via the registry. The DB is canonical.
+- Never hardcode hex colour values (except documented third-party brands like Ethereum, Google, EcoCash).
+- Never use lucide-react directly — go through @/lib/icons.
+- Never use margin-left / padding-right / left — use logical properties (margin-inline-start etc.) for RTL support.
+- Never bump major version without architectural redesign. 4.0.x is internal patches, 4.1.0 is first public release, 5.0.0 reserved for redesign.

--- a/station-console/.nyuchi-design.json
+++ b/station-console/.nyuchi-design.json
@@ -1,0 +1,11 @@
+{
+  "skills": {
+    "bundu-design": "1.0.0",
+    "cloudflare-worker-rust": "1.0.0",
+    "ecosystem-app-setup": "1.0.0",
+    "mcp-server-cloudflare": "1.0.0",
+    "mukoko-design": "1.0.0",
+    "nyuchi-design": "1.0.0",
+    "scaffold-component": "1.0.0"
+  }
+}

--- a/station-console/components.json
+++ b/station-console/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/station-console/package-lock.json
+++ b/station-console/package-lock.json
@@ -1,0 +1,3548 @@
+{
+  "name": "mukoko-station-console",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mukoko-station-console",
+      "version": "0.1.0",
+      "dependencies": {
+        "@workos-inc/authkit-nextjs": "^2.6.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "next": "^16.1.6",
+        "next-themes": "^0.4.6",
+        "radix-ui": "^1.6.2",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "tailwind-merge": "^3.6.0",
+        "tw-animate-css": "^1.4.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.1.16",
+        "@types/node": "^24.9.2",
+        "@types/react": "^19.2.6",
+        "tailwindcss": "^4.1.16",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
+      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
+      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
+      "integrity": "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.11.tgz",
+      "integrity": "sha512-HQDOFTKwSnmUij6l54wYJJtxTAnxI71+YJLOrjm2ladFB8HAV5Jt7hwaZPhWTGBkYoW4+ZAOfNZrLDh/qvxSYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.16.tgz",
+      "integrity": "sha512-BpZJNmetujnGgUI6OX0jEhEmlA46WPqgub8Rv09Kyquwd0cc1ndMKpiPYCjmBU6KSSRPAMtgLpEoZSG/tdNIWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collapsible": "1.1.16",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.19.tgz",
+      "integrity": "sha512-FA7n1f6D/DwGE0+AWxiY5LacNbbExQuEgMubeG06idEaH+mSLuf9dp/qBNqOnvbTQ+4gZ2ue1RATF1Ub91Mg5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dialog": "1.1.19",
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.11.tgz",
+      "integrity": "sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.11.tgz",
+      "integrity": "sha512-IUAhIVpBUvP5NNICjlaB1OFmtRLGqQqTF3ZOSGPoq3XeLXRFtHiWTRxSVEULgOd9GQR2c7tsYqDnhUennapZnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.2.tgz",
+      "integrity": "sha512-sST0qh8GzOB7besQ3tMLWLyngnRuSk0gc/Hm+667KYKQFCt6Y6ZXv25WlqM7dIDK54ULCh5+CHmk4LIolzfz+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.7.tgz",
+      "integrity": "sha512-JroKHfQBfh+fDuzpPsBC+pESkhuq8ql4hljTguz8MWnS35cISr3d/Jhl9kYrB44FlDtxCArYdDvTx+BSsJ64rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.16.tgz",
+      "integrity": "sha512-opfXRe6nnzyGmCDPx+l1Aqo/RbqWtQal2FnsBqF9hhePp6j0LsRoBaRxcMOlTv+uYTJVtWYZKg9t9wTe+BA/ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.12.tgz",
+      "integrity": "sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.3.tgz",
+      "integrity": "sha512-PS+gKE0z2prJ74Y0sM+brAGK4mYOHIR7TlcV5EJgUQ6E0xMvyswkK2X4yRqyganrzsRL+WCSKAPu0NQITICRWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-menu": "2.1.20",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz",
+      "integrity": "sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz",
+      "integrity": "sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.20.tgz",
+      "integrity": "sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-menu": "2.1.20",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.12.tgz",
+      "integrity": "sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.12.tgz",
+      "integrity": "sha512-JTX94E4LDL91rzLg7X0mHPdxr0A8JEdVwZEmeOwZJSMDHCGW5DFtSlTSJozUyUs807IQmnvbfzKZFVCK5DmkqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-label": "2.1.11",
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.19.tgz",
+      "integrity": "sha512-2KTgMLQtKvicznQgbindEI2RZ3QbDIwU5gabjUPwFJsormjGDz+rUvO4NANmYwzEEpTcTONUt33vBHIfTIVSfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-popper": "1.3.3",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.11.tgz",
+      "integrity": "sha512-3PKvDDxOn62k0oV1n4QtNtD2vpu+zYjXR7ojLBPaO6SPvhy53yg0vAmgNeBQeJW5rV3dffoRG+HYfLBZuzw0CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.20.tgz",
+      "integrity": "sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.3",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.20.tgz",
+      "integrity": "sha512-gzFZvybgmwYsFBWDqanycIoEYnhyk8MMnuLamdFVHUZYGp4COM+sqXiwbnn0VMWqGLeeU7GV7jm+dXRa+Wufag==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-menu": "2.1.20",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.18.tgz",
+      "integrity": "sha512-K9HiuxZ6xCwSaHcIuUpxyhy4w5gpwzWjh9dHTSbMN3Ix4qAyVObS9RlU3zMycb0PO3v9Tpk0BXMwWvXOUbVXew==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.12.tgz",
+      "integrity": "sha512-nQLu5OAcORDQp1EHAv6k3mJGV1hjMTw2NTGVAsGE1g/mWeNqAd1R5jyaAs3U+A8ZD/W8XNPY2yKT0ZdQnqo3NA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.7.tgz",
+      "integrity": "sha512-gB1Mr8vzdv1XzDjrtJTXmL0JORRs1B4g7ngUs0F+H2VvMOwXTZMTmLCl0wZZ3m7ylX8TssI7NCvgiSHmLuTm/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.19.tgz",
+      "integrity": "sha512-jkrTdQVxnIB8fpn0NyyxW9CTB5aCXZZelVz5z+Xmii6g5WxMqS3fInNslZ63puP39+Puu4jYohUK31y3dT87gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.3",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.3.tgz",
+      "integrity": "sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.11",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+      "integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.7.tgz",
+      "integrity": "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.12.tgz",
+      "integrity": "sha512-ZPHyI0JyzoH/rP0tq2uRaIZTj/4s8+kAbqPz+e2N8+ejHvwPJ889dHhqn+vh7PNvNeq+boAoH9yzqeoShzwF2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.3.tgz",
+      "integrity": "sha512-WwZFjWV4s3aC1QtR3k04R+oANHtX2q6fgKlc7MCEiDNlnTxCZ3H8k3mHtEgVlOejystwk1WQgarQhNOQZ2bK1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.15.tgz",
+      "integrity": "sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.14.tgz",
+      "integrity": "sha512-bBODCWZK7JTbQLHs0uIP4f73wIWatakK4OS33UzkR1x897wu0PuO658a3f+6P2GEGyDzGYMuHRatMVoAk9WZTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.3.tgz",
+      "integrity": "sha512-L5RQTXz6Anxsf9CCv+pTgiAsUpyVj7rJxsGtmhFaEOJ++cVfXucv4qWfsIO0AIB4NAhi3yovWGVMKKS1Xf1Wrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.3",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.7",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.11.tgz",
+      "integrity": "sha512-jRhe86+8PF7VZ1u14eOWVOuh2BuAhALg/FT1VcMC4OHedMTRUazDnDlKTt+yxo5cRNKHMfmvZ4sSQtWDeMV4CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.3.tgz",
+      "integrity": "sha512-CWVVj+XaTom0SKCqw1EUgb0NuiLwS+N3OFG73mVEezKEjgNIvZiu0EevMelSSU+CbX3owbqJweG2gPU31WGC5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.2",
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.3.tgz",
+      "integrity": "sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.17.tgz",
+      "integrity": "sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.19.tgz",
+      "integrity": "sha512-SxfVZfVOibWKWdkf0Xx1awW2d09fQu4V4PXDY1j5hi4MVf7MWdJZqTBJMa1KWtOr1S6GGtCk02nniZ0Iia+dHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.14.tgz",
+      "integrity": "sha512-QI/hB65XKWACA66P64A+aHxtLUgHJeJLkaQa+awUNXT6T3swndtY5DojeHA+vldrTspMTtFBd7HfZ9QGbM1Qrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.15.tgz",
+      "integrity": "sha512-gIC5Q+Xljg7lmUdzSuDoy0t97yZn1sZl00Ra37ZvKrYdWnQLU6sWLd09yG8cIB9jUAlQfHgJ2ACAG00MFwsqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-toggle": "1.1.14",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.15.tgz",
+      "integrity": "sha512-t/iEuVjUnXXtrsGK40AA43uIx37sn3AqZ7oAVnPICK6lFJP6dzMzWR3U9b6eCfFjb6wtSEqkJ9Rn9xDjiOx20g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-separator": "1.1.11",
+        "@radix-ui/react-toggle-group": "1.1.15"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.12.tgz",
+      "integrity": "sha512-U3HoftgWnmla78vzQbLvKKb7bUYJxoiiqYFzp1wu/TBMyDqMZSuCl3aRICsD6EfVEwcJD2mumGDGUXLFVqQHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.3",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-visually-hidden": "1.2.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.3.tgz",
+      "integrity": "sha512-3wEkMiPHXha/2VadZ68rYBcmYnPINVGl4Y3gtcM7fKRjANk0OscK+cdqBgUWdozb7YJxsh0vefM7vgAMHXOjqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
+      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+      "integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.7.tgz",
+      "integrity": "sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
+      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
+      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-x64": "4.3.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
+      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
+      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
+      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
+      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
+      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
+      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
+      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
+      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
+      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
+      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
+      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
+      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.2.tgz",
+      "integrity": "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.2",
+        "@tailwindcss/oxide": "4.3.2",
+        "postcss": "^8.5.15",
+        "tailwindcss": "4.3.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@workos-inc/authkit-nextjs": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-nextjs/-/authkit-nextjs-2.17.0.tgz",
+      "integrity": "sha512-bvy7cyfG7NAc6nRgeutYIQKAdcKfQaNZpfkGqXSXtetS6X4biudSQOHreCaZNsMWGGshN8vDK+NG/y/sv010wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@workos-inc/node": "^8.9.0",
+        "iron-session": "^8.0.4",
+        "jose": "^5.10.0",
+        "path-to-regexp": "^6.3.0"
+      },
+      "peerDependencies": {
+        "next": "^13.5.9 || ^14.2.26 || ^15.2.3 || ^16",
+        "react": "^18.0 || ^19.0.0",
+        "react-dom": "^18.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@workos-inc/node": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-8.13.0.tgz",
+      "integrity": "sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4"
+      },
+      "engines": {
+        "node": ">=20.15.0"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iron-session": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/iron-session/-/iron-session-8.0.4.tgz",
+      "integrity": "sha512-9ivNnaKOd08osD0lJ3i6If23GFS2LsxyMU8Gf/uBUEgm8/8CC1hrrCHFDpMo3IFbpBgwoo/eairRsaD3c5itxA==",
+      "funding": [
+        "https://github.com/sponsors/vvo",
+        "https://github.com/sponsors/brc-dd"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.2",
+        "iron-webcrypto": "^1.2.1",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
+      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.10",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.10",
+        "@next/swc-darwin-x64": "16.2.10",
+        "@next/swc-linux-arm64-gnu": "16.2.10",
+        "@next/swc-linux-arm64-musl": "16.2.10",
+        "@next/swc-linux-x64-gnu": "16.2.10",
+        "@next/swc-linux-x64-musl": "16.2.10",
+        "@next/swc-win32-arm64-msvc": "16.2.10",
+        "@next/swc-win32-x64-msvc": "16.2.10",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/radix-ui": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.2.tgz",
+      "integrity": "sha512-OwYUjzMwiInCUxgAWpPsavXC3Kh4iyi/49uU1/qZTG3RQDlvegyk1GOMiGvSkjua1RDb3JD3fo3eroL9FV4GQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-accessible-icon": "1.1.11",
+        "@radix-ui/react-accordion": "1.2.16",
+        "@radix-ui/react-alert-dialog": "1.1.19",
+        "@radix-ui/react-arrow": "1.1.11",
+        "@radix-ui/react-aspect-ratio": "1.1.11",
+        "@radix-ui/react-avatar": "1.2.2",
+        "@radix-ui/react-checkbox": "1.3.7",
+        "@radix-ui/react-collapsible": "1.1.16",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-context-menu": "2.3.3",
+        "@radix-ui/react-dialog": "1.1.19",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-dropdown-menu": "2.1.20",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-form": "0.1.12",
+        "@radix-ui/react-hover-card": "1.1.19",
+        "@radix-ui/react-label": "2.1.11",
+        "@radix-ui/react-menu": "2.1.20",
+        "@radix-ui/react-menubar": "1.1.20",
+        "@radix-ui/react-navigation-menu": "1.2.18",
+        "@radix-ui/react-one-time-password-field": "0.1.12",
+        "@radix-ui/react-password-toggle-field": "0.1.7",
+        "@radix-ui/react-popover": "1.1.19",
+        "@radix-ui/react-popper": "1.3.3",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-progress": "1.1.12",
+        "@radix-ui/react-radio-group": "1.4.3",
+        "@radix-ui/react-roving-focus": "1.1.15",
+        "@radix-ui/react-scroll-area": "1.2.14",
+        "@radix-ui/react-select": "2.3.3",
+        "@radix-ui/react-separator": "1.1.11",
+        "@radix-ui/react-slider": "1.4.3",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-switch": "1.3.3",
+        "@radix-ui/react-tabs": "1.1.17",
+        "@radix-ui/react-toast": "1.2.19",
+        "@radix-ui/react-toggle": "1.1.14",
+        "@radix-ui/react-toggle-group": "1.1.15",
+        "@radix-ui/react-toolbar": "1.1.15",
+        "@radix-ui/react-tooltip": "1.2.12",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-escape-keydown": "1.1.3",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/station-console/package.json
+++ b/station-console/package.json
@@ -10,9 +10,15 @@
   },
   "dependencies": {
     "@workos-inc/authkit-nextjs": "^2.6.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "next": "^16.1.6",
+    "next-themes": "^0.4.6",
+    "radix-ui": "^1.6.2",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "tailwind-merge": "^3.6.0",
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.16",

--- a/station-console/src/app/globals.css
+++ b/station-console/src/app/globals.css
@@ -1,104 +1,187 @@
 @import "tailwindcss";
+@import "tw-animate-css";
+/* @import "shadcn/tailwind.css"; */
 
-/* Mzizi / Mukoko Brand System — token subset mirrored from
-   mukoko-weather's globals.css (Brand System v6, brand kit doctrine
-   v4.1.0). Keep values in sync with the main app. */
-:root {
-  --color-primary: #0047ab; /* cobalt */
-  --color-primary-foreground: #ffffff;
-  --mineral-malachite: #0bda51;
-  --mineral-gold: #d4a017;
-  --mineral-terracotta: #c1440e;
-  --color-surface-base: #faf8f5;
-  --color-surface-card: #ffffff;
-  --color-text-primary: #1a1a1a;
-  --color-text-secondary: #4a4a4a;
-  --color-text-tertiary: #757575;
-  --color-border: #e5e0d8;
-  --color-severity-severe: #b3261e;
-  --color-severity-low: #0b6e4f;
-  --touch-target-min: 48px;
-  --radius-card: 16px;
-  --radius-button: 9999px;
-  --radius-input: 10px;
-}
-[data-theme="dark"] {
-  --color-primary: #4d8dff;
-  --color-primary-foreground: #0a0a0a;
-  --color-surface-base: #121212;
-  --color-surface-card: #1c1c1e;
-  --color-text-primary: #f5f5f5;
-  --color-text-secondary: #c7c7c7;
-  --color-text-tertiary: #8e8e93;
-  --color-border: #2c2c2e;
-  --color-severity-severe: #ff6b60;
-  --color-severity-low: #4cd58c;
-}
+@custom-variant dark (&:is(.dark *));
+
 @theme inline {
-  --color-primary: var(--color-primary);
-  --color-primary-foreground: var(--color-primary-foreground);
-  --color-surface-base: var(--color-surface-base);
-  --color-surface-card: var(--color-surface-card);
-  --color-text-primary: var(--color-text-primary);
-  --color-text-secondary: var(--color-text-secondary);
-  --color-text-tertiary: var(--color-text-tertiary);
-  --color-border: var(--color-border);
-  --color-severity-severe: var(--color-severity-severe);
-  --color-severity-low: var(--color-severity-low);
+  --font-sans: var(--font-noto-sans), "Noto Sans", system-ui, sans-serif;
+  --font-serif: var(--font-noto-serif), "Noto Serif", Georgia, serif;
+  --font-mono: var(--font-jetbrains-mono), "JetBrains Mono", monospace;
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-overlay: var(--overlay);
+  --color-overlay-foreground: var(--overlay-foreground);
+  --color-scrim: var(--scrim);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  /* Radius system — derived from --radius-unit (7px)
+   sm: 1×unit (7),  md: 1×unit + 5 (12),  lg: 2×unit (14),  xl: 1×unit + 10 (17)
+   Buttons are always pill (9999px) — brand identity decision */
+  --radius-unit: 7px;
+  --radius-sm: var(--radius-unit);
+  --radius-md: calc(var(--radius-unit) + 5px);
+  --radius-lg: calc(var(--radius-unit) * 2);
+  --radius-xl: calc(var(--radius-unit) + 10px);
+  --radius-2xl: calc(var(--radius-unit) + 10px);
+  --radius-3xl: 9999px;
+  --radius-4xl: 9999px;
+  /* Five African Minerals — theme-adaptive */
+  --color-cobalt: var(--mineral-cobalt);
+  --color-tanzanite: var(--mineral-tanzanite);
+  --color-malachite: var(--mineral-malachite);
+  --color-gold: var(--mineral-gold);
+  --color-terracotta: var(--mineral-terracotta);
 }
 
-body {
-  background: var(--color-surface-base);
-  color: var(--color-text-primary);
-  font-family: ui-sans-serif, system-ui, sans-serif;
+/* Light mode — L1 tokens synced from nyuchi-tokens registry (April 2026).
+ * Surfaces are SWAPPED and AAA-optimised:
+ *   - background is the AMBIENT page base (warm grey, slightly tinted)
+ *   - card is the CONTENT surface (pure white)
+ *   - muted is the WARM CREAM fill (used to be the background)
+ *   - overlay is the MODAL / SHEET surface (white, same as card in light mode)
+ *   - scrim is the modal backdrop
+ * muted-foreground darkened for AAA contrast. Border/input alpha tightened
+ * to 0.06. primary-foreground goes pure white. */
+:root {
+  /* Five African Minerals — light */
+  --mineral-cobalt: #0047ab;
+  --mineral-tanzanite: #4b0082;
+  --mineral-malachite: #004d40;
+  --mineral-gold: #5d4037;
+  --mineral-terracotta: #8b4513;
+  --background: #f3f2ee;
+  --foreground: #141413;
+  --card: #ffffff;
+  --card-foreground: #141413;
+  --popover: #ffffff;
+  --popover-foreground: #141413;
+  --primary: #141413;
+  --primary-foreground: #ffffff;
+  --secondary: #faf9f5;
+  --secondary-foreground: #141413;
+  --muted: #faf9f5;
+  --muted-foreground: #494840;
+  --accent: #faf9f5;
+  --accent-foreground: #141413;
+  --destructive: #b3261e;
+  --overlay: #ffffff;
+  --overlay-foreground: #141413;
+  --scrim: rgba(0, 0, 0, 0.4);
+  --border: rgba(10, 10, 10, 0.06);
+  --input: rgba(10, 10, 10, 0.06);
+  --ring: #141413;
+  --chart-1: #4b0082;
+  --chart-2: #0047ab;
+  --chart-3: #004d40;
+  --chart-4: #5d4037;
+  --chart-5: #8b4513;
+  --radius: calc(var(--radius-unit) * 2);
+  --sidebar: #faf9f5;
+  --sidebar-foreground: #141413;
+  --sidebar-primary: #141413;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f3f2ee;
+  --sidebar-accent-foreground: #141413;
+  --sidebar-border: rgba(10, 10, 10, 0.06);
+  --sidebar-ring: #141413;
 }
 
-/* Fauna classes (Mzizi component naming) — subset used by the console */
-.kudu {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  min-height: var(--touch-target-min);
-  border-radius: var(--radius-button);
-  background: var(--color-primary);
-  color: var(--color-primary-foreground);
-  padding: 0.75rem 1.25rem;
-  font-weight: 600;
+/* Dark mode — L1 tokens synced from nyuchi-tokens registry (April 2026).
+ * Surfaces are SWAPPED and AAA-optimised:
+ *   - background is the AMBIENT page base (warm near-black, L10%)
+ *   - card is the CONTENT surface (darker, L6%)
+ *   - muted is the DEEPEST fill (L2%, maximum text contrast)
+ *   - overlay is the MODAL / SHEET surface (L14%, scrim creates pop)
+ *   - scrim is the modal backdrop
+ * muted-foreground lightened for AAA contrast. Border/input alpha tightened
+ * to 0.06. primary-foreground matches the new warm-near-black background. */
+.dark {
+  /* Five African Minerals — dark */
+  --mineral-cobalt: #00b0ff;
+  --mineral-tanzanite: #b388ff;
+  --mineral-malachite: #64ffda;
+  --mineral-gold: #ffd740;
+  --mineral-terracotta: #d4a574;
+  --background: #1b1a17;
+  --foreground: #f5f5f4;
+  --card: #100f0e;
+  --card-foreground: #f5f5f4;
+  --popover: #100f0e;
+  --popover-foreground: #f5f5f4;
+  --primary: #f5f5f4;
+  --primary-foreground: #1b1a17;
+  --secondary: #050504;
+  --secondary-foreground: #f5f5f4;
+  --muted: #050504;
+  --muted-foreground: #b2afa8;
+  --accent: #050504;
+  --accent-foreground: #f5f5f4;
+  --destructive: #f2b8b5;
+  --overlay: #252421;
+  --overlay-foreground: #f5f5f4;
+  --scrim: rgba(0, 0, 0, 0.6);
+  --border: rgba(255, 255, 255, 0.06);
+  --input: rgba(255, 255, 255, 0.06);
+  --ring: #f5f5f4;
+  --chart-1: #b388ff;
+  --chart-2: #00b0ff;
+  --chart-3: #64ffda;
+  --chart-4: #ffd740;
+  --chart-5: #d4a574;
+  --sidebar: #100f0e;
+  --sidebar-foreground: #f5f5f4;
+  --sidebar-primary: #f5f5f4;
+  --sidebar-primary-foreground: #1b1a17;
+  --sidebar-accent: #050504;
+  --sidebar-accent-foreground: #f5f5f4;
+  --sidebar-border: rgba(255, 255, 255, 0.06);
+  --sidebar-ring: #f5f5f4;
 }
-.impala {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  min-height: var(--touch-target-min);
-  border-radius: var(--radius-button);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-primary);
-  padding: 0.75rem 1.25rem;
-  font-weight: 500;
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
 }
-.baobab {
-  border-radius: var(--radius-card);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-card);
-  padding: 1.25rem;
-}
-.giraffe {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-.dove {
-  font-size: 0.875rem;
-  color: var(--color-text-tertiary);
-}
-.field {
-  width: 100%;
-  min-height: var(--touch-target-min);
-  border-radius: var(--radius-input);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-card);
-  color: var(--color-text-primary);
-  padding: 0.5rem 0.75rem;
+
+/* `.full-bleed` — break MDX content out of the layout container to go full-width. */
+.full-bleed {
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
 }

--- a/station-console/src/app/layout.tsx
+++ b/station-console/src/app/layout.tsx
@@ -1,9 +1,24 @@
 import type { Metadata } from "next";
+import { Noto_Sans, Noto_Serif, JetBrains_Mono } from "next/font/google";
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
+import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
+const notoSans = Noto_Sans({
+  subsets: ["latin"],
+  variable: "--font-noto-sans",
+});
+const notoSerif = Noto_Serif({
+  subsets: ["latin"],
+  variable: "--font-noto-serif",
+});
+const jetBrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-jetbrains-mono",
+});
+
 export const metadata: Metadata = {
-  title: "Mukoko Weather Stations — Console",
+  title: "mukoko weather stations — Console",
   description:
     "Register community weather stations, connect station hardware, and log manual readings for the mukoko weather network.",
   robots: { index: false },
@@ -15,9 +30,20 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${notoSans.variable} ${notoSerif.variable} ${jetBrainsMono.variable}`}
+    >
       <body>
-        <AuthKitProvider>{children}</AuthKitProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <AuthKitProvider>{children}</AuthKitProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/station-console/src/components/Console.tsx
+++ b/station-console/src/components/Console.tsx
@@ -11,6 +11,21 @@ import {
   type RegisteredStation,
   type StationStatus,
 } from "@/lib/api";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 
 interface Credentials {
   stationId: string;
@@ -96,121 +111,161 @@ export function Console({
     <main className="mx-auto max-w-3xl space-y-6 p-4 sm:p-8">
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="text-xl font-semibold">Mukoko Weather Stations</h1>
-          <p className="dove">Signed in as {userEmail}</p>
+          <h1 className="font-serif text-xl font-semibold">
+            mukoko weather stations
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Signed in as {userEmail}
+          </p>
         </div>
-        <a href="/auth/signout" className="impala">
-          Sign out
-        </a>
+        <Button variant="outline" size="sm" asChild>
+          <a href="/auth/signout">Sign out</a>
+        </Button>
       </header>
 
       {error && (
-        <p role="alert" className="baobab" style={undefined}>
-          <span className="text-[var(--color-severity-severe)]">{error}</span>
-        </p>
+        <Alert variant="destructive" role="alert">
+          <AlertTitle>Something went wrong</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
       )}
 
       {/* One-time credentials after registration */}
       {creds && (
-        <section className="baobab space-y-2" aria-label="Station credentials">
-          <h2 className="giraffe">
-            Save these credentials — the key is shown ONCE
-          </h2>
-          <p className="dove">
-            Station ID: <code>{creds.stationId}</code>
-          </p>
-          <p className="dove break-all">
-            Ingest key: <code>{creds.ingestKey}</code>
-          </p>
-          <div className="space-y-1 text-sm">
-            <p className="giraffe">Point your station console at:</p>
-            <p className="dove">
-              Wunderground protocol — server <code>weather.mukoko.com</code>,
-              path <code>/api/py/stations/ingest</code>, ID = station ID,
-              PASSWORD = ingest key
+        <Card aria-label="Station credentials">
+          <CardHeader>
+            <CardTitle>
+              Save these credentials — the key is shown ONCE
+            </CardTitle>
+            <CardDescription>
+              Station ID <code className="font-mono">{creds.stationId}</code> ·
+              ingest key{" "}
+              <code className="break-all font-mono">{creds.ingestKey}</code>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">
+              Point your station console at:
             </p>
-            <p className="dove">
-              Ecowitt protocol — server <code>weather.mukoko.com</code>, path{" "}
-              <code>/api/py/stations/ingest</code>, PASSKEY ={" "}
-              <code>
+            <p>
+              Wunderground protocol — server{" "}
+              <code className="font-mono">weather.mukoko.com</code>, path{" "}
+              <code className="font-mono">/api/py/stations/ingest</code>, ID =
+              station ID, PASSWORD = ingest key
+            </p>
+            <p>
+              Ecowitt protocol — server{" "}
+              <code className="font-mono">weather.mukoko.com</code>, path{" "}
+              <code className="font-mono">/api/py/stations/ingest</code>,
+              PASSKEY ={" "}
+              <code className="font-mono">
                 {creds.stationId}:{"<key>"}
               </code>
             </p>
-          </div>
-          <button className="impala" onClick={() => setCreds(null)}>
-            I have saved them
-          </button>
-        </section>
+          </CardContent>
+          <CardFooter>
+            <Button variant="secondary" onClick={() => setCreds(null)}>
+              I have saved them
+            </Button>
+          </CardFooter>
+        </Card>
       )}
 
       {/* Register */}
-      <section className="baobab space-y-3" aria-label="Register a station">
-        <h2 className="giraffe">Register a station</h2>
-        <form onSubmit={handleRegister} className="space-y-3">
-          <input
-            className="field"
-            required
-            minLength={2}
-            placeholder="Station name (e.g. Marondera High School)"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
-          <div className="flex gap-2">
-            <input
-              className="field"
-              required
-              placeholder="Latitude"
-              inputMode="decimal"
-              value={lat}
-              onChange={(e) => setLat(e.target.value)}
-            />
-            <input
-              className="field"
-              required
-              placeholder="Longitude"
-              inputMode="decimal"
-              value={lon}
-              onChange={(e) => setLon(e.target.value)}
-            />
-            <button type="button" className="impala shrink-0" onClick={useGps}>
-              Use GPS
-            </button>
-          </div>
-          <div className="flex gap-4">
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                checked={stationType === "digital"}
-                onChange={() => setStationType("digital")}
+      <Card aria-label="Register a station">
+        <CardHeader>
+          <CardTitle>Register a station</CardTitle>
+          <CardDescription>
+            Digital consoles push readings automatically; analog stations log
+            manual readings below.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleRegister} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="station-name">Station name</Label>
+              <Input
+                id="station-name"
+                required
+                minLength={2}
+                placeholder="e.g. Marondera High School"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
               />
-              Digital (uploads automatically)
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                checked={stationType === "manual"}
-                onChange={() => setStationType("manual")}
+            </div>
+            <div className="flex flex-wrap items-end gap-2">
+              <div className="min-w-32 flex-1 space-y-2">
+                <Label htmlFor="station-lat">Latitude</Label>
+                <Input
+                  id="station-lat"
+                  required
+                  placeholder="-17.8"
+                  inputMode="decimal"
+                  value={lat}
+                  onChange={(e) => setLat(e.target.value)}
+                />
+              </div>
+              <div className="min-w-32 flex-1 space-y-2">
+                <Label htmlFor="station-lon">Longitude</Label>
+                <Input
+                  id="station-lon"
+                  required
+                  placeholder="31.05"
+                  inputMode="decimal"
+                  value={lon}
+                  onChange={(e) => setLon(e.target.value)}
+                />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={useGps}
+              >
+                Use GPS
+              </Button>
+            </div>
+            <RadioGroup
+              value={stationType}
+              onValueChange={(v) => setStationType(v as "digital" | "manual")}
+              className="flex flex-wrap gap-4"
+              aria-label="Station type"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="digital" id="type-digital" />
+                <Label htmlFor="type-digital">
+                  Digital (uploads automatically)
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="manual" id="type-manual" />
+                <Label htmlFor="type-manual">Analog (manual readings)</Label>
+              </div>
+            </RadioGroup>
+            <div className="space-y-2">
+              <Label htmlFor="station-hardware">Hardware (optional)</Label>
+              <Input
+                id="station-hardware"
+                placeholder="e.g. Ecowitt WS2910"
+                value={hardware}
+                onChange={(e) => setHardware(e.target.value)}
               />
-              Analog (manual readings)
-            </label>
-          </div>
-          <input
-            className="field"
-            placeholder="Hardware (optional, e.g. Ecowitt WS2910)"
-            value={hardware}
-            onChange={(e) => setHardware(e.target.value)}
-          />
-          <button type="submit" className="kudu w-full" disabled={busy}>
-            {busy ? "Registering…" : "Register station"}
-          </button>
-        </form>
-      </section>
+            </div>
+            <Button type="submit" className="w-full" disabled={busy}>
+              {busy ? "Registering…" : "Register station"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
 
       {/* My stations */}
       <section className="space-y-3" aria-label="My stations">
-        <h2 className="giraffe">My stations</h2>
+        <h2 className="text-base font-semibold">My stations</h2>
         {stations.length === 0 && (
-          <p className="dove">No stations on this device yet.</p>
+          <p className="text-sm text-muted-foreground">
+            No stations on this device yet.
+          </p>
         )}
         {stations.map((s) => (
           <StationCard
@@ -226,7 +281,7 @@ export function Console({
         ))}
       </section>
 
-      <footer className="dove">
+      <footer className="text-sm text-muted-foreground">
         API: {API_BASE} · Owner: {userId}
       </footer>
     </main>
@@ -273,78 +328,86 @@ function StationCard({
     setReading((prev) => ({ ...prev, [k]: e.target.value }));
 
   return (
-    <article className="baobab space-y-3">
-      <div className="flex items-center justify-between gap-2">
-        <div>
-          <h3 className="giraffe">{station.name}</h3>
-          <p className="dove">
-            {station.stationId} ·{" "}
-            {station.stationType === "manual" ? "Analog" : "Digital"} ·{" "}
-            {status?.lastObservationAt
-              ? `Last reading ${new Date(status.lastObservationAt).toLocaleString()}`
-              : "No readings yet"}
+    <Card>
+      <CardHeader>
+        <CardTitle>{station.name}</CardTitle>
+        <CardDescription>
+          <code className="font-mono">{station.stationId}</code> ·{" "}
+          {status?.lastObservationAt
+            ? `Last reading ${new Date(status.lastObservationAt).toLocaleString()}`
+            : "No readings yet"}
+        </CardDescription>
+        <CardAction className="flex items-center gap-2">
+          <Badge variant="secondary">
+            {station.stationType === "manual" ? "Analog" : "Digital"}
+          </Badge>
+          <Button variant="ghost" size="sm" onClick={onRemove}>
+            Remove
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {status?.latestMetrics && (
+          <p className="text-sm text-muted-foreground">
+            {Object.entries(status.latestMetrics)
+              .map(
+                ([k, v]) =>
+                  `${k.replace(/([A-Z])/g, " $1").toLowerCase()}: ${v}`,
+              )
+              .join(" · ")}
           </p>
-        </div>
-        <button className="impala" onClick={onRemove}>
-          Remove
-        </button>
-      </div>
+        )}
 
-      {status?.latestMetrics && (
-        <p className="dove">
-          {Object.entries(status.latestMetrics)
-            .map(
-              ([k, v]) => `${k.replace(/([A-Z])/g, " $1").toLowerCase()}: ${v}`,
-            )
-            .join(" · ")}
-        </p>
-      )}
-
-      <form onSubmit={submit} className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-        <input
-          className="field"
-          placeholder="Temp °C"
-          inputMode="decimal"
-          value={reading.temperatureC ?? ""}
-          onChange={set("temperatureC")}
-        />
-        <input
-          className="field"
-          placeholder="Rain mm"
-          inputMode="decimal"
-          value={reading.rainfallMm ?? ""}
-          onChange={set("rainfallMm")}
-        />
-        <input
-          className="field"
-          placeholder="Humidity %"
-          inputMode="decimal"
-          value={reading.humidityPercent ?? ""}
-          onChange={set("humidityPercent")}
-        />
-        <input
-          className="field"
-          placeholder="Pressure hPa"
-          inputMode="decimal"
-          value={reading.pressureHpa ?? ""}
-          onChange={set("pressureHpa")}
-        />
-        <input
-          className="field"
-          placeholder="Wind km/h"
-          inputMode="decimal"
-          value={reading.windKph ?? ""}
-          onChange={set("windKph")}
-        />
-        <button type="submit" className="kudu" disabled={busy}>
-          {busy ? "Saving…" : "Log reading"}
-        </button>
-      </form>
-      {result && (
-        <p className="dove" role="status">
-          {result}
-        </p>
-      )}
-    </article>
+        <form
+          onSubmit={submit}
+          className="grid grid-cols-2 gap-2 sm:grid-cols-3"
+          aria-label={`Log a manual reading for ${station.name}`}
+        >
+          <Input
+            placeholder="Temp °C"
+            aria-label="Temperature in Celsius"
+            inputMode="decimal"
+            value={reading.temperatureC ?? ""}
+            onChange={set("temperatureC")}
+          />
+          <Input
+            placeholder="Rain mm"
+            aria-label="Rainfall in millimetres"
+            inputMode="decimal"
+            value={reading.rainfallMm ?? ""}
+            onChange={set("rainfallMm")}
+          />
+          <Input
+            placeholder="Humidity %"
+            aria-label="Relative humidity percent"
+            inputMode="decimal"
+            value={reading.humidityPercent ?? ""}
+            onChange={set("humidityPercent")}
+          />
+          <Input
+            placeholder="Pressure hPa"
+            aria-label="Pressure in hectopascals"
+            inputMode="decimal"
+            value={reading.pressureHpa ?? ""}
+            onChange={set("pressureHpa")}
+          />
+          <Input
+            placeholder="Wind km/h"
+            aria-label="Wind speed in kilometres per hour"
+            inputMode="decimal"
+            value={reading.windKph ?? ""}
+            onChange={set("windKph")}
+          />
+          <Button type="submit" size="sm" disabled={busy}>
+            {busy ? "Saving…" : "Log reading"}
+          </Button>
+        </form>
+        {result && (
+          <p className="text-sm text-muted-foreground" role="status">
+            {result}
+          </p>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/station-console/src/components/theme-provider.tsx
+++ b/station-console/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import * as React from "react";
+import {
+  ThemeProvider as NextThemesProvider,
+  type ThemeProviderProps,
+} from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/station-console/src/components/ui/alert.tsx
+++ b/station-console/src/components/ui/alert.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "grid gap-0.5 rounded-[var(--radius-lg,14px)] border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 w-full relative group/alert",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      data-portal="https://mzizi.dev/components/alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:transition-colors hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:transition-colors hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2.5 right-3", className)}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };

--- a/station-console/src/components/ui/badge.tsx
+++ b/station-console/src/components/ui/badge.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "h-5 gap-1 rounded-full border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground bg-input/30",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-portal="https://mzizi.dev/components/badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/station-console/src/components/ui/button.tsx
+++ b/station-console/src/components/ui/button.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+/* ═══════════════════════════════════════════════════════════════
+   BUTTON — Layer 2 Primitive
+   
+   Nyuchi Frontend Architecture: Layer 2 (Primitives)
+   
+   Token compliance:
+   ✅ Radius: rounded-full (9999px) — buttons are ALWAYS pill per brand
+   ✅ Touch target: 56px default, 48px minimum — NEVER below 48px
+   ✅ Focus ring: uses --ring token from semantic layer
+   ✅ Colors: uses semantic tokens (primary, secondary, muted, destructive)
+   ✅ data-slot: present for CSS targeting and testing
+   
+   No harness — primitives are too low-level for observability wiring.
+   Brand components that USE buttons wire into the harness at their level.
+   ═══════════════════════════════════════════════════════════════ */
+
+const buttonVariants = cva(
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-full border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        outline:
+          "border-border bg-input/30 hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+        destructive:
+          "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        /* DEFAULT = 56px (--touch-target) — the brand standard */
+        default:
+          "h-14 gap-2 px-5 has-data-[icon=inline-end]:pr-4 has-data-[icon=inline-start]:pl-4",
+        /* SM = 48px (--touch-target-sm) — the MINIMUM allowed */
+        sm: "h-12 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+        /* LG = 56px — same as default, wider padding */
+        lg: "h-14 gap-2 px-6 has-data-[icon=inline-end]:pr-5 has-data-[icon=inline-start]:pl-5",
+        /* ICON variants — square touch targets */
+        icon: "size-14",
+        "icon-sm": "size-12",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot.Root : "button";
+
+  return (
+    <Comp
+      data-slot="button"
+      data-portal="https://mzizi.dev/components/button"
+      data-variant={variant}
+      data-size={size}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/station-console/src/components/ui/card.tsx
+++ b/station-console/src/components/ui/card.tsx
@@ -1,0 +1,144 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/* ═══════════════════════════════════════════════════════════════
+   CARD — Layer 2 Primitive
+   
+   Nyuchi Frontend Architecture: Layer 2 (Primitives)
+   
+   Token compliance:
+   ✅ Radius: rounded-[var(--radius-lg,14px)] — THE Nyuchi card radius
+   ✅ Inner radius: rounded-[var(--radius-md,12px)] for header/footer corners
+   ✅ Colors: uses semantic tokens (card, card-foreground, foreground)
+   ✅ Border: ring-1 ring-foreground/10 — consistent across themes
+   ✅ data-slot: present on all sub-components
+   
+   The card is the most composed primitive in the system.
+   Every brand component that shows content in a container
+   ultimately renders a card.
+   ═══════════════════════════════════════════════════════════════ */
+
+function Card({
+  className,
+  size = "default",
+  loading = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  size?: "default" | "sm";
+  loading?: boolean;
+}) {
+  // Built-in loading state — every component from L2 up renders its own skeleton
+  if (loading) {
+    return (
+      <div
+        data-slot="card"
+        data-portal="https://mzizi.dev/components/card"
+        data-loading
+        className={cn(
+          "group/card flex flex-col gap-4 overflow-hidden rounded-[var(--radius-lg,14px)] bg-card p-6 text-sm ring-1 ring-foreground/10 animate-pulse",
+          size === "sm" && "gap-3 p-4",
+          className,
+        )}
+      >
+        <div className="h-4 w-2/3 rounded bg-muted" />
+        <div className="h-3 w-full rounded bg-muted" />
+        <div className="h-3 w-4/5 rounded bg-muted" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-6 overflow-hidden rounded-[var(--radius-lg,14px)] bg-card py-6 text-sm text-card-foreground ring-1 ring-foreground/10 has-[>img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-[var(--radius-md,12px)] *:[img:last-child]:rounded-b-[var(--radius-md,12px)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-2 rounded-t-[var(--radius-md,12px)] px-6 group-data-[size=sm]/card:px-4 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-6 group-data-[size=sm]/card:[.border-b]:pb-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("text-base font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6 group-data-[size=sm]/card:px-4", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-[var(--radius-md,12px)] px-6 group-data-[size=sm]/card:px-4 [.border-t]:pt-6 group-data-[size=sm]/card:[.border-t]:pt-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/station-console/src/components/ui/input.tsx
+++ b/station-console/src/components/ui/input.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/* ═══════════════════════════════════════════════════════════════
+   INPUT — Layer 2 Primitive
+   
+   Nyuchi Frontend Architecture: Layer 2 (Primitives)
+   
+   Token compliance:
+   ✅ Radius: rounded-full (9999px) — inputs use pill radius per brand
+   ✅ Touch target: h-12 (48px) — meets minimum touch target
+   ✅ Focus ring: uses --ring token from semantic layer
+   ✅ Colors: uses semantic tokens (input, foreground, muted-foreground)
+   ✅ data-slot: present for CSS targeting
+   
+   Height was 36px (h-9) — VIOLATION of 48px minimum.
+   Now 48px (h-12) as the base, with touch-safe proportions.
+   ═══════════════════════════════════════════════════════════════ */
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      data-portal="https://mzizi.dev/components/input"
+      className={cn(
+        "h-12 w-full min-w-0 rounded-full border border-input bg-input/30 px-4 py-1 text-base transition-colors outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/station-console/src/components/ui/label.tsx
+++ b/station-console/src/components/ui/label.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+import { Label as LabelPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      data-portal="https://mzizi.dev/components/label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/station-console/src/components/ui/radio-group.tsx
+++ b/station-console/src/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      data-portal="https://mzizi.dev/components/radio-group"
+      className={cn("grid w-full gap-3", className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:data-checked:bg-primary",
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="flex size-4 items-center justify-center"
+      >
+        <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/station-console/src/lib/utils.ts
+++ b/station-console/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/station-console/tsconfig.json
+++ b/station-console/tsconfig.json
@@ -11,11 +11,23 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
-    "paths": { "@/*": ["./src/*"] }
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Station console — Nyuchi Design system (Mzizi doctrine)

Bootstrapped via **`@nyuchi/design-cli`** (the canonical entry point among the `@nyuchi` npm packages — `@nyuchi/ui` / `@bundu/ui` are Astro-only and don't fit the Next.js console):

- `init` — canonical **L1 token** `globals.css` (five African Minerals, AAA-optimised light/dark surfaces synced from the nyuchi-tokens registry), `cn()` helper, next-themes provider, `components.json` pinned to the Nyuchi registry
- **L2 primitives** installed from the registry (design.nyuchi.com → mzizi.dev) via the shadcn CLI: `Button`, `Input`, `Label`, `Card`, `Badge`, `Alert`, `RadioGroup` — pill buttons, 56 px touch targets, semantic tokens, `data-slot` attributes
- `Console.tsx` rewritten as **pure composition** over the primitives; the hand-rolled fauna CSS classes (`.kudu`/`.impala`/`.baobab`/`.giraffe`/`.dove`/`.field`) are deleted with the old globals
- Class-based dark mode via next-themes (system default); Noto Sans/Serif + JetBrains Mono via `next/font`; lowercase serif wordmark heading per the mukoko brand guide
- Nyuchi Design **agent skills** installed to `station-console/.claude/skills/` (versions pinned in `.nyuchi-design.json`)
- Repo-root `.gitignore` now covers `station-console/node_modules` + `.next`

## Footer outbound links

- Tomorrow.io, Open-Meteo, and the Nyuchi Africa copyright links were missing `target="_blank"` — all external links now open in a new tab with `rel="noopener noreferrer"`
- GitHub links pointed at the wrong org (`nyuchitech/mukoko-weather`, which 404s) — corrected to `nyuchi/mukoko-weather` in the footer icon link, "Report an issue", the error-boundary issue-URL builder (`observability.ts` + test), and the terms-page LICENSE link
- Removed the Ecosystem "Travel" link — `travel.mukoko.com` has no DNS record

## Validation

- `npm test` — 2078 passed
- `python -m pytest tests/py/` — 999 passed
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean
- `npm run build` — main app OK; `station-console` builds clean with the new components
- Prettier run on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW

---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_