### PR TITLE
Console: seven minerals from Mzizi registry + public landing page; footer Travel link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,7 +397,7 @@ mukoko-weather/
 │   ├── package.json               # Own Next.js app: web-only, NO PWA/offline; WorkOS AuthKit with the SAME credentials as the main app (register the /callback redirect URI in WorkOS)
 │   ├── components.json            # Nyuchi Design registry config — bootstrapped via `npx @nyuchi/design-cli init`, components installed from the registry (design.nyuchi.com → mzizi.dev) via the shadcn CLI
 │   ├── .claude/skills/            # Nyuchi Design agent skills (`npx @nyuchi/design-cli skills install`; versions pinned in .nyuchi-design.json)
-│   └── src/                       # Auth-gated console: register stations, one-time credentials + WU/Ecowitt setup instructions, manual readings, status. Calls the /api/py/stations/* endpoints (CORS-allowed origin); station keys live in the owner's browser localStorage.
+│   └── src/                       # Public landing page at / (anonymous visitors get a sign-in CTA; signed-in users get the console — middleware lists "/" in unauthenticatedPaths); console: register stations, one-time credentials + WU/Ecowitt setup instructions, manual readings, status. Calls the /api/py/stations/* endpoints (CORS-allowed origin); station keys live in the owner's browser localStorage.
 │                                  # Styling per Mzizi doctrine: canonical Nyuchi L1 tokens in src/app/globals.css + registry L2 primitives in src/components/ui/ (Button, Input, Label, Card, Badge, Alert, RadioGroup) — pages are pure composition, no hand-rolled CSS classes or inline styles; theme via next-themes (class-based dark mode); fonts Noto Sans/Serif + JetBrains Mono via next/font
 ├── worker/                        # Cloudflare Workers edge API (optional)
 │   ├── src/

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -170,6 +170,14 @@ export function Footer() {
             >
               Barstool
             </a>
+            <a
+              href="https://travel-info.co.zw"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={link}
+            >
+              Travel
+            </a>
           </div>
         </div>
 

--- a/station-console/src/app/globals.css
+++ b/station-console/src/app/globals.css
@@ -54,12 +54,15 @@
   --radius-2xl: calc(var(--radius-unit) + 10px);
   --radius-3xl: 9999px;
   --radius-4xl: 9999px;
-  /* Five African Minerals — theme-adaptive */
+  /* Seven African Minerals — theme-adaptive (source of truth: Mzizi
+     registry `brand_minerals`, doctrine v4.1.0) */
   --color-cobalt: var(--mineral-cobalt);
   --color-tanzanite: var(--mineral-tanzanite);
   --color-malachite: var(--mineral-malachite);
   --color-gold: var(--mineral-gold);
   --color-terracotta: var(--mineral-terracotta);
+  --color-sodalite: var(--mineral-sodalite);
+  --color-copper: var(--mineral-copper);
 }
 
 /* Light mode — L1 tokens synced from nyuchi-tokens registry (April 2026).
@@ -72,12 +75,14 @@
  * muted-foreground darkened for AAA contrast. Border/input alpha tightened
  * to 0.06. primary-foreground goes pure white. */
 :root {
-  /* Five African Minerals — light */
+  /* Seven African Minerals — light (Mzizi registry values) */
   --mineral-cobalt: #0047ab;
   --mineral-tanzanite: #4b0082;
   --mineral-malachite: #004d40;
   --mineral-gold: #5d4037;
-  --mineral-terracotta: #8b4513;
+  --mineral-terracotta: #a0522d;
+  --mineral-sodalite: #283593;
+  --mineral-copper: #bf5a36;
   --background: #f3f2ee;
   --foreground: #141413;
   --card: #ffffff;
@@ -125,12 +130,14 @@
  * muted-foreground lightened for AAA contrast. Border/input alpha tightened
  * to 0.06. primary-foreground matches the new warm-near-black background. */
 .dark {
-  /* Five African Minerals — dark */
+  /* Seven African Minerals — dark (Mzizi registry values) */
   --mineral-cobalt: #00b0ff;
   --mineral-tanzanite: #b388ff;
   --mineral-malachite: #64ffda;
   --mineral-gold: #ffd740;
-  --mineral-terracotta: #d4a574;
+  --mineral-terracotta: #e1b07e;
+  --mineral-sodalite: #3d5afe;
+  --mineral-copper: #ff8a65;
   --background: #1b1a17;
   --foreground: #f5f5f4;
   --card: #100f0e;

--- a/station-console/src/app/page.tsx
+++ b/station-console/src/app/page.tsx
@@ -1,12 +1,93 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { Console } from "@/components/Console";
+import { MineralsStripe } from "@/components/MineralsStripe";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 
 /**
- * The whole console is auth-gated (authkitMiddleware enforces sign-in on
- * every path) — station owners sign in with the same Nyuchi identity used
- * on weather.mukoko.com.
+ * `/` is public: anonymous visitors see the landing page below; signed-in
+ * station owners go straight to the console. The middleware lists "/" in
+ * unauthenticatedPaths — everything else stays auth-gated, and the console
+ * itself only renders when withAuth() returns a user.
  */
 export default async function Home() {
-  const { user } = await withAuth({ ensureSignedIn: true });
-  return <Console userEmail={user.email ?? ""} userId={user.id} />;
+  const { user } = await withAuth();
+
+  if (user) {
+    return <Console userEmail={user.email ?? ""} userId={user.id} />;
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-8 p-4 py-12 sm:p-8 sm:py-16">
+      <header className="space-y-4">
+        <MineralsStripe />
+        <h1 className="font-serif text-3xl font-semibold sm:text-4xl">
+          mukoko weather stations
+        </h1>
+        <p className="text-lg text-muted-foreground">
+          Put your weather station on the map. Readings from community stations
+          feed live current conditions on{" "}
+          <a
+            href="https://weather.mukoko.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-cobalt underline underline-offset-4"
+          >
+            weather.mukoko.com
+          </a>{" "}
+          for everyone nearby — farmers, schools, pilots, and neighbours.
+        </p>
+        <Button asChild>
+          <a href="/auth/signin">Sign in to register your station</a>
+        </Button>
+      </header>
+
+      <section aria-label="How it works" className="grid gap-4 sm:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Digital stations</CardTitle>
+            <CardDescription>
+              Ecowitt, Fine Offset, Ambient-style consoles and compatibles
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Point your console&apos;s &ldquo;customized upload&rdquo; at our
+            servers — Wunderground and Ecowitt protocols are both supported. No
+            Weather Underground account needed: your data goes straight to the
+            mukoko network, quality-checked on arrival.
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Analog stations</CardTitle>
+            <CardDescription>
+              Rain gauge and thermometer — no electronics required
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Farms and schools with manual instruments can log readings right
+            here in the console. Each entry passes the same quality checks and
+            joins the network alongside digital stations.
+          </CardContent>
+        </Card>
+      </section>
+
+      <footer className="space-y-2 text-sm text-muted-foreground">
+        <p>
+          Registration is free. You get a station ID and a private ingest key —
+          shown once, stored only as a salted hash on our side.
+        </p>
+        <p>
+          A Mukoko Africa project by Nyuchi Africa (PVT) Ltd.{" "}
+          <span className="italic">Ndiri nekuti tiri.</span>
+        </p>
+      </footer>
+    </main>
+  );
 }

--- a/station-console/src/components/MineralsStripe.tsx
+++ b/station-console/src/components/MineralsStripe.tsx
@@ -1,0 +1,27 @@
+/**
+ * Decorative seven-mineral stripe — the Mukoko brand ribbon (Mzizi registry
+ * `brand_minerals` order: cobalt, tanzanite, malachite, gold, terracotta,
+ * sodalite, copper). Colours come from the L1 tokens in globals.css.
+ */
+const MINERALS = [
+  "bg-cobalt",
+  "bg-tanzanite",
+  "bg-malachite",
+  "bg-gold",
+  "bg-terracotta",
+  "bg-sodalite",
+  "bg-copper",
+] as const;
+
+export function MineralsStripe() {
+  return (
+    <div
+      className="flex h-1 w-full overflow-hidden rounded-full"
+      aria-hidden="true"
+    >
+      {MINERALS.map((cls) => (
+        <span key={cls} className={`${cls} flex-1`} />
+      ))}
+    </div>
+  );
+}

--- a/station-console/src/middleware.ts
+++ b/station-console/src/middleware.ts
@@ -3,10 +3,14 @@ import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
 // Same WorkOS credentials as weather.mukoko.com (shared Nyuchi identity) —
 // only the redirect URI differs (this app's /callback must be registered in
 // the WorkOS dashboard).
+//
+// "/" is public: it renders the landing page for anonymous visitors and the
+// console for signed-in users (page.tsx branches on withAuth()). Every other
+// path still requires sign-in.
 export default authkitMiddleware({
   middlewareAuth: {
     enabled: true,
-    unauthenticatedPaths: [],
+    unauthenticatedPaths: ["/"],
   },
 });
 


### PR DESCRIPTION
## Seven minerals, not five

The `@nyuchi/design-cli` template shipped only five minerals — the doctrine is **seven**, sourced live from the Mzizi registry (`brand_minerals`):

- Added **sodalite** (`#283593` light / `#3D5AFE` dark — AI/deep-reasoning surfaces) and **copper** (`#BF5A36` / `#FF8A65` — Bundu/commons) to the console's L1 tokens and `@theme` registration
- Corrected **terracotta** to the registry values (`#A0522D` light / `#E1B07E` dark — the template carried stale hexes)
- The main app already had all seven with correct values — verified against the registry, no change needed

## Public landing page before login

`/` on the station console is now public: anonymous visitors get a landing page — seven-mineral stripe, hero, digital (WU/Ecowitt protocol) + analog (manual readings) explainer cards, and a "Sign in to register your station" CTA — composed entirely from the registry `Card`/`Button` primitives per the Mzizi doctrine. Signed-in users still land straight in the console. The middleware lists `/` in `unauthenticatedPaths`; every other path remains auth-gated.

## Footer Travel link

Restored the Ecosystem "Travel" link pointing at `https://travel-info.co.zw` (verified live; the previously-removed `travel.mukoko.com` had no DNS record).

## Validation

- `npm test` — 2078 passed; `python -m pytest tests/py/` — 999 passed
- `npm run lint` — 0 errors; `npx tsc --noEmit` — clean (both apps)
- `npm run build` — main app and station-console both build
- Prettier 3.9.4 (CI's version) clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW

---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_