### PR TITLE
Link the nyuchi-docs help guides from the weather app and station console

### DIFF
--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -70,172 +70,284 @@ export default function HelpPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
       <Header />
-      <main id="main-content" className="mx-auto max-w-3xl px-4 py-10 pb-24 sm:pb-10 sm:px-6 md:px-8">
-        <h1 className="font-display text-3xl font-bold text-text-primary sm:text-4xl">Help & FAQ</h1>
+      <main
+        id="main-content"
+        className="mx-auto max-w-3xl px-4 py-10 pb-24 sm:pb-10 sm:px-6 md:px-8"
+      >
+        <h1 className="font-display text-3xl font-bold text-text-primary sm:text-4xl">
+          Help & FAQ
+        </h1>
         <p className="mt-3 text-text-secondary">
           Everything you need to know about using mukoko weather.
         </p>
 
         {/* Getting Started */}
         <section className="mt-10">
-          <h2 className="font-heading text-2xl font-bold text-text-primary">Getting started</h2>
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Getting started
+          </h2>
           <div className="mt-4 space-y-4 text-text-secondary leading-relaxed">
             <p>
-              mukoko weather gives you accurate weather data for 265+ locations worldwide. No account needed —
-              just visit{" "}
-              <a href={BASE_URL} className="text-primary underline">weather.mukoko.com</a>{" "}
+              mukoko weather gives you accurate weather data for 265+ locations
+              worldwide. No account needed — just visit{" "}
+              <a href={BASE_URL} className="text-primary underline">
+                weather.mukoko.com
+              </a>{" "}
               and you&apos;re ready to go.
             </p>
-            <h3 className="font-semibold text-text-primary">Selecting a location</h3>
+            <h3 className="font-semibold text-text-primary">
+              Selecting a location
+            </h3>
             <p>
-              Tap the location button in the top-right corner of the header. You can:
+              Tap the location button in the top-right corner of the header. You
+              can:
             </p>
             <ul className="list-disc pl-6 space-y-1">
-              <li>Search by name (e.g. &quot;London&quot;, &quot;Nairobi&quot;, &quot;Bangkok&quot;)</li>
-              <li>Filter by category — cities, farming areas, mining, tourism, national parks</li>
-              <li>Tap &quot;Use my location&quot; to auto-detect your nearest supported weather location</li>
+              <li>
+                Search by name (e.g. &quot;London&quot;, &quot;Nairobi&quot;,
+                &quot;Bangkok&quot;)
+              </li>
+              <li>
+                Filter by category — cities, farming areas, mining, tourism,
+                national parks
+              </li>
+              <li>
+                Tap &quot;Use my location&quot; to auto-detect your nearest
+                supported weather location
+              </li>
             </ul>
 
-            <h3 className="font-semibold text-text-primary">Using your location</h3>
+            <h3 className="font-semibold text-text-primary">
+              Using your location
+            </h3>
             <p>
-              When you tap &quot;Use my location&quot;, your browser will ask for permission. Your coordinates
-              are used to find the nearest supported weather location. If you
-              deny permission, you can always select a location manually.
+              When you tap &quot;Use my location&quot;, your browser will ask
+              for permission. Your coordinates are used to find the nearest
+              supported weather location. If you deny permission, you can always
+              select a location manually.
             </p>
           </div>
         </section>
 
         {/* Understanding the forecast */}
         <section className="mt-10">
-          <h2 className="font-heading text-2xl font-bold text-text-primary">Understanding the forecast</h2>
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Understanding the forecast
+          </h2>
           <div className="mt-4 space-y-4 text-text-secondary leading-relaxed">
-            <h3 className="font-semibold text-text-primary">Current conditions</h3>
+            <h3 className="font-semibold text-text-primary">
+              Current conditions
+            </h3>
             <p>
-              The main card shows the current temperature, &quot;feels like&quot; temperature, and weather
-              condition (e.g. Clear sky, Partly cloudy, Rain). Below that you&apos;ll find humidity, wind
-              speed and direction, UV index, atmospheric pressure, cloud cover, and precipitation.
+              The main card shows the current temperature, &quot;feels
+              like&quot; temperature, and weather condition (e.g. Clear sky,
+              Partly cloudy, Rain). Below that you&apos;ll find humidity, wind
+              speed and direction, UV index, atmospheric pressure, cloud cover,
+              and precipitation.
             </p>
 
-            <h3 className="font-semibold text-text-primary">24-hour forecast</h3>
+            <h3 className="font-semibold text-text-primary">
+              24-hour forecast
+            </h3>
             <p>
-              The hourly forecast shows hour-by-hour predictions for the next 24 hours, including temperature,
-              weather icon, and rain probability. Scroll horizontally to see the full timeline.
+              The hourly forecast shows hour-by-hour predictions for the next 24
+              hours, including temperature, weather icon, and rain probability.
+              Scroll horizontally to see the full timeline.
             </p>
 
             <h3 className="font-semibold text-text-primary">7-day forecast</h3>
             <p>
-              The daily forecast shows each day&apos;s high and low temperatures, weather condition, and rain
-              probability. This helps with planning the week ahead.
+              The daily forecast shows each day&apos;s high and low
+              temperatures, weather condition, and rain probability. This helps
+              with planning the week ahead.
             </p>
 
-            <h3 className="font-semibold text-text-primary">AI weather summary</h3>
+            <h3 className="font-semibold text-text-primary">
+              AI weather summary
+            </h3>
             <p>
-              Our AI assistant, <strong className="text-text-primary">Shamwari Weather</strong>, provides a
-              contextual summary of current conditions with practical advice. Summaries are tailored to the
-              location type — farming areas get crop advice, tourism spots get outdoor activity guidance,
-              mining areas get safety tips.
+              Our AI assistant,{" "}
+              <strong className="text-text-primary">Shamwari Weather</strong>,
+              provides a contextual summary of current conditions with practical
+              advice. Summaries are tailored to the location type — farming
+              areas get crop advice, tourism spots get outdoor activity
+              guidance, mining areas get safety tips.
             </p>
 
-            <h3 className="font-semibold text-text-primary">Sunrise & sunset</h3>
+            <h3 className="font-semibold text-text-primary">
+              Sunrise & sunset
+            </h3>
             <p>
-              Today&apos;s sunrise and sunset times for your selected location, useful for planning outdoor
-              activities and understanding daylight hours.
+              Today&apos;s sunrise and sunset times for your selected location,
+              useful for planning outdoor activities and understanding daylight
+              hours.
             </p>
           </div>
         </section>
 
         {/* Frost alerts */}
         <section className="mt-10">
-          <h2 className="font-heading text-2xl font-bold text-text-primary">Frost alerts</h2>
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Frost alerts
+          </h2>
           <div className="mt-4 space-y-4 text-text-secondary leading-relaxed">
             <p>
-              mukoko weather automatically monitors overnight temperatures and displays a frost alert banner
-              when conditions are risky. This is especially useful for farmers during frost-prone seasons.
+              mukoko weather automatically monitors overnight temperatures and
+              displays a frost alert banner when conditions are risky. This is
+              especially useful for farmers during frost-prone seasons.
             </p>
             <h3 className="font-semibold text-text-primary">Alert levels</h3>
             <dl className="mt-2 space-y-2">
               <div className="flex gap-3">
-                <dt className="w-24 flex-shrink-0 font-semibold text-text-primary">Severe</dt>
-                <dd>Below 0°C — protect all crops immediately, cover sensitive plants, drain exposed pipes</dd>
+                <dt className="w-24 flex-shrink-0 font-semibold text-text-primary">
+                  Severe
+                </dt>
+                <dd>
+                  Below 0°C — protect all crops immediately, cover sensitive
+                  plants, drain exposed pipes
+                </dd>
               </div>
               <div className="flex gap-3">
-                <dt className="w-24 flex-shrink-0 font-semibold text-text-primary">High</dt>
-                <dd>0°C to 2°C — significant frost risk, cover sensitive crops and seedlings</dd>
+                <dt className="w-24 flex-shrink-0 font-semibold text-text-primary">
+                  High
+                </dt>
+                <dd>
+                  0°C to 2°C — significant frost risk, cover sensitive crops and
+                  seedlings
+                </dd>
               </div>
               <div className="flex gap-3">
-                <dt className="w-24 flex-shrink-0 font-semibold text-text-primary">Moderate</dt>
-                <dd>2°C to 3°C — light frost possible, protect delicate plants</dd>
+                <dt className="w-24 flex-shrink-0 font-semibold text-text-primary">
+                  Moderate
+                </dt>
+                <dd>
+                  2°C to 3°C — light frost possible, protect delicate plants
+                </dd>
               </div>
             </dl>
             <p>
-              Frost checks run for nighttime hours (10pm to 8am) when frost is most likely. Alerts
-              appear as a banner at the top of the weather page.
+              Frost checks run for nighttime hours (10pm to 8am) when frost is
+              most likely. Alerts appear as a banner at the top of the weather
+              page.
             </p>
           </div>
         </section>
 
         {/* Seasonal awareness */}
         <section className="mt-10">
-          <h2 className="font-heading text-2xl font-bold text-text-primary">Seasonal awareness</h2>
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Seasonal awareness
+          </h2>
           <div className="mt-4 space-y-4 text-text-secondary leading-relaxed">
             <p>
-              mukoko weather displays country-specific seasonal context on forecast pages. Season data
-              covers 50+ countries with local season names and agricultural calendars — from Zimbabwe&apos;s
-              Masika and Chirimo to tropical monsoon and dry seasons across Africa, Asia, and beyond.
+              mukoko weather displays country-specific seasonal context on
+              forecast pages. Season data covers 50+ countries with local season
+              names and agricultural calendars — from Zimbabwe&apos;s Masika and
+              Chirimo to tropical monsoon and dry seasons across Africa, Asia,
+              and beyond.
             </p>
             <p>
-              Seasonal information helps you understand how weather patterns affect daily life,
-              agriculture, and travel in each region throughout the year.
+              Seasonal information helps you understand how weather patterns
+              affect daily life, agriculture, and travel in each region
+              throughout the year.
             </p>
           </div>
         </section>
 
         {/* Install as app */}
         <section className="mt-10">
-          <h2 className="font-heading text-2xl font-bold text-text-primary">Install as an app</h2>
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Install as an app
+          </h2>
           <div className="mt-4 space-y-4 text-text-secondary leading-relaxed">
             <p>
-              mukoko weather works as a Progressive Web App (PWA) — you can install it on your phone&apos;s
-              home screen for quick access.
+              mukoko weather works as a Progressive Web App (PWA) — you can
+              install it on your phone&apos;s home screen for quick access.
             </p>
-            <h3 className="font-semibold text-text-primary">Android / Huawei</h3>
+            <h3 className="font-semibold text-text-primary">
+              Android / Huawei
+            </h3>
             <ol className="list-decimal pl-6 space-y-1">
-              <li>Open <strong className="text-text-primary">weather.mukoko.com</strong> in Chrome or your browser</li>
-              <li>Tap the <strong className="text-text-primary">menu button</strong> (three dots in the top-right)</li>
-              <li>Tap <strong className="text-text-primary">&quot;Add to Home Screen&quot;</strong> or <strong className="text-text-primary">&quot;Install App&quot;</strong></li>
+              <li>
+                Open{" "}
+                <strong className="text-text-primary">
+                  weather.mukoko.com
+                </strong>{" "}
+                in Chrome or your browser
+              </li>
+              <li>
+                Tap the{" "}
+                <strong className="text-text-primary">menu button</strong>{" "}
+                (three dots in the top-right)
+              </li>
+              <li>
+                Tap{" "}
+                <strong className="text-text-primary">
+                  &quot;Add to Home Screen&quot;
+                </strong>{" "}
+                or{" "}
+                <strong className="text-text-primary">
+                  &quot;Install App&quot;
+                </strong>
+              </li>
               <li>The app icon will appear on your home screen</li>
             </ol>
             <h3 className="font-semibold text-text-primary">iPhone / iPad</h3>
             <ol className="list-decimal pl-6 space-y-1">
-              <li>Open <strong className="text-text-primary">weather.mukoko.com</strong> in Safari</li>
-              <li>Tap the <strong className="text-text-primary">Share button</strong> (square with arrow)</li>
-              <li>Scroll down and tap <strong className="text-text-primary">&quot;Add to Home Screen&quot;</strong></li>
+              <li>
+                Open{" "}
+                <strong className="text-text-primary">
+                  weather.mukoko.com
+                </strong>{" "}
+                in Safari
+              </li>
+              <li>
+                Tap the{" "}
+                <strong className="text-text-primary">Share button</strong>{" "}
+                (square with arrow)
+              </li>
+              <li>
+                Scroll down and tap{" "}
+                <strong className="text-text-primary">
+                  &quot;Add to Home Screen&quot;
+                </strong>
+              </li>
             </ol>
             <p>
-              Once installed, the app opens in standalone mode (no browser address bar) and supports quick
-              shortcuts to your favourite locations via long-press on the app icon.
+              Once installed, the app opens in standalone mode (no browser
+              address bar) and supports quick shortcuts to your favourite
+              locations via long-press on the app icon.
             </p>
           </div>
         </section>
 
         {/* Dark mode */}
         <section className="mt-10">
-          <h2 className="font-heading text-2xl font-bold text-text-primary">Dark mode</h2>
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Dark mode
+          </h2>
           <div className="mt-4 text-text-secondary leading-relaxed">
             <p>
-              Tap the theme toggle button in the top-right corner of the header (next to the location selector)
-              to switch between light and dark mode. Your preference is saved and remembered on your next visit.
+              Tap the theme toggle button in the top-right corner of the header
+              (next to the location selector) to switch between light and dark
+              mode. Your preference is saved and remembered on your next visit.
             </p>
           </div>
         </section>
 
         {/* Embed widget */}
         <section className="mt-10">
-          <h2 className="font-heading text-2xl font-bold text-text-primary">Embed widget</h2>
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Embed widget
+          </h2>
           <div className="mt-4 text-text-secondary leading-relaxed">
             <p>
-              mukoko weather offers an embeddable weather widget for third-party websites. Visit the{" "}
-              <Link href="/embed" className="text-primary underline hover:text-primary/80 transition-colors">
+              mukoko weather offers an embeddable weather widget for third-party
+              websites. Visit the{" "}
+              <Link
+                href="/embed"
+                className="text-primary underline hover:text-primary/80 transition-colors"
+              >
                 embed page
               </Link>{" "}
               for documentation and code snippets.
@@ -245,33 +357,91 @@ export default function HelpPage() {
 
         {/* FAQ */}
         <section className="mt-10">
-          <h2 className="font-heading text-2xl font-bold text-text-primary">Frequently asked questions</h2>
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Frequently asked questions
+          </h2>
           <div className="mt-4">
             <FAQ />
           </div>
         </section>
 
+        {/* Full guides */}
+        <section className="mt-10">
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Full guides
+          </h2>
+          <div className="mt-4 text-text-secondary leading-relaxed">
+            <p>In-depth guides live in the Nyuchi documentation:</p>
+            <ul className="mt-2 space-y-1">
+              <li>
+                <a
+                  href="https://docs.nyuchi.com/mukoko-weather/user-guide/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Mukoko Weather user guide
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://docs.nyuchi.com/mukoko-weather/weather-stations/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Community weather stations — setup guide
+                </a>
+              </li>
+            </ul>
+          </div>
+        </section>
+
         {/* Contact */}
         <section className="mt-10">
-          <h2 className="font-heading text-2xl font-bold text-text-primary">Still need help?</h2>
+          <h2 className="font-heading text-2xl font-bold text-text-primary">
+            Still need help?
+          </h2>
           <div className="mt-4 text-text-secondary leading-relaxed">
             <p>Reach out to us:</p>
             <ul className="mt-2 space-y-1">
               <li>
                 <strong className="text-text-primary">Support:</strong>{" "}
-                <a href="mailto:support@mukoko.com" className="text-primary underline">support@mukoko.com</a>
+                <a
+                  href="mailto:support@mukoko.com"
+                  className="text-primary underline"
+                >
+                  support@mukoko.com
+                </a>
               </li>
               <li>
                 <strong className="text-text-primary">General:</strong>{" "}
-                <a href="mailto:hi@mukoko.com" className="text-primary underline">hi@mukoko.com</a>
+                <a
+                  href="mailto:hi@mukoko.com"
+                  className="text-primary underline"
+                >
+                  hi@mukoko.com
+                </a>
               </li>
               <li>
                 <strong className="text-text-primary">Twitter:</strong>{" "}
-                <a href="https://twitter.com/mukokoafrica" className="text-primary underline" rel="noopener noreferrer">@mukokoafrica</a>
+                <a
+                  href="https://twitter.com/mukokoafrica"
+                  className="text-primary underline"
+                  rel="noopener noreferrer"
+                >
+                  @mukokoafrica
+                </a>
               </li>
               <li>
                 <strong className="text-text-primary">Instagram:</strong>{" "}
-                <a href="https://instagram.com/mukoko.africa" className="text-primary underline" rel="noopener noreferrer">@mukoko.africa</a>
+                <a
+                  href="https://instagram.com/mukoko.africa"
+                  className="text-primary underline"
+                  rel="noopener noreferrer"
+                >
+                  @mukoko.africa
+                </a>
               </li>
             </ul>
           </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -124,6 +124,14 @@ export function Footer() {
             <Link href="/help" prefetch={false} className={link}>
               Help
             </Link>
+            <a
+              href="https://docs.nyuchi.com/mukoko-weather/user-guide/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={link}
+            >
+              Docs
+            </a>
             <Link href="/privacy" prefetch={false} className={link}>
               Privacy
             </Link>

--- a/station-console/src/app/page.tsx
+++ b/station-console/src/app/page.tsx
@@ -81,7 +81,17 @@ export default async function Home() {
       <footer className="space-y-2 text-sm text-muted-foreground">
         <p>
           Registration is free. You get a station ID and a private ingest key —
-          shown once, stored only as a salted hash on our side.
+          shown once, stored only as a salted hash on our side. Full setup
+          instructions live in the{" "}
+          <a
+            href="https://docs.nyuchi.com/mukoko-weather/weather-stations/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-cobalt underline underline-offset-4"
+          >
+            weather stations guide
+          </a>
+          .
         </p>
         <p>
           A Mukoko Africa project by Nyuchi Africa (PVT) Ltd.{" "}

--- a/station-console/src/components/Console.tsx
+++ b/station-console/src/components/Console.tsx
@@ -162,6 +162,17 @@ export function Console({
                 {creds.stationId}:{"<key>"}
               </code>
             </p>
+            <p>
+              Step-by-step instructions:{" "}
+              <a
+                href="https://docs.nyuchi.com/mukoko-weather/weather-stations/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-cobalt underline underline-offset-4"
+              >
+                weather stations guide
+              </a>
+            </p>
           </CardContent>
           <CardFooter>
             <Button variant="secondary" onClick={() => setCreds(null)}>


### PR DESCRIPTION
Help guides for the weather app and station console now live in nyuchi-docs (docs.nyuchi.com, "Mukoko Weather" section — user guide + weather-stations setup guide). This PR wires up the links:

- **`/help`** gains a "Full guides" section linking both guides
- **Footer** Company column gains a **Docs** link (opens in a new tab like the other outbound links)
- **Station console**: the landing-page footer and the one-time credentials card link the weather-stations guide right next to the WU/Ecowitt setup values

The docs-side changes (two MDX guides, sidebar section, and the logo refresh to the gold mineral palette) are committed on `claude/help-guides-logo` in the local nyuchi-docs clone — pushing awaits write access to that repo from this session.

## Validation

- `npm test` — 2078 passed
- `npm run lint` — 0 errors; `npx tsc --noEmit` — clean (both apps)
- `npm run build` — main app and station-console both build
- Prettier (CI's 3.9.4) run on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW

---
_Generated by [Claude Code](https://claude.ai/code/session_0134B5yBr5fKNwQ5WziyYBWW)_